### PR TITLE
add meta-mender-update-modules layer with the first module

### DIFF
--- a/meta-mender-update-modules/README.md
+++ b/meta-mender-update-modules/README.md
@@ -1,0 +1,43 @@
+meta-mender-update-modules
+==========================
+
+Mender is an open source over-the-air (OTA) software updater for embedded Linux devices. Mender comprises a client running at the embedded device, as well as a server that manages deployments across many devices.
+
+This repository contains Yocto recipes for community supported Update Modules. An Update Module is an extension to the Mender client for supporting a new type of software update, such as a package manager, container, bootloader or even updates of nearby microcontrollers. An Update Module can be tailored to a specific device or environment (e.g. update a proprietary bootloader), or be more general-purpose (e.g. install a set of .deb packages.).
+
+There are a couple of general-purpose Update Modules bundled together with the [Mender client source code](https://github.com/mendersoftware/mender/tree/master/support/modules), these can be installed using [meta-mender](https://github.com/mendersoftware/meta-mender).
+
+![Mender logo](https://mender.io/user/pages/resources/06.digital-assets/mender.io.png)
+
+## Getting started
+
+To start using Mender, we recommend that you begin with the Getting started
+section in [the Mender documentation](https://docs.mender.io/).
+
+To start using Mender Update Modules, we recommend that you begin with the Update Modules - Introduction
+section in [the Mender documentation](https://docs.mender.io/devices/update-modules).
+
+You can find detailed information about available Update Modules on [Mender Hub](https://hub.mender.io/c/update-modules).
+
+## Contributing
+
+We welcome and ask for your contribution. If you would like to contribute to Mender, please read our guide on how to best get started [contributing code or
+documentation](https://github.com/mendersoftware/mender/blob/master/CONTRIBUTING.md).
+
+## Connect with us
+
+* Join the [Mender Hub discussion forum](https://hub.mender.io)
+* Follow us on [Twitter](https://twitter.com/mender_io). Please
+  feel free to tweet us questions.
+* Fork us on [Github](https://github.com/mendersoftware)
+* Create an issue in the [bugtracker](https://tracker.mender.io/projects/MEN)
+* Email us at [contact@mender.io](mailto:contact@mender.io)
+* Connect to the [#mender IRC channel on Freenode](http://webchat.freenode.net/?channels=mender)
+
+
+## Authors
+
+Mender was created by the team at [Northern.tech AS](https://northern.tech), with many contributions from
+the community. Thanks [everyone](https://github.com/mendersoftware/meta-mender-community/graphs/contributors)!
+
+[Mender](https://mender.io) is sponsored by [Northern.tech AS](https://northern.tech).

--- a/meta-mender-update-modules/conf/layer.conf
+++ b/meta-mender-update-modules/conf/layer.conf
@@ -1,0 +1,14 @@
+# Copyright 2019 Northern.tech AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-update-modules"
+BBFILE_PATTERN_mender-update-modules = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-update-modules = "15"
+
+LAYERSERIES_COMPAT_mender-update-modules = "rocko sumo thud warrior"

--- a/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-dir-overlay_git.bb
+++ b/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-dir-overlay_git.bb
@@ -1,0 +1,20 @@
+DESCRIPTION = "The Directory Overlay Update Module installs a user defined file tree structure into a given destination directory in the target."
+
+require mender-update-modules.inc
+
+do_install_class-target() {
+    install -d ${D}/${datadir}/mender/modules/v3
+    install -m 755 ${S}/dir-overlay/module/dir-overlay ${D}/${datadir}/mender/modules/v3/dir-overlay
+}
+
+do_install_class-native() {
+    install -d ${D}/${bindir}
+    install -m 755 ${S}/dir-overlay/module-artifact-gen/dir-overlay-artifact-gen ${D}/${bindir}/dir-overlay-artifact-gen
+}
+
+FILES_${PN} += "${datadir}/mender/modules/v3/dir-overlay"
+FILES_${PN}-class-native += "${bindir}/dir-overlay-gen"
+
+BBCLASSEXTEND = "native"
+
+inherit allarch

--- a/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
+++ b/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
@@ -1,0 +1,9 @@
+HOMEPAGE = "https://mender.io"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
+
+SRC_URI = "git://github.com/mirzak/mender-update-modules.git"
+
+SRCREV = "e2ea09b5f3a877dd298a1f4746c613e53ac95cc9"
+
+S = "${WORKDIR}/git"


### PR DESCRIPTION
meta-mender-update-modules is the intended location where one can share Yocto recipes for specific Update Modules, in the simplest form it is simply a recipe installing the Update Module on the device. 

More advanced use-cases would be enabling creating of Update Module artifacts during an Yocto build.