### PR TITLE
Add NVIDIA tegra support

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -1,0 +1,30 @@
+# Mender integration for NVIDIA Tegra
+
+This layer contains [mender](https://mender.io/) specific integrations for NVIDIA Tegra hardware, for Over The Air (OTA) software update support of Yocto based NVIDIA Tegra builds.
+
+It depends on the [meta-tegra](https://github.com/madisongh/meta-tegra) layer with branch matching the selected branch name.
+
+See integration details in the [Mender Hub Page](https://hub.mender.io/t/nvidia-tegra-jetson-tx2/123)
+
+Supported and Tested Boards:
+* Jetson TX2 Development Board
+
+### Build
+Download the source:
+
+    $ mkdir mender-tegra
+    $ cd mender-tegra
+    $ repo init \
+            -u https://github.com/mendersoftware/meta-mender-community \
+            -m meta-mender-tegra/scripts/manifest-tegra.xml \
+            -b sumo
+    $ repo sync
+
+Setup environment
+
+    $ . setup-environment tegra
+
+Build
+
+    $ bitbake core-image-base
+

--- a/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
+++ b/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
@@ -1,0 +1,14 @@
+inherit image_types_tegra
+
+DATAFILE ?= "${IMAGE_BASENAME}-${MACHINE}.dataimg"
+
+tegraflash_custom_pre() {
+    # Target needs to match install target in IMAGE_CMD_dataimg
+    ln -s ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.dataimg ./${DATAFILE}
+}
+
+tegraflash_create_flash_config_append() {
+    sed -i \
+        -e"s,DATAFILE,${DATAFILE}," \
+        flash.xml.in
+}

--- a/meta-mender-tegra/conf/layer.conf
+++ b/meta-mender-tegra/conf/layer.conf
@@ -1,0 +1,12 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+		${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-mender-tegra"
+BBFILE_PATTERN_meta-mender-tegra = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-mender-tegra = "10"
+LAYERVERSION_meta-mender-tegra = "1"
+LAYERSERIES_COMPAT_meta-mender-tegra = "sumo"
+LAYERDEPENDS_meta-mender-tegra = "tegra"

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/files/flash_l4t_t186.custom.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/files/flash_l4t_t186.custom.xml
@@ -1,0 +1,436 @@
+<?xml version="1.0"?>
+
+<!-- Nvidia Tegra Partition Layout Version 1.0.0 -->
+
+<partition_layout version="01.00.0000">
+    <device type="sdmmc_boot" instance="3">
+        <partition name="BCT" type="boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 32768 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="MB1NAME" type="MB1TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB1FILE </filename>
+        </partition>
+        <partition name="MB1NAME_b" type="MB1TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB1FILE </filename>
+        </partition>
+        <partition name="MB1_BCT" type="mb1_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="MB1_BCT_b" type="mb1_boot_config_table">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 65536 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="SPENAME" type="SPETYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SPEFILE </filename>
+        </partition>
+        <partition name="SPENAME_b" type="SPETYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 131072 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SPEFILE </filename>
+        </partition>
+        <partition name="MB2NAME" type="MB2TYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB2FILE </filename>
+        </partition>
+        <partition name="MB2NAME_b" type="MB2TYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MB2FILE </filename>
+        </partition>
+        <partition name="MPBNAME" type="MPBTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MPBFILE </filename>
+        </partition>
+        <partition name="MPBNAME_b" type="MPBTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 262144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MPBFILE </filename>
+        </partition>
+        <partition name="SMD" type="smd">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4096 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> slot_metadata.bin </filename>
+        </partition>
+        <partition name="SMD_b" type="smd">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4096 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> slot_metadata.bin </filename>
+        </partition>
+        <partition name="secondary_gpt" type="secondary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 0xFFFFFFFFFFFFFFFF </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+    </device>
+
+    <device type="sdmmc_user" instance="3">
+        <partition name="master_boot_record" type="protective_master_boot_record">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="primary_gpt" type="primary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> PPTSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="APP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> APPFILE </filename>
+        </partition>
+        <partition name="MBPNAME" type="MBPTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4194304 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MBPFILE </filename>
+        </partition>
+        <partition name="MBPNAME_b" type="MBPTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4194304 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> MBPFILE </filename>
+        </partition>
+        <partition name="TBCNAME" type="TBCTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+        </partition>
+        <partition name="TBCNAME_b" type="TBCTYPE" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCFILE </filename>
+        </partition>
+        <partition name="TBCDTB-NAME" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCDTB-FILE </filename>
+        </partition>
+        <partition name="TBCDTB-NAME_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TBCDTB-FILE </filename>
+        </partition>
+        <partition name="TOSNAME" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 3145728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+        </partition>
+        <partition name="TOSNAME_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 3145728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> TOSFILE </filename>
+        </partition>
+        <partition name="eks" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> EKSFILE </filename>
+        </partition>
+<!-- Uncomment below partition once filename is updated
+        <partition name="adsp-fw" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 4194304 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+-->
+        <partition name="BPFNAME" type="data" oem_sign="BPFSIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 618144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+        </partition>
+        <partition name="BPFNAME_b" type="data" oem_sign="BPFSIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 618144 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFFILE </filename>
+        </partition>
+        <partition name="BPFDTB-NAME" type="data" oem_sign="BPMPDTB-SIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 512000 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+        </partition>
+        <partition name="BPFDTB-NAME_b" type="data" oem_sign="BPMPDTB-SIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 512000 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> BPFDTB-FILE </filename>
+        </partition>
+        <partition name="SCENAME" type="data" oem_sign="SCESIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SCEFILE </filename>
+        </partition>
+        <partition name="SCENAME_b" type="data" oem_sign="SCESIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SCEFILE </filename>
+        </partition>
+        <partition name="SC7NAME" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 6291456 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+        </partition>
+        <partition name="SC7NAME_b" type="WB0TYPE">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 6291456 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> WB0FILE </filename>
+        </partition>
+        <partition name="FBNAME" type="FBTYPE" oem_sign="FBSIGN">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 2097152 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> FBFILE </filename>
+        </partition>
+        <partition name="BMP" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 134217728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+        </partition>
+        <partition name="BMP_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 134217728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> bmp.blob </filename>
+        </partition>
+        <partition name="SOS" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 33554432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SOSFILE </filename>
+        </partition>
+        <partition name="SOS_b" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 33554432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> SOSFILE </filename>
+        </partition>
+        <partition name="LNXNAME" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> LNXSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> LNXFILE </filename>
+        </partition>
+        <partition name="LNXNAME_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> LNXSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> LNXFILE </filename>
+        </partition>
+        <partition name="KERNELDTB-NAME" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> KERNELDTB-FILE </filename>
+        </partition>
+        <partition name="KERNELDTB-NAME_b" type="data" oem_sign="true">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> KERNELDTB-FILE </filename>
+        </partition>
+        <partition name="uboot-env" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="APP2" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> APPFILE </filename>
+        </partition>
+        <partition name="UDA" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 18432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x808 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DATAFILE </filename>
+        </partition>
+        <partition name="secondary_gpt" type="secondary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 0xFFFFFFFFFFFFFFFF </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+    </device>
+</partition_layout>

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-binaries_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-binaries_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI += "file://flash_l4t_t186.custom.xml"
+
+do_preconfigure_append() {
+    cp ${WORKDIR}/flash_l4t_t186.custom.xml ${S}/
+}
+

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
@@ -1,0 +1,1 @@
+PARTITION_FILE = "${S}/flash_l4t_t186.custom.xml"

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0001-env-tool-add-command-line-option-to-input-lockfile-p.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0001-env-tool-add-command-line-option-to-input-lockfile-p.patch
@@ -1,0 +1,157 @@
+From 12203a6ab241238db8e30df265965e7f862b5fbd Mon Sep 17 00:00:00 2001
+From: "B, Ravi" <ravibabu@ti.com>
+Date: Mon, 26 Sep 2016 18:24:08 +0530
+Subject: [PATCH] env: tool: add command line option to input lockfile path
+
+The default lockname is set to /var/lock. This limits the
+usage of this application where OS uses different lockfile
+location parameter.
+For example, In case of android, the default lock
+path location is /data.
+Hence by providing the command line option to input lockfile
+path will be useful to reuse the tool across multiple
+operating system.
+
+usage: ./fw_printenv -l <lockfile path>
+
+Signed-off-by: Ravi Babu <ravibabu@ti.com>
+---
+ tools/env/fw_env.h      |  1 +
+ tools/env/fw_env_main.c | 35 +++++++++++++++++++++++++++++------
+ 2 files changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/tools/env/fw_env.h b/tools/env/fw_env.h
+index dac964d..6422769 100644
+--- a/tools/env/fw_env.h
++++ b/tools/env/fw_env.h
+@@ -63,6 +63,7 @@ struct env_opts {
+ #endif
+ 	int aes_flag; /* Is AES encryption used? */
+ 	uint8_t aes_key[AES_KEY_LENGTH];
++	char *lockname;
+ };
+ 
+ int parse_aes_key(char *key, uint8_t *bin_key);
+diff --git a/tools/env/fw_env_main.c b/tools/env/fw_env_main.c
+index 7a17b28..443de36 100644
+--- a/tools/env/fw_env_main.c
++++ b/tools/env/fw_env_main.c
+@@ -46,6 +46,7 @@ static struct option long_options[] = {
+ 	{"help", no_argument, NULL, 'h'},
+ 	{"script", required_argument, NULL, 's'},
+ 	{"noheader", required_argument, NULL, 'n'},
++	{"lock", required_argument, NULL, 'l'},
+ 	{NULL, 0, NULL, 0}
+ };
+ 
+@@ -72,6 +73,7 @@ void usage_printenv(void)
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
+ 		" -n, --noheader       do not repeat variable name in output\n"
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		"\n");
+ }
+ 
+@@ -88,6 +90,7 @@ void usage_setenv(void)
+ #ifdef CONFIG_FILE
+ 		" -c, --config         configuration file, default:" CONFIG_FILE "\n"
+ #endif
++		" -l, --lock           lock node, default:/var/lock\n"
+ 		" -s, --script         batch mode to minimize writes\n"
+ 		"\n"
+ 		"Examples:\n"
+@@ -119,7 +122,7 @@ static void parse_common_args(int argc, char *argv[])
+ 	env_opts.config_file = CONFIG_FILE;
+ #endif
+ 
+-	while ((c = getopt_long(argc, argv, ":a:c:h", long_options, NULL)) !=
++	while ((c = getopt_long(argc, argv, ":a:c:l:h", long_options, NULL)) !=
+ 	       EOF) {
+ 		switch (c) {
+ 		case 'a':
+@@ -134,6 +137,9 @@ static void parse_common_args(int argc, char *argv[])
+ 			env_opts.config_file = optarg;
+ 			break;
+ #endif
++		case 'l':
++			env_opts.lockname = optarg;
++			break;
+ 		case 'h':
+ 			do_printenv ? usage_printenv() : usage_setenv();
+ 			exit(EXIT_SUCCESS);
+@@ -155,8 +161,8 @@ int parse_printenv_args(int argc, char *argv[])
+ 
+ 	parse_common_args(argc, argv);
+ 
+-	while ((c = getopt_long(argc, argv, "a:c:ns:h", long_options, NULL)) !=
+-	       EOF) {
++	while ((c = getopt_long(argc, argv, "a:c:ns:l:h", long_options, NULL))
++		!= EOF) {
+ 		switch (c) {
+ 		case 'n':
+ 			noheader = 1;
+@@ -164,6 +170,7 @@ int parse_printenv_args(int argc, char *argv[])
+ 		case 'a':
+ 		case 'c':
+ 		case 'h':
++		case 'l':
+ 			/* ignore common options */
+ 			break;
+ 		default: /* '?' */
+@@ -181,8 +188,8 @@ int parse_setenv_args(int argc, char *argv[])
+ 
+ 	parse_common_args(argc, argv);
+ 
+-	while ((c = getopt_long(argc, argv, "a:c:ns:h", long_options, NULL)) !=
+-	       EOF) {
++	while ((c = getopt_long(argc, argv, "a:c:ns:l:h", long_options, NULL))
++		!= EOF) {
+ 		switch (c) {
+ 		case 's':
+ 			script_file = optarg;
+@@ -190,6 +197,7 @@ int parse_setenv_args(int argc, char *argv[])
+ 		case 'a':
+ 		case 'c':
+ 		case 'h':
++		case 'l':
+ 			/* ignore common options */
+ 			break;
+ 		default: /* '?' */
+@@ -203,7 +211,7 @@ int parse_setenv_args(int argc, char *argv[])
+ 
+ int main(int argc, char *argv[])
+ {
+-	const char *lockname = "/var/lock/" CMD_PRINTENV ".lock";
++	char *lockname = "/var/lock/" CMD_PRINTENV ".lock";
+ 	int lockfd = -1;
+ 	int retval = EXIT_SUCCESS;
+ 	char *_cmdname;
+@@ -235,6 +243,18 @@ int main(int argc, char *argv[])
+ 	argc -= optind;
+ 	argv += optind;
+ 
++	if (env_opts.lockname) {
++		lockname = malloc(sizeof(env_opts.lockname) +
++				sizeof(CMD_PRINTENV) + 10);
++		if (!lockname) {
++			fprintf(stderr, "Unable allocate memory");
++			exit(EXIT_FAILURE);
++		}
++
++		sprintf(lockname, "%s/%s.lock",
++			env_opts.lockname, CMD_PRINTENV);
++	}
++
+ 	lockfd = open(lockname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+ 	if (-1 == lockfd) {
+ 		fprintf(stderr, "Error opening lock file %s\n", lockname);
+@@ -260,6 +280,9 @@ int main(int argc, char *argv[])
+ 		}
+ 	}
+ 
++	if (env_opts.lockname)
++		free(lockname);
++
+ 	flock(lockfd, LOCK_UN);
+ 	close(lockfd);
+ 	return retval;

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0003-tegra-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0003-tegra-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,0 +1,49 @@
+From 9697e669d849ad53ca374a5e2c4b260c1ba9f67e Mon Sep 17 00:00:00 2001
+From: Marcin Pasinski <marcin.pasinski@northern.tech>
+Date: Wed, 31 Jan 2018 18:10:04 +0100
+Subject: [PATCH] Integration of Mender boot code into U-Boot.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>
+
+---
+ include/env_default.h     | 3 +++
+ scripts/Makefile.autoconf | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index ea6704a..700aedb 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -10,6 +10,8 @@
+ 
+ #include <env_callback.h>
+ 
++#include <env_mender.h>
++
+ #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
+ env_t environment __PPCENV__ = {
+ 	ENV_CRC,	/* CRC Sum */
+@@ -22,6 +24,7 @@ static char default_environment[] = {
+ #else
+ const uchar default_environment[] = {
+ #endif
++	MENDER_ENV_SETTINGS
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+ #endif
+diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
+index 01a739d..4c4067d 100644
+--- a/scripts/Makefile.autoconf
++++ b/scripts/Makefile.autoconf
+@@ -98,7 +98,8 @@ define filechk_config_h
+ 	echo \#include \<config_uncmd_spl.h\>;				\
+ 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	echo \#include \<asm/config.h\>;				\
+-	echo \#include \<config_fallbacks.h\>;)
++	echo \#include \<config_fallbacks.h\>;				\
++	echo \#include \<config_mender.h\>;)
+ endef
+ 
+ include/config.h: scripts/Makefile.autoconf create_symlink FORCE

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0010-tegra-mender-auto-configured-modified.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0010-tegra-mender-auto-configured-modified.patch
@@ -1,0 +1,73 @@
+diff -r -u a/configs/p2771-0000-500_defconfig b/configs/p2771-0000-500_defconfig
+--- a/configs/p2771-0000-500_defconfig	2018-10-24 15:26:57.852705468 +0000
++++ b/configs/p2771-0000-500_defconfig	2018-10-24 15:27:17.668734604 +0000
+@@ -36,3 +36,4 @@ CONFIG_USB=y
+ CONFIG_DM_USB=y
+ CONFIG_POWER_DOMAIN=y
+ CONFIG_TEGRA186_POWER_DOMAIN=y
++CONFIG_MMC=y
+Binary files a/.git/index and b/.git/index differ
+diff -r -u a/include/config_defaults.h b/include/config_defaults.h
+--- a/include/config_defaults.h	2018-10-24 15:26:57.896705532 +0000
++++ b/include/config_defaults.h	2018-10-24 15:27:17.504734363 +0000
+@@ -21,3 +21,11 @@
+ #define CONFIG_PARTITIONS 1
+ 
+ #endif
++#define CONFIG_ENV_SIZE 0x20000
++#define CONFIG_ENV_OFFSET 0x400000
++#define CONFIG_ENV_OFFSET_REDUND 0x800000
++#define CONFIG_SYS_MMC_ENV_DEV 0
++#define CONFIG_SYS_MMC_ENV_PART 0
++#define CONFIG_ENV_IS_IN_MMC
++#define CONFIG_BOOTCOUNT_LIMIT
++#define CONFIG_BOOTCOUNT_ENV
+diff -r -u a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
+--- a/include/config_distro_bootcmd.h	2018-10-24 15:26:57.896705532 +0000
++++ b/include/config_distro_bootcmd.h	2018-10-24 15:27:17.528734398 +0000
+@@ -397,7 +397,6 @@
+ 		"done\0"
+ 
+ #ifndef CONFIG_BOOTCOMMAND
+-#define CONFIG_BOOTCOMMAND "run distro_bootcmd"
+ #endif
+ 
+ #endif  /* _CONFIG_CMD_DISTRO_BOOTCMD_H */
+diff -r -u a/include/configs/p2771-0000.h b/include/configs/p2771-0000.h
+--- a/include/configs/p2771-0000.h	2018-10-24 15:26:57.912705556 +0000
++++ b/include/configs/p2771-0000.h	2018-10-24 15:27:17.508734369 +0000
+@@ -23,10 +23,6 @@
+ #define CONFIG_TEGRA_MMC
+ 
+ /* Environment in eMMC, at the end of 2nd "boot sector" */
+-#define CONFIG_ENV_IS_IN_MMC
+-#define CONFIG_SYS_MMC_ENV_DEV		0
+-#define CONFIG_SYS_MMC_ENV_PART		2
+-#define CONFIG_ENV_OFFSET		(-CONFIG_ENV_SIZE)
+ 
+ /* PCI host support */
+ #define CONFIG_PCI
+diff -r -u a/include/configs/tegra186-common.h b/include/configs/tegra186-common.h
+--- a/include/configs/tegra186-common.h	2018-10-24 15:26:57.916705562 +0000
++++ b/include/configs/tegra186-common.h	2018-10-24 15:27:17.512734374 +0000
+@@ -54,7 +54,7 @@
+ #define MEM_LAYOUT_ENV_SETTINGS \
+ 	"scriptaddr=0x90000000\0" \
+ 	"pxefile_addr_r=0x90100000\0" \
+-	"kernel_addr_r=" __stringify(CONFIG_LOADADDR) "\0" \
++	"loadaddr=" __stringify(CONFIG_LOADADDR) "\0" \
+ 	"fdt_addr_r=0x82000000\0" \
+ 	"ramdisk_addr_r=0x82100000\0"
+ 
+diff -r -u a/include/configs/tegra-common.h b/include/configs/tegra-common.h
+--- a/include/configs/tegra-common.h	2018-10-24 15:26:57.916705562 +0000
++++ b/include/configs/tegra-common.h	2018-10-24 15:27:17.512734374 +0000
+@@ -34,7 +34,6 @@
+ 
+ /* Environment */
+ #define CONFIG_ENV_VARS_UBOOT_CONFIG
+-#define CONFIG_ENV_SIZE			0x2000	/* Total Size Environment */
+ 
+ /*
+  * NS16550 Configuration
+Only in b: .scmversion

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0011-Jetson-TX2-mender-boot-commands.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0011-Jetson-TX2-mender-boot-commands.patch
@@ -1,0 +1,51 @@
+From 631334da464f8eada6606f987a14eb4a4a66224b Mon Sep 17 00:00:00 2001
+From: Dan Walkes <danwalkes@trellis-logic.com>
+Date: Wed, 31 Oct 2018 12:25:48 -0600
+Subject: [PATCH] Jetson TX2 mender boot commands
+
+Modify u-boot to use bootcmd setting based on
+values which support jetson-tx2 boot partition layout
+and setup.
+---
+ include/env_default.h | 4 ++--
+ include/env_mender.h  | 9 ++++++---
+ 2 files changed, 8 insertions(+), 5 deletions(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index 700aedb..ae631c0 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -34,8 +34,8 @@ const uchar default_environment[] = {
+ #ifdef	CONFIG_BOOTARGS
+ 	"bootargs="	CONFIG_BOOTARGS			"\0"
+ #endif
+-#ifdef	CONFIG_BOOTCOMMAND
+-	"bootcmd="	CONFIG_BOOTCOMMAND		"\0"
++#ifdef	CONFIG_MENDER_BOOTCOMMAND
++	"bootcmd="	CONFIG_MENDER_BOOTCOMMAND	"\0"
+ #endif
+ #ifdef	CONFIG_RAMBOOTCOMMAND
+ 	"ramboot="	CONFIG_RAMBOOTCOMMAND		"\0"
+diff --git a/include/env_mender.h b/include/env_mender.h
+index cf46ef0..ac53536 100644
+--- a/include/env_mender.h
++++ b/include/env_mender.h
+@@ -136,9 +136,12 @@
+ 
+ #define CONFIG_MENDER_BOOTCOMMAND                                       \
+     "run mender_setup; "                                                \
+-    MENDER_BOOTARGS                                                     \
+-    MENDER_LOAD_KERNEL_AND_FDT                                          \
+-    "${mender_boot_kernel_type} ${loadaddr} - ${fdt_addr_r}; "     \
++    "setenv distro_bootpart ${mender_boot_part}; "			\
++    "setenv distro_bootpart_hex ${mender_boot_part_hex}; "		\
++    "setenv devnum " __stringify(MENDER_UBOOT_STORAGE_DEVICE) "; " 	\
++    "setenv devtype " __stringify(MENDER_UBOOT_STORAGE_INTERFACE) "; "  \
++    "setenv prefix /boot/; " 						\
++    "sysboot ${devtype} ${devnum}:${distro_bootpart_hex} any ${scriptaddr} ${prefix}extlinux/extlinux.conf; " \
+     "run mender_try_to_recover"
+ 
+ #endif /* !MENDER_AUTO_PROBING */
+-- 
+2.7.4
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0012-Update-environment-defaults-for-tegra.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0012-Update-environment-defaults-for-tegra.patch
@@ -1,0 +1,35 @@
+From 427efe0a95ed3d0e2e912a1cb91d31605d465e74 Mon Sep 17 00:00:00 2001
+From: Dan Walkes <danwalkes@trellis-logic.com>
+Date: Wed, 31 Oct 2018 14:46:43 -0600
+Subject: [PATCH] Update environment defaults for tegra
+
+Remove definitions for CONFIG_ENV_OFFSET, CONFIG_ENV_OFFSET_REDUND,
+and partition definition, allowing these to be configured in yocto mender
+framework instead.
+---
+ include/config_defaults.h | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/include/config_defaults.h b/include/config_defaults.h
+index 2b503f8..3b0e251 100644
+--- a/include/config_defaults.h
++++ b/include/config_defaults.h
+@@ -22,10 +22,12 @@
+ 
+ #endif
+ #define CONFIG_ENV_SIZE 0x20000
+-#define CONFIG_ENV_OFFSET 0x400000
+-#define CONFIG_ENV_OFFSET_REDUND 0x800000
++/* Let mender define these */
++/*#define CONFIG_ENV_OFFSET 0x400000 */
++/*#define CONFIG_ENV_OFFSET_REDUND 0x800000 */
+ #define CONFIG_SYS_MMC_ENV_DEV 0
+-#define CONFIG_SYS_MMC_ENV_PART 0
++/* Don't use this definition, per mender requirements */
++/*#define CONFIG_SYS_MMC_ENV_PART 0 */
+ #define CONFIG_ENV_IS_IN_MMC
+ #define CONFIG_BOOTCOUNT_LIMIT
+ #define CONFIG_BOOTCOUNT_ENV
+-- 
+2.7.4
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-fw-utils-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-fw-utils-tegra_%.bbappend
@@ -1,0 +1,2 @@
+require recipes-bsp/u-boot/u-boot-fw-utils-mender.inc
+require recipes-bsp/u-boot/u-boot-mender-tegra.inc

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -1,0 +1,13 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+MENDER_UBOOT_AUTO_CONFIGURE = "0"
+
+SRC_URI += " file://0001-env-tool-add-command-line-option-to-input-lockfile-p.patch"
+SRC_URI += " file://0003-tegra-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
+SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
+SRC_URI_append_mender-uboot = " file://0012-Update-environment-defaults-for-tegra.patch"
+SRC_URI_remove = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI_remove = " file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch"
+# Is not used for normal build but causes errors with devtool if not added here
+SRC_URI_remove = " file://0007-distro_bootcmd-Switch-bootefi-to-use-loadaddr-by-def.patch"

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -1,0 +1,2 @@
+require recipes-bsp/u-boot/u-boot-mender.inc
+require recipes-bsp/u-boot/u-boot-mender-tegra.inc

--- a/meta-mender-tegra/recipes-core/images/tegra186-minimal-initramfs.bbappend
+++ b/meta-mender-tegra/recipes-core/images/tegra186-minimal-initramfs.bbappend
@@ -1,0 +1,2 @@
+do_image_mender[noexec]="1"
+do_image_sdimg[noexec]="1"

--- a/meta-mender-tegra/scripts/deploy.sh
+++ b/meta-mender-tegra/scripts/deploy.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+machine=jetson-tx2
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+deployfile=core-image-base-${machine}.tegraflash.zip
+tmpdir=`mktemp`
+rm -rf $tmpdir
+mkdir -p $tmpdir
+echo "Using temp directory $tmpdir"
+pushd $tmpdir
+cp $scriptdir/build/tmp/deploy/images/${machine}/$deployfile .
+unzip $deployfile
+set -e
+sudo ./doflash.sh
+popd
+echo "Removing temp directory $tmpdir"
+rm -rf $tmpdir

--- a/meta-mender-tegra/scripts/manifest-tegra.xml
+++ b/meta-mender-tegra/scripts/manifest-tegra.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+  <default sync-j="4" revision="sumo"/>
+
+  <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
+  <remote fetch="https://github.com/madisongh"        name="madisongh"/>
+
+  <project name="poky" remote="yocto" revision="sumo" path="sources/poky"/>
+  <project name="meta-tegra" remote="madisongh" revision="sumo" path="sources/meta-tegra" />
+
+  <include name="scripts/mender.xml"/>
+
+  </manifest>
+

--- a/meta-mender-tegra/templates/bblayers.conf.sample
+++ b/meta-mender-tegra/templates/bblayers.conf.sample
@@ -1,0 +1,16 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "1"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../sources/poky/meta \
+  ${TOPDIR}/../sources/poky/meta-poky \
+  ${TOPDIR}/../sources/poky/meta-yocto-bsp \
+  ${TOPDIR}/../sources/meta-tegra \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-core \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-demo \
+  ${TOPDIR}/../sources/meta-mender-community/meta-mender-tegra \
+"

--- a/meta-mender-tegra/templates/local.conf.append
+++ b/meta-mender-tegra/templates/local.conf.append
@@ -1,0 +1,37 @@
+# Appended fragment from meta-mender-community/meta-mender-tegra/templates
+MACHINE ?= "jetson-tx2"
+# meta-tegra and tegraflash requirements
+IMAGE_CLASSES += "image_types_mender_tegra"
+IMAGE_FSTYPES += "tegraflash"
+
+ARTIFACTIMG_FSTYPE = "ext4"
+# Generate dataimg for use with tegraflash
+IMAGE_TYPEDEP_tegraflash += " dataimg"
+IMAGE_FSTYPES += "dataimg"
+# Additional mender settings, See discussion in VS-68
+EXTRA_IMAGECMD_ext4 = " -b 2048"
+PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
+PREFERRED_RPROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
+# Note: this isn't really a boot file, just put it here to keep the mender build from
+# complaining about empty IMAGE_BOOT_FILES.  We won't use the full image anyway, just the mender file
+IMAGE_BOOT_FILES = "u-boot-dtb.bin"
+# Mender customizations to support jetson tx2.  This needs to match up with flash_l4t_t186.custom.xml scheme
+# We don't use a boot partition
+MENDER_BOOT_PART = ""
+MENDER_DATA_PART = "${MENDER_STORAGE_DEVICE_BASE}30"
+MENDER_ROOTFS_PART_A = "${MENDER_STORAGE_DEVICE_BASE}1"
+MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}29"
+# See setting in meta-tegra/conf/machine
+# Need to oversize this to make sure IMAGE_ROOTFS_SIZE is less than this, however any change
+# will mean you need to change the offsets below as well.
+ROOTFSPART_SIZE = "3000000000"
+# Assumes a default partition layout for jetson with partition 28 reserved for uboot environment
+# At LBA 0x68b170.  0x68b170 = 6861168 blocks and 6861168 blocks *512 bytes/block = 3512918016 byte offset
+# This will need to be modified whenever flash layout changes
+# Use mmc part command in u-boot to find partition start for any new platforms
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "3512918016"
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA = "262144"
+# Use a 4096 byte alignment for support of tegraflash scheme and default partition locations
+MENDER_PARTITION_ALIGNMENT = "4096"
+# Not required, gives you access via SSH by default
+EXTRA_IMAGE_FEATURES += " ssh-server-dropbear"

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -26,6 +26,7 @@ targets=(
     "renesas"
     "rockchip"
     "sunxi"
+    "tegra"
     "up"
     "variscite")
 


### PR DESCRIPTION
Thanks for creating this project!

This pull request adds support for NVIDIA tegra, as discussed [in the forum](https://groups.google.com/a/lists.mender.io/forum/#!topic/mender/ISaA1ll9Fbo) and [mender hub page](https://hub.mender.io/t/nvidia-tegra-jetson-tx2/123).

To test before the pull request is complete you can use
```
repo init \
        -u https://github.com/Trellis-Logic/meta-mender-community \
        -m meta-mender-tegra/scripts/manifest-tegra.xml \
        -b add-tegra
repo sync
```

Based on Mirza's recommendations in the forum and the recommendations in the [meta-tegra pull request](https://github.com/madisongh/meta-tegra/pull/114) I haven't tried to update partitioning or moving u-boot environment out of a dedicated sector.  Although I'd expect these patches to support any NVIDIA platforms supported by meta-tegra there will be partition layout related work to do which I've summarized in the README.  I only have access to a TX 2 development board today and can't test on other platforms, therefore I'll avoid trying to add untested work with the initial PR.

This was my first time setting up a yocto project with the repo tool and I think it's a cool way to setup a project.  A few observations:

* I think the mkdir mender-<vendor/soc name> would really be setting up your yocto based project, so a directory name like yocto-yourprojectname might be more appropriate.
* I think the README.md instructions in the root folder are missing a repo sync command after repo init.
* Some detail about the workflow in the README might be warranted.  I don't think repo upload works unless you have a gerrit server for instance, so it's likely anyone not using gerrit will want to add git submodules and also add their conf/local.conf and bblayers.conf files to share their project with others on the local team.  Let me know if you have a different workflow in mind.  If this is the workflow you expect people to use often it might be handy to add a script which can create git submodules and adds appropriate .gitignore files.
* I added a helper meta-mender-tegra/scripts/deploy.sh script but couldn't figure out how to add this to the root directory of the project on init.  I needed to back out my first attempt in f3f0537791722cf4aaff9b60233c1cfd80b3cf3f because the repo init command was failing with:
```
fatal: manifest 'meta-mender-tegra/scripts/manifest-tegra.xml' not available
fatal: duplicate path sources/meta-mender-community in /home/dan/yocto-tegra-2/.repo/manifests/meta-mender-tegra/scripts/manifest-tegra.xml
```
probably because I had duplicated the same project attribute from [scripts/mender.xml](scripts/mender.xml).  Let me know if you have ideas about how I could accomplish this.
* Related to the comment above, I like to put really simple scripts in the base directory of projects so team members, even ones who don't know yocto or bitbake workflow, are comfortable doing simple tasks like building and deploying software.  For this reason I typically add a ./build.sh script with content like [this one](https://github.com/Trellis-Logic/yocto-tegra/blob/master/build.sh) in the root of a project directory.  This could be shared with all projects and would be useful after the first setup-environment step for future builds.  Just an idea and no worries if you'd rather not.  I'd be interested in any reasons this is not a good idea from your perspective.

I'm happy to incorporate any of the changes above into this or a new PR, and equally happy to just let the project be as-is, just let me know.

Thanks again for creating this project!