### PR TITLE
add additional Mender server config examples in templates

### DIFF
--- a/templates/local.conf.append
+++ b/templates/local.conf.append
@@ -12,16 +12,40 @@ MENDER_ARTIFACT_NAME = "release-1"
 
 INHERIT += "mender-full"
 
-# Build for Hosted Mender
-# To get your tenant token, log in to https://hosted.mender.io,
-# click your email at the top right and then "My organization".
-# Remember to remove the meta-mender-demo layer (if you have added it).
-# We recommend Mender 1.3.0 and Yocto Project's rocko or later for Hosted Mender.
-#
-#MENDER_SERVER_URL = "https://hosted.mender.io"
-#MENDER_TENANT_TOKEN = ""
-
 DISTRO_FEATURES_append = " systemd"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""
+
+# Build for Hosted Mender
+#
+# To get your tenant token:
+#    - log in to https://hosted.mender.io
+#    - click your email at the top right and then "My organization"
+#    - press the "COPY TO CLIPBOARD"
+#    - assign content of clipboard to MENDER_TENANT_TOKEN
+#
+#MENDER_SERVER_URL = "https://hosted.mender.io"
+#MENDER_TENANT_TOKEN = ""
+
+# Build for Mender demo server
+#
+# https://docs.mender.io/getting-started/create-a-test-environment
+#
+# Uncomment below and update IP address to match the machine running the
+# Mender demo server
+#MENDER_DEMO_HOST_IP_ADDRESS = "192.168.0.100"
+
+# Build for Mender production setup (on-prem)
+#
+# https://docs.mender.io/artifacts/building-for-production
+#
+# Uncomment below and update the URL to match your configured domain
+# name and provide the path to the generated server.crt file.
+#
+# NOTE! It is recommend that you provide below information in your custom
+# Yocto layer and this is only for demo purposes. See linked documentation
+# for additional information.
+#MENDER_SERVER_URL = "https://docker.mender.io"
+#FILESEXTRAPATHS_prepend_pn-mender := "<DIRECTORY-CONTAINING-server.crt>:"
+#SRC_URI_append_pn-mender = " file://server.crt"


### PR DESCRIPTION
This is preparation work to add information about different server configurations using Yocto to Mender Hub templates. 