### PR TITLE
initial support for Odroid C2 SBC

### DIFF
--- a/meta-mender-odroid/classes/odroid-sdimg.bbclass
+++ b/meta-mender-odroid/classes/odroid-sdimg.bbclass
@@ -1,0 +1,45 @@
+inherit image_types
+
+# This is a re-work of meta-otroid/classes/image_types_odroid.bbclass
+
+# It is not possible to specific this using MENDER_IMAGE_BOOTLOADER_FILE/OFFSET,
+# instead we use an append to "sdimg" to embedd the bootloader
+
+generic_odroid_xu_wic_cmd() {
+    outimgname="${IMGDEPLOYDIR}/${IMAGE_NAME}.$suffix"
+    dd if=${DEPLOY_DIR_IMAGE}/bl1.bin.hardkernel of=${outimgname} conv=notrunc bs=512 seek=1
+    dd if=${DEPLOY_DIR_IMAGE}/bl2.bin.hardkernel of=${outimgname} conv=notrunc bs=512 seek=31
+    dd if=${DEPLOY_DIR_IMAGE}/u-boot-dtb.bin of=${outimgname} conv=notrunc bs=512 seek=63
+    dd if=${DEPLOY_DIR_IMAGE}/tzsw.bin.hardkernel of=${outimgname} conv=notrunc bs=512 seek=2111
+    dd if=/dev/zero of=${outimgname} conv=notrunc count=32 bs=512 seek="2625"
+}
+
+IMAGE_CMD_wic_append_odroid-xu3() {
+    generic_odroid_xu_wic_cmd
+}
+
+IMAGE_CMD_wic_append_odroid-xu4() {
+    generic_odroid_xu_wic_cmd
+}
+
+IMAGE_CMD_wic_append_odroid-xu3-lite() {
+    generic_odroid_xu_wic_cmd
+}
+
+IMAGE_CMD_wic_append_odroid-hc1() {
+    generic_odroid_xu_wic_cmd
+}
+
+IMAGE_CMD_wic_append_odroid-c1() {
+    outimgname="${IMGDEPLOYDIR}/${IMAGE_NAME}.$suffix"
+    dd if=${DEPLOY_DIR_IMAGE}/bl1.bin.hardkernel   of=${outimgname} conv=notrunc bs=1 count=442
+    dd if=${DEPLOY_DIR_IMAGE}/bl1.bin.hardkernel   of=${outimgname} conv=notrunc bs=512 skip=1 seek=1
+    dd if=${DEPLOY_DIR_IMAGE}/u-boot-${MACHINE}.${UBOOT_SUFFIX} of=${outimgname} conv=notrunc bs=512 seek=64
+}
+
+IMAGE_CMD_sdimg_append_odroid-c2() {
+    outimgname="${IMGDEPLOYDIR}/${IMAGE_NAME}.$suffix"
+    dd if=${DEPLOY_DIR_IMAGE}/bl1.bin.hardkernel   of=${outimgname} conv=notrunc bs=1 count=442
+    dd if=${DEPLOY_DIR_IMAGE}/bl1.bin.hardkernel   of=${outimgname} conv=notrunc bs=512 skip=1 seek=1
+    dd if=${DEPLOY_DIR_IMAGE}/u-boot-dtb.bin of=${outimgname} conv=notrunc bs=512 seek=97
+}

--- a/meta-mender-odroid/conf/layer.conf
+++ b/meta-mender-odroid/conf/layer.conf
@@ -1,0 +1,13 @@
+# Copyright 2019 Northern.tech AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-odroid"
+BBFILE_PATTERN_mender-odroid = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-odroid = "10"
+LAYERSERIES_COMPAT_mender-odroid = "thud"

--- a/meta-mender-odroid/recipes-bsp/odroid-u-boot-scr/files/boot.cmd.in
+++ b/meta-mender-odroid/recipes-bsp/odroid-u-boot-scr/files/boot.cmd.in
@@ -1,0 +1,14 @@
+setenv video 'drm.edid_firmware=edid/1024x768.bin'
+setenv console 'console=ttyAML0,115200'
+
+run mender_setup;
+
+setenv root root=${mender_kernel_root} rw rootwait
+setenv bootargs ${console} ${root} rw rootwait ${video}
+
+load ${mender_uboot_root} ${kernel_addr_r} /boot/@@KERNEL_IMAGETYPE@@
+load ${mender_uboot_root} ${fdt_addr_r} /boot/@@KERNEL_DEVICETREE@@
+
+@@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}
+
+run mender_try_to_recover

--- a/meta-mender-odroid/recipes-bsp/odroid-u-boot-scr/odroid-u-boot-scr.bb
+++ b/meta-mender-odroid/recipes-bsp/odroid-u-boot-scr/odroid-u-boot-scr.bb
@@ -1,0 +1,26 @@
+SUMMARY = "U-boot boot scripts for Odroid-C2"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+DEPENDS = "u-boot-mkimage-native"
+
+SRC_URI = "file://boot.cmd.in"
+
+KERNEL_BOOTCMD ?= "booti"
+
+do_compile() {
+    sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
+        -e 's/@@KERNEL_DEVICETREE@@/${KERNEL_DEVICETREE_FN}/' \
+        -e 's/@@KERNEL_BOOTCMD@@/${KERNEL_BOOTCMD}/' \
+           "${WORKDIR}/boot.cmd.in" > "${WORKDIR}/boot.cmd"
+    mkimage -A arm -T script -C none -n "Boot script" -d "${WORKDIR}/boot.cmd" odroid-boot.scr
+}
+
+inherit deploy
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 odroid-boot.scr ${DEPLOYDIR}
+}
+
+addtask deploy before do_package after do_install

--- a/meta-mender-odroid/recipes-bsp/u-boot/patches/odroid-c2/0001-configs-meson-gx-add-Mender-requirements.patch
+++ b/meta-mender-odroid/recipes-bsp/u-boot/patches/odroid-c2/0001-configs-meson-gx-add-Mender-requirements.patch
@@ -1,0 +1,35 @@
+From 409c5dfad8999b4679d506576c52a565ea5bdd1e Mon Sep 17 00:00:00 2001
+From: Mirza Krak <mirza.krak@northern.tech>
+Date: Sat, 13 Apr 2019 18:35:09 +0200
+Subject: [PATCH 1/1] configs: meson-gx: add Mender requirements
+
+Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
+---
+ configs/odroid-c2_defconfig       | 1 +
+ include/configs/meson-gx-common.h | 3 +++
+ 2 files changed, 4 insertions(+)
+
+diff --git a/configs/odroid-c2_defconfig b/configs/odroid-c2_defconfig
+index 9be69adcac..0d534603c6 100644
+--- a/configs/odroid-c2_defconfig
++++ b/configs/odroid-c2_defconfig
+@@ -38,3 +38,4 @@ CONFIG_DEBUG_UART_ANNOUNCE=y
+ CONFIG_DEBUG_UART_SKIP_INIT=y
+ CONFIG_MESON_SERIAL=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
++CONFIG_ENV_IS_IN_MMC=y
+diff --git a/include/configs/meson-gx-common.h b/include/configs/meson-gx-common.h
+index 7435f3475e..064c2c9036 100644
+--- a/include/configs/meson-gx-common.h
++++ b/include/configs/meson-gx-common.h
+@@ -50,4 +50,7 @@
+ 
+ #define CONFIG_SYS_BOOTM_LEN    (64 << 20)      /* 64 MiB */
+ 
++#define CONFIG_BOOTCOUNT_LIMIT
++#define CONFIG_BOOTCOUNT_ENV
++
+ #endif /* __MESON_GX_COMMON_CONFIG_H */
+-- 
+2.11.0
+

--- a/meta-mender-odroid/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-odroid/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
+
+SRC_URI_append_odroid-c2 = " file://0001-configs-meson-gx-add-Mender-requirements.patch"
+
+MENDER_UBOOT_AUTO_CONFIGURE_odroid-c2 = "0"
+BOOTENV_SIZE_odroid-c2 = "0x2000"
+
+DEPENDS_append_odroid-c2 = " odroid-u-boot-scr"

--- a/meta-mender-odroid/recipes-kernel/linux/linux-stable/vfat.cfg
+++ b/meta-mender-odroid/recipes-kernel/linux/linux-stable/vfat.cfg
@@ -1,0 +1,1 @@
+CONFIG_VFAT_FS=y

--- a/meta-mender-odroid/recipes-kernel/linux/linux-stable_%.bbappend
+++ b/meta-mender-odroid/recipes-kernel/linux/linux-stable_%.bbappend
@@ -1,0 +1,3 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append = " file://vfat.cfg"

--- a/meta-mender-odroid/scripts/manifest-odroid.xml
+++ b/meta-mender-odroid/scripts/manifest-odroid.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+  <default sync-j="4" revision="thud"/>
+
+  <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
+  <remote fetch="https://github.com/akuster"        name="odroid"/>
+
+  <project name="poky" remote="yocto" revision="thud" path="sources/poky"/>
+  <project name="meta-odroid" remote="odroid" revision="thud" path="sources/meta-odroid"/>
+  
+  <include name="scripts/mender.xml"/>
+
+  </manifest>

--- a/meta-mender-odroid/templates/bblayers.conf.sample
+++ b/meta-mender-odroid/templates/bblayers.conf.sample
@@ -1,0 +1,16 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../sources/poky/meta \
+  ${TOPDIR}/../sources/poky/meta-poky \
+  ${TOPDIR}/../sources/poky/meta-yocto-bsp \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-core \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-demo \
+  ${TOPDIR}/../sources/meta-mender-community/meta-mender-odroid \
+  ${TOPDIR}/../sources/meta-odroid \
+"

--- a/meta-mender-odroid/templates/local.conf.append
+++ b/meta-mender-odroid/templates/local.conf.append
@@ -1,0 +1,20 @@
+# Appended fragment from meta-mender-community/meta-mender-odroid/templates
+
+MACHINE ?= "odroid-c2"
+
+MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
+MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
+
+IMAGE_CLASSES += "odroid-sdimg"
+
+MENDER_UBOOT_STORAGE_DEVICE_odroid-c2 = "0"
+MENDER_STORAGE_DEVICE_odroid-c2 = "/dev/mmcblk1"
+
+# Disable uboot-boot-scr.bbclass", we will provide a custom one as this is
+# not flexible enough to apply all changes necessary for Mender.
+#
+# Bug in meta-odroid, which triggers a build error if boot.scr is disable,
+# leave this commented until upstream is fixed.
+#USE_BOOTSCR = "0"
+
+IMAGE_BOOT_FILES_odroid-c2 = "odroid-boot.scr;boot.scr"

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -23,6 +23,7 @@ targets=(
     "clearfog"
     "intel"
     "nxp"
+    "odroid"
     "qemu"
     "raspberrypi"
     "renesas"


### PR DESCRIPTION
The integration is based on the "odroid-c2" machine which uses upstream Linux
and U-boot.

This integration probably will not work out-of-the-box for the "odroid-c2-hardkernel"
machine which uses "hardkernel" U-boot and Linux forks.