### PR TITLE
initial support for Siemens IOT2000

### DIFF
--- a/meta-mender-iot2000/scripts/kas.yml
+++ b/meta-mender-iot2000/scripts/kas.yml
@@ -1,0 +1,18 @@
+header:
+  version: 2
+  includes:
+    - repo: meta-iot2000
+      file: meta-iot2000-example/kas.yml
+    - ../../scripts/kas.yml
+
+repos:
+  meta-iot2000:
+    url: "https://github.com/siemens/meta-iot2000"
+    refspec: 93e163f8b4f4448718c8997126fd8f12c2790268
+
+local_conf_header:
+  storage: |
+    MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "4096"
+
+  device: |
+    MENDER_STORAGE_DEVICE = "/dev/sda"

--- a/scripts/kas.yml
+++ b/scripts/kas.yml
@@ -1,0 +1,62 @@
+header:
+  version: 2
+
+repos:
+  meta-mender:
+    url: https://github.com/mendersoftware/meta-mender.git
+    refspec: thud
+    layers:
+      meta-mender-core:
+      meta-mender-demo:
+
+local_conf_header:
+  mender: |
+    MENDER_ARTIFACT_NAME = "release-1"
+    INHERIT += "mender-full"
+
+  storage: |
+    MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "4096"
+
+  systemd: |
+    DISTRO_FEATURES_append = " systemd"
+    VIRTUAL-RUNTIME_init_manager = "systemd"
+    DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
+    VIRTUAL-RUNTIME_initscripts = ""
+
+  mender-fs: |
+    ARTIFACTIMG_FSTYPE = "ext4"
+
+  mender-server-hosted: |
+    # Build for Hosted Mender
+    # To get your tenant token:
+    #    - log in to https://hosted.mender.io
+    #    - click your email at the top right and then "My organization"
+    #    - press the "COPY TO CLIPBOARD"
+    #    - assign content of clipboard to MENDER_TENANT_TOKEN
+    #
+    #MENDER_SERVER_URL = "https://hosted.mender.io"
+    #MENDER_TENANT_TOKEN = ""
+
+  mender-server-demo: |
+    # Build for Mender demo server
+    #
+    # https://docs.mender.io/getting-started/create-a-test-environment
+    #
+    # Uncomment below and update IP address to match the machine running the
+    # Mender demo server
+    #MENDER_DEMO_HOST_IP_ADDRESS = "192.168.0.100"
+
+  mender-server-onprem: |
+    # Build for Mender production setup (on-prem)
+    #
+    # https://docs.mender.io/artifacts/building-for-production
+    #
+    # Uncomment below and update the URL to match your configured domain
+    # name and provide the path to the generated server.crt file.
+    #
+    # NOTE! It is recommend that you provide below information in your custom
+    # Yocto layer and this is only for demo purposes. See linked documentation
+    # for additional information.
+    #MENDER_SERVER_URL = "https://docker.mender.io"
+    #FILESEXTRAPATHS_prepend_pn-mender := "<DIRECTORY-CONTAINING-server.crt>:"
+    #SRC_URI_append_pn-mender = " file://server.crt"


### PR DESCRIPTION
The default settings assume that one is booting from USB.

The integration actually does not work yet, due to this error:

```
root@iot2000:~# mender                                                                                                                                                                                            
This program can only be run on processors with MMX support.
```

See [this](https://support.industry.siemens.com/tf/WW/en/posts/mmx-in-iot2020/201161?page=0&pageSize=10) for more information on why. Essentalily `golang` does not work in the SoC used by IOT2000 board. They do have a fork of golang with a patchset that resolves this, but they only have patches for 1.6 and 1.8 versions of go (1.8 was used in pyro)

But I would still like to merge this, in the hopes that someone see it and fixes it.

Also as the [meta-iot2000](https://github.com/siemens/meta-iot2000) uses [kas](https://github.com/siemens/kas), I have added support for this in meta-mender-community and added a `kas.yml` for iot2000 board along with a generic one for Mender