### PR TITLE
Wip morty

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ a server that manages deployments across many devices.
 
 This repository contains Yocto integration layers for various boards.
 
-Please check out https://mender.trydiscourse.com/ for more information on
-supported boards and instructions on how to setup an environment and build.
+Please check out https://hub.mender.io for more information on
+supported boards and instructions on how to setup environment and build images.
 
-![Mender logo](https://mender.io/user/pages/05.resources/06.digital-assets/logo.png)
+![Mender logo](https://mender.io/user/pages/resources/06.digital-assets/mender.io.png)
 
 ## Structure
 
@@ -109,7 +109,7 @@ documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING
 ## License
 
 Mender is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/mirzak/meta-mender-community/blob/master/LICENSE) for the
+[LICENSE](https://github.com/mendersoftware/meta-mender-community/blob/sumo/LICENSE) for the
 full license text.
 
 ## Connect with us

--- a/meta-mender-compulab/README.md
+++ b/meta-mender-compulab/README.md
@@ -1,0 +1,38 @@
+# Mender integration for Compulab boards
+
+Supported boards:
+
+ - CL-SOM-iMX6 - NXP i.MX6 System-on-Module (https://www.compulab.com/products/computer-on-modules/cl-som-imx6-nxp-freescale-i-mx-6-system-on-module/)
+
+## Build
+
+Download the source:
+
+    $ mkdir mender-compulab
+    $ cd mender-compulab
+    $ repo init \
+           -u git://git.freescale.com/imx/fsl-arm-yocto-bsp.git \
+           -m imx-4.1.33-7ulp_beta.xml \
+           -b imx-morty
+    $ mkdir .repo/local_manifests
+    $ cd .repo/local_manifests/
+    $ wget https://raw.githubusercontent.com/mendersoftware/meta-mender-community/morty/meta-mender-compulab/scripts/manifest-compulab-local-manifest.xml
+    $ wget https://raw.githubusercontent.com/mendersoftware/meta-mender-community/morty/scripts/mender-local-manifest.xml
+    $ cd -
+    $ repo sync
+    $ cd .repo/local_manifests/
+    $ ln -sf ../../sources/meta-mender-community/meta-mender-compulab/scripts/manifest-compulab-local-manifest.xml .
+    $ ln -sf ../../sources/meta-mender-community/scripts/mender-local-manifest.xml .
+    $ cd -
+
+Setup environment
+
+    $ source fsl-setup-release.sh -b build
+    $ source ../sources/meta-compulab/bb-tools/setup-compulab-env
+    $ cat ../sources/meta-mender-community/meta-mender-compulab/templates/bblayers.conf.append >> conf/bblayers.conf
+    $ cat ../sources/meta-mender-community/templates/local.conf.append >> conf/local.conf
+    $ cat ../sources/meta-mender-community/meta-mender-compulab/templates/local.conf.append >> conf/local.conf
+
+Build
+
+    $ bitbake core-image-full-cmdline

--- a/meta-mender-compulab/conf/layer.conf
+++ b/meta-mender-compulab/conf/layer.conf
@@ -1,0 +1,12 @@
+# Copyright 2018 Northern.tech AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-compulab"
+BBFILE_PATTERN_mender-compulab = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-compulab = "10"

--- a/meta-mender-compulab/recipes-bsp/u-boot/files/fw_env.config.default
+++ b/meta-mender-compulab/recipes-bsp/u-boot/files/fw_env.config.default
@@ -1,0 +1,6 @@
+# Configuration file for fw_(printenv/saveenv) utility for
+# CompuLab cm-fx6, cl-som-imx(X)
+
+# MTD name	Device offset	Env. size	Flash sector size
+/dev/mtd1	0x0000		0x2000		0x2000
+/dev/mtd1       0x2000          0x2000          0x2000

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0001-cm-fx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT-for-.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0001-cm-fx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT-for-.patch
@@ -1,0 +1,25 @@
+From 1aaa1d11ccc24ed485e0da827eeddc123ea136b8 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Sun, 11 Nov 2018 15:45:12 +0000
+Subject: [PATCH 1/2] cm-fx6: Enable BOOTCOUNT_ENV and BOOTCOUNT_LIMIT for
+ Mender
+
+---
+ include/configs/cm_fx6.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/cm_fx6.h b/include/configs/cm_fx6.h
+index 8c11721..b9d6b1d 100644
+--- a/include/configs/cm_fx6.h
++++ b/include/configs/cm_fx6.h
+@@ -260,4 +260,7 @@
+ #define CONFIG_VIDEO_LOGO
+ #define CONFIG_VIDEO_BMP_LOGO
+ 
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
++
+ #endif	/* __CONFIG_CM_FX6_H */
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0001-cm_fx6-Enabled-redundant-environment.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0001-cm_fx6-Enabled-redundant-environment.patch
@@ -1,0 +1,27 @@
+From 21b5f90f1ef8a3b36d869447288128eecd75df04 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Thu, 8 Nov 2018 20:18:09 +0000
+Subject: [PATCH 1/5] cm_fx6: Enabled redundant environment.
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cm_fx6.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/cm_fx6.h b/include/configs/cm_fx6.h
+index 6474160..fed4d60 100644
+--- a/include/configs/cm_fx6.h
++++ b/include/configs/cm_fx6.h
+@@ -70,6 +70,9 @@
+ #define CONFIG_ENV_SECT_SIZE		(64 * 1024)
+ #define CONFIG_ENV_SIZE			(8 * 1024)
+ #define CONFIG_ENV_OFFSET		(768 * 1024)
++#define CONFIG_ENV_OFFSET_REDUND	(CONFIG_ENV_OFFSET + CONFIG_ENV_SIZE)
++#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
++#define CONFIG_ENV_RANGE                (2*CONFIG_ENV_OFFSET)
+ 
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+ 	"stdin=serial,usbkbd\0" \
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0002-cl-som-imx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0002-cl-som-imx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT.patch
@@ -1,0 +1,26 @@
+From 7bc12458b2fa5dd26e0c6846120f81ff8f4f96a1 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Thu, 8 Nov 2018 16:06:36 +0000
+Subject: [PATCH 2/5] cl-som-imx6: Enable BOOTCOUNT_ENV and BOOTCOUNT_LIMIT for
+ Mender
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cl_som_imx6.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/cl_som_imx6.h b/include/configs/cl_som_imx6.h
+index 61d0b78..e1d1bd5 100644
+--- a/include/configs/cl_som_imx6.h
++++ b/include/configs/cl_som_imx6.h
+@@ -27,4 +27,7 @@
+ #define CONFIG_BOARD_NAME	"SOM-iMX6-ATP"
+ #endif
+ 
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
++
+ #endif	/* __CONFIG_CL_SOM_IMX6_H */
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0002-cm_fx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0002-cm_fx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch
@@ -1,0 +1,28 @@
+From 20691a2cf3d936b3e6b5140d2e28867519c6946d Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Sun, 11 Nov 2018 15:55:14 +0000
+Subject: [PATCH 2/2] cm_fx6: Disable CONFIG_ENV_OFFSET for Mender
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cm_fx6.h | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/include/configs/cm_fx6.h b/include/configs/cm_fx6.h
+index b9d6b1d..406b9de 100644
+--- a/include/configs/cm_fx6.h
++++ b/include/configs/cm_fx6.h
+@@ -62,10 +62,7 @@
+ #define CONFIG_ENV_SPI_CS		CONFIG_SF_DEFAULT_CS
+ #define CONFIG_ENV_SECT_SIZE		(64 * 1024)
+ #define CONFIG_ENV_SIZE			(8 * 1024)
+-#define CONFIG_ENV_OFFSET		(768 * 1024)
+-#define CONFIG_ENV_OFFSET_REDUND	(CONFIG_ENV_OFFSET + CONFIG_ENV_SIZE)
+ #define CONFIG_SYS_REDUNDAND_ENVIRONMENT
+-#define CONFIG_ENV_RANGE                (2*CONFIG_ENV_OFFSET)
+ 
+ #define CONFIG_EXTRA_ENV_SETTINGS \
+ 	"stdin=serial,usbkbd\0" \
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0003-mender-Support-CONFIG_ENV_IS_IN_SPI_FLASH.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0003-mender-Support-CONFIG_ENV_IS_IN_SPI_FLASH.patch
@@ -1,0 +1,28 @@
+From 72a733556392aabe349cf47aff53885f4169282d Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Thu, 8 Nov 2018 16:20:57 +0000
+Subject: [PATCH 3/5] mender: Support CONFIG_ENV_IS_IN_SPI_FLASH
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/config_mender.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/config_mender.h b/include/config_mender.h
+index 116b87f..734cc89 100644
+--- a/include/config_mender.h
++++ b/include/config_mender.h
+@@ -21,8 +21,8 @@
+ 
+ #include <config_mender_defines.h>
+ 
+-#if !defined(CONFIG_ENV_IS_IN_MMC) && !defined(CONFIG_ENV_IS_IN_NAND) && !defined(CONFIG_ENV_IS_IN_FLASH)
+-# error CONFIG_ENV_IS_IN_MMC, CONFIG_ENV_IS_IN_NAND or CONFIG_ENV_IS_IN_FLASH is required for Mender to work
++#if !defined(CONFIG_ENV_IS_IN_MMC) && !defined(CONFIG_ENV_IS_IN_NAND) && !defined(CONFIG_ENV_IS_IN_FLASH) && !defined(CONFIG_ENV_IS_IN_SPI_FLASH)
++# error CONFIG_ENV_IS_IN_MMC, CONFIG_ENV_IS_IN_NAND, CONFIG_ENV_IS_IN_FLASH or CONFIG_ENV_IS_IN_SPI_FLASH is required for Mender to work
+ #endif
+ 
+ #ifndef CONFIG_BOOTCOUNT_LIMIT
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0004-cl-som-imx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0004-cl-som-imx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch
@@ -1,0 +1,26 @@
+From 8efd72acd999dd9ea96a3f263e0a695c0eb968fc Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Thu, 8 Nov 2018 19:38:40 +0000
+Subject: [PATCH 4/5] cl-som-imx6: Disable CONFIG_ENV_OFFSET for Mender
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cl_som_imx6.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/include/configs/cl_som_imx6.h b/include/configs/cl_som_imx6.h
+index e1d1bd5..2c92627 100644
+--- a/include/configs/cl_som_imx6.h
++++ b/include/configs/cl_som_imx6.h
+@@ -29,5 +29,8 @@
+ 
+ #define CONFIG_BOOTCOUNT_ENV
+ #define CONFIG_BOOTCOUNT_LIMIT
++#undef CONFIG_ENV_OFFSET
++#undef CONFIG_ENV_OFFSET_REDUND
++#undef CONFIG_ENV_RANGE
+ 
+ #endif	/* __CONFIG_CL_SOM_IMX6_H */
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0005-cl-som-imx6-Add-Mender-specific-BOARD_NAME.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0005-cl-som-imx6-Add-Mender-specific-BOARD_NAME.patch
@@ -1,0 +1,25 @@
+From 51dd2cc65eb1c2cdce81468e898467c51fdcbc07 Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Sun, 11 Nov 2018 17:11:36 +0000
+Subject: [PATCH 5/5] cl-som-imx6: Add Mender-specific BOARD_NAME
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cl_som_imx6.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/include/configs/cl_som_imx6.h b/include/configs/cl_som_imx6.h
+index 2c92627..f235e20 100644
+--- a/include/configs/cl_som_imx6.h
++++ b/include/configs/cl_som_imx6.h
+@@ -32,5 +32,7 @@
+ #undef CONFIG_ENV_OFFSET
+ #undef CONFIG_ENV_OFFSET_REDUND
+ #undef CONFIG_ENV_RANGE
++#undef CONFIG_BOARD_NAME
++#define CONFIG_BOARD_NAME	"SOM-iMX6-Mender"
+ 
+ #endif	/* __CONFIG_CL_SOM_IMX6_H */
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/patches/0006-cl_som_imx6-Enable-Mender-environment-and-bootcomman.patch
+++ b/meta-mender-compulab/recipes-bsp/u-boot/patches/0006-cl_som_imx6-Enable-Mender-environment-and-bootcomman.patch
@@ -1,0 +1,41 @@
+From 1fabc5e1cdecbdb613e0a9829481a64cf8d4c35b Mon Sep 17 00:00:00 2001
+From: Drew Moseley <drew.moseley@northern.tech>
+Date: Tue, 13 Nov 2018 18:27:18 +0000
+Subject: [PATCH 6/6] cl_som_imx6: Enable Mender environment and bootcommand.
+
+Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
+---
+ include/configs/cl_som_imx6.h | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/include/configs/cl_som_imx6.h b/include/configs/cl_som_imx6.h
+index f235e20..4ed39aa 100644
+--- a/include/configs/cl_som_imx6.h
++++ b/include/configs/cl_som_imx6.h
+@@ -35,4 +35,23 @@
+ #undef CONFIG_BOARD_NAME
+ #define CONFIG_BOARD_NAME	"SOM-iMX6-Mender"
+ 
++#undef CONFIG_PREBOOT
++#undef CONFIG_BOOTCOMMAND
++#define CONFIG_BOOTCOMMAND CONFIG_MENDER_BOOTCOMMAND
++
++#undef CONFIG_EXTRA_ENV_SETTINGS
++#define CONFIG_EXTRA_ENV_SETTINGS \
++	"stdin=serial,usbkbd\0" \
++	"stdout=serial,vga\0" \
++	"stderr=serial,vga\0" \
++	"panel=HDMI\0" \
++        "fdt_high=0xffffffff\0" \
++	"console=ttymxc3,115200\0" \
++	"ethprime=FEC0\0" \
++	"video_hdmi=mxcfb0:dev=hdmi,1920x1080M-32@50,if=RGB32\0" \
++	"video_dvi=mxcfb0:dev=dvi,1280x800M-32@50,if=RGB32\0" \
++	"kernel_addr_r=0x10800000\0" \
++	"fdt_addr_r=0x15000000\0" \
++	"bootargs=console=${console} ${video} vmalloc=256M cma=384M dmfc=3\0"
++
+ #endif	/* __CONFIG_CL_SOM_IMX6_H */
+-- 
+2.7.4
+

--- a/meta-mender-compulab/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
+++ b/meta-mender-compulab/recipes-bsp/u-boot/u-boot-compulab_%.bbappend
@@ -1,0 +1,9 @@
+require recipes-bsp/u-boot/u-boot-mender.inc
+require u-boot-mender-compulab.inc
+
+SRC_URI_append_cl-som-imx6 += " \
+    file://0002-cl-som-imx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT.patch \
+    file://0004-cl-som-imx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch \
+    file://0005-cl-som-imx6-Add-Mender-specific-BOARD_NAME.patch \
+    file://0006-cl_som_imx6-Enable-Mender-environment-and-bootcomman.patch \
+"

--- a/meta-mender-compulab/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
+++ b/meta-mender-compulab/recipes-bsp/u-boot/u-boot-fw-utils_%.bbappend
@@ -1,0 +1,7 @@
+require u-boot-mender-compulab.inc
+
+SRC_URI_append_cl-som-imx6 += " \
+    file://0001-cm-fx6-Enable-BOOTCOUNT_ENV-and-BOOTCOUNT_LIMIT-for-.patch \
+    file://0002-cm_fx6-Disable-CONFIG_ENV_OFFSET-for-Mender.patch \
+    file://fw_env.config.default \
+"

--- a/meta-mender-compulab/recipes-bsp/u-boot/u-boot-mender-compulab.inc
+++ b/meta-mender-compulab/recipes-bsp/u-boot/u-boot-mender-compulab.inc
@@ -1,0 +1,18 @@
+FILESEXTRAPATHS_prepend_cl-som-imx6 := "${THISDIR}/patches:${THISDIR}/files:"
+
+# Compulab board is using 2015.07 u-boot, need to apply a patch that matches our version
+SRC_URI_remove_cl-som-imx6 += " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI_append_cl-som-imx6 += " file://0003-U-Boot-pre-2017.03-integration-of-Mender-boot-code-i.patch"
+
+SRC_URI_append_cl-som-imx6 += " \
+    file://0001-cm_fx6-Enabled-redundant-environment.patch \
+    file://0003-mender-Support-CONFIG_ENV_IS_IN_SPI_FLASH.patch \
+"
+
+# UBoot environment on Compulab boards is 8kB
+# Stored in SPI Flash at offset 768KB
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1_cl-som-imx6 = "0xC0000"
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2_cl-som-imx6 = "0xC2000"
+BOOTENV_SIZE_cl-som-imx6 = "0x2000"
+
+KERNEL_DEVICETREE = "imx6q-sbc-imx6-hdmi.dtb"

--- a/meta-mender-compulab/scripts/manifest-compulab-local-manifest.xml
+++ b/meta-mender-compulab/scripts/manifest-compulab-local-manifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+
+  <remote fetch="git://github.com/compulab-yokneam" name="compulab"/>
+  <project name="meta-compulab" remote="compulab" revision="devel" path="sources/meta-compulab"/>
+
+  </manifest>

--- a/meta-mender-compulab/templates/bblayers.conf.append
+++ b/meta-mender-compulab/templates/bblayers.conf.append
@@ -1,0 +1,4 @@
+BBLAYERS += " ${BSPDIR}/sources/oe-meta-go "
+BBLAYERS += " ${BSPDIR}/sources/meta-mender/meta-mender-core "
+BBLAYERS += " ${BSPDIR}/sources/meta-mender/meta-mender-demo "
+BBLAYERS += " ${BSPDIR}/sources/meta-mender-community/meta-mender-compulab "

--- a/meta-mender-compulab/templates/local.conf.append
+++ b/meta-mender-compulab/templates/local.conf.append
@@ -1,0 +1,31 @@
+
+# Appended fragment from meta-mender-community/meta-mender-compulab/templates
+
+MACHINE ?= "cl-som-imx6"
+
+IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
+
+IMAGE_FSTYPES_remove = "sdcard"
+
+IMAGE_BOOTLOADER_FILE = "u-boot.imx"
+
+MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+MENDER_UBOOT_STORAGE_DEVICE = "3"
+
+# The compulab BSP is based on an earlier version of the morty branch
+# than what the Mender layers have been developed against. We need
+# to explicitly remove this recipe to avoid build failures.
+BBMASK_append = " meta-mender-demo/recipes-core/volatile-binds/volatile-binds.bbappend"
+
+# The cl-som-imx6 board has 16GB eMMC and the Compulab demo images are rather
+# large.  However filling the entire 16GB space takes a lot of time so we will
+# use a smaller amount here. Also, the data partition is arbitrarily sized to
+# 1GB which should allow us to create an SDCard bootable image with a copy of
+# the SDIMG file to then deploy to eMMC.
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "4096"
+MENDER_DATA_PART_SIZE_MB = "1024"
+
+# Do not really need a boot part and files in it,
+# but we need to satisfy a dependency that the sdimg format has.
+# IMAGE_BOOT_FILES = "zImage"
+IMAGE_BOOT_FILES = "u-boot.imx"

--- a/scripts/mender-local-manifest.xml
+++ b/scripts/mender-local-manifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+
+  <remote fetch="https://github.com/mendersoftware" name="mender"/>
+  <remote fetch="https://github.com" name="github"/>
+
+  <project name="meta-mender" remote="mender" revision="morty" path="sources/meta-mender"/>
+  <project name="meta-mender-community" remote="mender" revision="morty" path="sources/meta-mender-community" />
+  <project name="mem/oe-meta-go.git" path="sources/oe-meta-go" revision="master" remote="github" />
+
+  </manifest>

--- a/scripts/mender.xml
+++ b/scripts/mender.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+  <default sync-j="4" revision="morty"/>
+
+  <remote fetch="https://github.com/mendersoftware" name="mender"/>
+  <remote fetch="https://github.com" name="github"/>
+
+  <project name="meta-mender" remote="mender" revision="morty" path="sources/meta-mender"/>
+  <project name="meta-mender-community" remote="mender" revision="morty" path="sources/meta-mender-community">
+    <copyfile dest="setup-environment" src="scripts/setup-environment"/>
+  </project>
+  <project name="mem/oe-meta-go.git" path="sources/oe-meta-go" revision="master" remote="github" />
+
+  </manifest>

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Inspired by "probe" in oe-init-build-env
+if [ -n "$BASH_SOURCE" ]; then
+    this_script=$BASH_SOURCE
+elif [ -n "$ZSH_NAME" ]; then
+    this_script=$0
+else
+    this_script="$(pwd)/setup-environment"
+fi
+
+script_dir=$(dirname "$this_script")
+script_dir=$(readlink -f "$script_dir")
+
+mender_community_dir=${script_dir}/sources/meta-mender-community
+build_dir=${script_dir}/build
+
+target=""
+
+targets=(
+)
+
+for i in ${targets[@]}
+do
+    if [[ $i == $1 ]]
+    then
+        target=$1
+        break
+    fi
+done
+
+if [ -z "${target}" ]; then
+    echo "Sorry, it does not seem that *$1* is a valid target"
+    echo ""
+
+    printf "Supported targets are:\n"
+    printf '%s\n' "${targets[@]}"
+    return 1
+fi
+
+target_templates=${mender_community_dir}/meta-mender-${target}/templates
+
+. ${script_dir}/sources/poky/oe-init-build-env ${build_dir}
+
+if [ -f ${build_dir}/conf/mender_append_complete ]; then
+    return 1
+fi
+
+# Common entries for Mender
+cat ${mender_community_dir}/templates/local.conf.append >> ${build_dir}/conf/local.conf
+
+# Board specific entries
+cp ${target_templates}/bblayers.conf.sample ${build_dir}/conf/bblayers.conf
+cat ${target_templates}/local.conf.append >> ${build_dir}/conf/local.conf
+
+touch ${build_dir}/conf/mender_append_complete

--- a/templates/local.conf.append
+++ b/templates/local.conf.append
@@ -1,0 +1,27 @@
+
+# Appended fragment from meta-mender-community/templates
+
+# This really saves a lot of disk space!
+INHERIT += "rm_work"
+
+# The name of the disk image and Artifact that will be built.
+# This is what the device will report that it is running, and different updates
+# must have different names because Mender will skip installation of an Artifact
+# if it is already installed.
+MENDER_ARTIFACT_NAME = "release-1"
+
+INHERIT += "mender-full"
+
+# Build for Hosted Mender
+# To get your tenant token, log in to https://hosted.mender.io,
+# click your email at the top right and then "My organization".
+# Remember to remove the meta-mender-demo layer (if you have added it).
+# We recommend Mender 1.3.0 and Yocto Project's rocko or later for Hosted Mender.
+#
+#MENDER_SERVER_URL = "https://hosted.mender.io"
+#MENDER_TENANT_TOKEN = ""
+
+DISTRO_FEATURES_append = " systemd"
+VIRTUAL-RUNTIME_init_manager = "systemd"
+DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+VIRTUAL-RUNTIME_initscripts = ""


### PR DESCRIPTION
Add the first platform supported in the morty branch.

Note that this is a bit convoluted due to wanting to stay with the Compulab provided BSP.