### PR TITLE
meta-mender-toradex-nxp: initial template files

### DIFF
--- a/meta-mender-toradex-nxp/scripts/manifest-toradex.xml
+++ b/meta-mender-toradex-nxp/scripts/manifest-toradex.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+  <default sync-j="4" revision="rocko"/>
+
+  <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
+  <remote fetch="git://git.openembedded.org"        name="oe"/>
+  <remote fetch="https://git.toradex.com"           name="tdx"/>
+  <remote fetch="https://github.com/Freescale"      name="freescale"/>
+
+  <project name="poky" remote="yocto" revision="rocko" path="sources/poky"/>
+  <project name="meta-openembedded" remote="oe" revision="rocko" path="sources/meta-openembedded"/>
+  <project name="meta-freescale" remote="freescale" revision="rocko" path="sources/meta-freescale"/>
+  <project name="meta-freescale-3rdparty" remote="freescale" revision="rocko" path="sources/meta-freescale-3rdparty"/>
+  <project name="meta-toradex-bsp-common.git" remote="tdx" revision="rocko" path="sources/meta-toradex-bsp-common"/>
+  <project name="meta-toradex-nxp.git" remote="tdx" revision="rocko" path="sources/meta-toradex-nxp"/>
+
+  <include name="scripts/mender.xml"/>
+
+  </manifest>

--- a/meta-mender-toradex-nxp/templates/bblayers.conf.sample
+++ b/meta-mender-toradex-nxp/templates/bblayers.conf.sample
@@ -1,0 +1,25 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../sources/poky/meta \
+  ${TOPDIR}/../sources/poky/meta-poky \
+  ${TOPDIR}/../sources/poky/meta-yocto-bsp \
+  \
+  ${TOPDIR}/../sources/meta-openembedded/meta-oe \
+  \
+  ${TOPDIR}/../sources/meta-toradex-bsp-common \
+  \
+  ${TOPDIR}/../sources/meta-freescale \
+  ${TOPDIR}/../sources/meta-freescale-3rdparty \
+  ${TOPDIR}/../sources/meta-toradex-nxp \
+  \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-core \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-demo \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-toradex-nxp \
+"
+

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -1,0 +1,64 @@
+
+# Appended fragment from meta-mender-community/meta-mender-toradex-nxp/templates
+
+INHERIT_remove = "mender-full"
+
+INHERIT_append_colibri-imx7 = " mender-full-ubi"
+
+# MTD partitioning defined for colibri_imx7:
+#
+# #define MTDPARTS_DEFAULT  "mtdparts=gpmi-nand:"       \
+#               "512k(mx7-bcb),"        \
+#               "1536k(u-boot1)ro,"     \
+#               "1536k(u-boot2)ro,"     \
+#               "512k(u-boot-env),"     \
+#               "-(ubi)"
+
+# Inherit toradex easyinstaller metadata generation ("image.json")
+INHERIT += "toradex_image_json"
+
+# u-boot-env partition holds 2 environments, each 128kB with env range set to 256kB
+BOOTENV_SIZE ?= "0x20000"
+BOOTENV_RANGE ?= "0x40000"
+
+# 512MB of NAND flash
+MENDER_STORAGE_TOTAL_SIZE_MB ?= "512"
+# 512kB for iMX BCB, 2*1.5 MB for uboot and additional 512kB for uboot env, pretend it's a
+# single boot partition
+MENDER_BOOT_PART_SIZE_MB ?= "4"
+# 16MB for data partition
+MENDER_DATA_PART_SIZE_MB ?= "16"
+# align to PEB size 128k
+MENDER_PARTITION_ALIGNMENT_KB ?= "128"
+# there is no partitioning overhead (no MBR and such)
+MENDER_PARTITIONING_OVERHEAD_KB ?= "0"
+# Account for UBI overhead, see
+# http://www.linux-mtd.infradead.org/doc/ubi.html#L_overhead for details,
+MENDER_STORAGE_RESERVED_RAW_SPACE ?= "20971520"
+# all of above should give ~244MB for rootfs
+
+# since UBIFS employs compression, we override maximum rootfs size and put the
+# upper limit at 300MB
+IMAGE_ROOTFS_MAXSIZE ?= "307200"
+
+# NOTE: this affects only u-boot's autoconfigured headers, the same variable is
+# also used for generating fw_env.config but because of assumptions made in
+# meta-mender-core/recipes-bsp/u-boot/u-boot-fw-utils-mender.inc we need ship
+# our own config instead.
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET ?= "0x380000"
+# calculated offsets are:
+# - 0x380000
+# - 0x3c0000 (redundant env)
+
+# make sure that kernel and devicetree are installed
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "mtd-utils mtd-utils-ubifs"
+
+# pick u-boot-toradex-fsl-fw-utils as provider of fw_{printenv,setenv}
+PREFERRED_PROVIDER_u-boot-fw-utils ?= "u-boot-toradex-fsl-fw-utils"
+PREFERRED_RPROVIDER_u-boot-fw-utils ?= "u-boot-toradex-fsl-fw-utils"
+
+# Set product id vars (needed by toradex_image_json)
+TORADEX_PRODUCT_IDS_append = " 0033"
+TORADEX_PRODUCT_IDS[0033] = "colibri-imx7"
+

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -23,6 +23,7 @@ targets=(
     "renesas"
     "rockchip"
     "sunxi"
+    "toradex-nxp"
     "variscite")
 
 for i in ${targets[@]}


### PR DESCRIPTION
Toradex does not use 'poky' in upstream configuration, and instead
provide a distrobution based on Angstrom + oe-core. To simplify
the setup a bit the template files here are based on poky and more
aligned with the rest of boards and provides a good enough base
to evaluate Mender on Toradex NXP SoMs.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>