### PR TITLE
Use official release of meta raspberry pi instead of the developers repository

### DIFF
--- a/meta-mender-raspberrypi/scripts/manifest-raspberrypi.xml
+++ b/meta-mender-raspberrypi/scripts/manifest-raspberrypi.xml
@@ -3,13 +3,12 @@
 
   <default sync-j="4" revision="thud"/>
 
-  <remote fetch="https://git.yoctoproject.org/git"            name="yocto"/>
-  <remote fetch="https://github.com/openembedded"             name="oe"/>
-  <remote fetch="git://git.yoctoproject.org/meta-raspberrypi" name="rpi"/>
+  <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
+  <remote fetch="https://github.com/openembedded"  name="oe"/>
 
   <project name="poky" remote="yocto" revision="thud" path="sources/poky"/>
   <project name="meta-openembedded" remote="oe" revision="thud" path="sources/meta-openembedded"/>
-  <project name="meta-raspberrypi" remote="rpi" revision="thud" path="sources/meta-raspberrypi"/>
+  <project name="meta-raspberrypi" remote="yocto" revision="thud" path="sources/meta-raspberrypi"/>
 
   <include name="scripts/mender.xml"/>
 

--- a/meta-mender-raspberrypi/scripts/manifest-raspberrypi.xml
+++ b/meta-mender-raspberrypi/scripts/manifest-raspberrypi.xml
@@ -3,9 +3,9 @@
 
   <default sync-j="4" revision="thud"/>
 
-  <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
-  <remote fetch="https://github.com/openembedded"  name="oe"/>
-  <remote fetch="https://github.com/agherzan"      name="rpi"/>
+  <remote fetch="https://git.yoctoproject.org/git"            name="yocto"/>
+  <remote fetch="https://github.com/openembedded"             name="oe"/>
+  <remote fetch="git://git.yoctoproject.org/meta-raspberrypi" name="rpi"/>
 
   <project name="poky" remote="yocto" revision="thud" path="sources/poky"/>
   <project name="meta-openembedded" remote="oe" revision="thud" path="sources/meta-openembedded"/>


### PR DESCRIPTION
This Patch uses the official meta raspberrypi instead of the developers