### PR TITLE
Added support for orangepi zero

### DIFF
--- a/meta-mender-sunxi/recipes-kernel/linux/linux-mainline_%.bbappend
+++ b/meta-mender-sunxi/recipes-kernel/linux/linux-mainline_%.bbappend
@@ -1,0 +1,4 @@
+do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}binutils:do_populate_sysroot"
+do_kernel_configme[depends] += "virtual/${TARGET_PREFIX}gcc:do_populate_sysroot"
+do_kernel_configme[depends] += "bc-native:do_populate_sysroot bison-native:do_populate_sysroot"
+


### PR DESCRIPTION
Few patches which add wifi support, but one blocking point (kernel doesn't boot without this change: https://github.com/linux-sunxi/meta-sunxi/issues/232)