### PR TITLE
Fix storage device for Pico-Pi i.MX7D

### DIFF
--- a/meta-mender-nxp/templates/local.conf.append
+++ b/meta-mender-nxp/templates/local.conf.append
@@ -8,12 +8,14 @@ DISTRO ?= "fslc-framebuffer"
 IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
 
 # Specific Kernel devicetree and U-Boot Configuration for Pico-Pi i.MX7D
+MENDER_STORAGE_DEVICE_imx7d-pico = "/dev/mmcblk2"
 KERNEL_DEVICETREE_remove_imx7d-pico = "imx7d-pico-hobbit.dtb"
 UBOOT_CONFIG_remove_imx7d-pico = "hobbit generic"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1_imx7d-pico = "0xC0000"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2_imx7d-pico = "0xE0000"
 
 # Specific Configuration for WaRP7
+MENDER_STORAGE_DEVICE_imx7s-warp = "/dev/mmcblk1"
 IMAGE_BOOT_FILES_imx7s-warp = "boot.scr"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1_imx7s-warp = "0x80000"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2_imx7s-warp = "0xA0000"
@@ -21,6 +23,5 @@ MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2_imx7s-warp = "0xA0000"
 # General Configuration for imx device 
 MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
 MENDER_UBOOT_STORAGE_DEVICE = "0"
-MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
 MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
 MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"


### PR DESCRIPTION
With the update of the linux-fslc the block memory and the emmc has changed


Signed-off-by: Joris Offouga <offougajoris@gmail.com>