### PR TITLE
README: update Mender logo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains Yocto integration layers for various boards.
 Please check out https://hub.mender.io for more information on
 supported boards and instructions on how to setup environment and build images.
 
-![Mender logo](https://mender.io/user/pages/05.resources/06.digital-assets/logo.png)
+![Mender logo](https://mender.io/user/pages/resources/06.digital-assets/mender.io.png)
 
 ## Structure
 


### PR DESCRIPTION
Recently there where some updates to the mender.io
site and digital assets where moved. Update URL accordingly.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
(cherry picked from commit 03d97eb3e1df1912420374e28f1d046c17d1b622)