### PR TITLE
Update/uboot

### DIFF
--- a/meta-mender-atmel/recipes-bsp/u-boot/files/0001-ARM-sama5d27_som1_ek-Add-support-to-mender-for-U-Boo.patch
+++ b/meta-mender-atmel/recipes-bsp/u-boot/files/0001-ARM-sama5d27_som1_ek-Add-support-to-mender-for-U-Boo.patch
@@ -1,0 +1,78 @@
+From dea234aada238b9579420cccc5765effa8db7543 Mon Sep 17 00:00:00 2001
+From: Pierre-Jean Texier <pjtexier@koncepto.io>
+Date: Tue, 25 Jun 2019 21:13:53 +0200
+Subject: [PATCH] ARM: sama5d27_som1_ek: Add support to mender for U-Boot
+ 2019.04
+
+Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>
+---
+ configs/sama5d27_som1_ek_mmc_defconfig | 10 ++++++----
+ include/configs/sama5d27_som1_ek.h     | 11 +++++++++++
+ 2 files changed, 17 insertions(+), 4 deletions(-)
+
+diff --git a/configs/sama5d27_som1_ek_mmc_defconfig b/configs/sama5d27_som1_ek_mmc_defconfig
+index e31eb1c..09290e5 100644
+--- a/configs/sama5d27_som1_ek_mmc_defconfig
++++ b/configs/sama5d27_som1_ek_mmc_defconfig
+@@ -23,7 +23,7 @@ CONFIG_SYS_EXTRA_OPTIONS="SAMA5D2"
+ CONFIG_SD_BOOT=y
+ CONFIG_BOOTDELAY=3
+ CONFIG_USE_BOOTARGS=y
+-CONFIG_BOOTARGS="console=ttyS0,115200 earlyprintk root=/dev/mmcblk0p2 rw rootwait"
++CONFIG_BOOTARGS="console=ttyS0,115200 earlyprintk root='${mender_kernel_root}' rw rootwait"
+ CONFIG_MISC_INIT_R=y
+ # CONFIG_DISPLAY_BOARDINFO is not set
+ CONFIG_SPL_SEPARATE_BSS=y
+@@ -39,14 +39,17 @@ CONFIG_CMD_DHCP=y
+ CONFIG_CMD_PING=y
+ CONFIG_CMD_EXT4=y
+ CONFIG_CMD_FAT=y
++CONFIG_CMD_FS_GENERIC=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_DEFAULT_DEVICE_TREE="at91-sama5d27_som1_ek"
+ CONFIG_OF_SPL_REMOVE_PROPS="interrupts interrupt-parent dmas dma-names"
+-CONFIG_ENV_IS_IN_FAT=y
++CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_DM=y
+ CONFIG_SPL_DM=y
+ CONFIG_SPL_DM_SEQ_ALIAS=y
++CONFIG_BOOTCOUNT_LIMIT=y
++CONFIG_BOOTCOUNT_ENV=y
+ CONFIG_CLK=y
+ CONFIG_SPL_CLK=y
+ CONFIG_CLK_AT91=y
+@@ -92,7 +95,6 @@ CONFIG_USB_STORAGE=y
+ CONFIG_USB_GADGET=y
+ CONFIG_USB_GADGET_ATMEL_USBA=y
+ CONFIG_DM_VIDEO=y
+-CONFIG_W1_GPIO=y
+ CONFIG_W1_EEPROM=y
+-CONFIG_W1_EEPROM_DS24XXX=y
++CONFIG_FAT_WRITE=y
+ CONFIG_OF_LIBFDT_OVERLAY=y
+diff --git a/include/configs/sama5d27_som1_ek.h b/include/configs/sama5d27_som1_ek.h
+index f128bdb..339ba32 100644
+--- a/include/configs/sama5d27_som1_ek.h
++++ b/include/configs/sama5d27_som1_ek.h
+@@ -40,6 +40,17 @@
+ #define CONFIG_BOOTCOMMAND	"fatload mmc " CONFIG_ENV_FAT_DEVICE_AND_PART " 0x21000000 at91-sama5d27_som1_ek.dtb; " \
+ 				"fatload mmc " CONFIG_ENV_FAT_DEVICE_AND_PART " 0x22000000 zImage; " \
+ 				"bootz 0x22000000 - 0x21000000"
++
++#undef CONFIG_ENV_SIZE
++#undef CONFIG_BOOTCOMMAND
++
++#define CONFIG_ENV_SIZE		0x1000
++#define CONFIG_BOOTCOMMAND	\
++	"run mender_setup;" \
++	"load ${mender_uboot_root} 0x21000000 /boot/at91-sama5d27_som1_ek.dtb; " \
++	"load ${mender_uboot_root} 0x22000000 /boot/zImage; " \
++	"bootz 0x22000000 - 0x21000000; " \
++	"run mender_try_to_recover"
+ #endif
+ 
+ #ifdef CONFIG_QSPI_BOOT
+-- 
+2.7.4
+

--- a/meta-mender-atmel/recipes-bsp/u-boot/u-boot-mender-atmel.inc
+++ b/meta-mender-atmel/recipes-bsp/u-boot/u-boot-mender-atmel.inc
@@ -1,13 +1,20 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 # Currently, the U-Boot version in meta-atmel is
-# more recent (2018.07) than the one on poky (sumo), which is in 2018.01.
+# more recent (2019.04) than the one on poky (thud), which is in 2019.01.
 # So, it is required to remove these patch.
 
 SRC_URI_remove = " \
 	file://0005-fw_env_main.c-Fix-incorrect-size-for-malloc-ed-strin.patch \
 	file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch \
 "
+
+SRC_URI_remove = "\
+	${@bb.utils.contains('PREFERRED_VERSION_u-boot-at91', \
+	'v2018.07%', \
+	'', \
+	'file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch', \
+	d)}"
 
 # It is also required to re-implement the patch
 # "0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
@@ -17,9 +24,15 @@ SRC_URI_append = " \
 	file://0002-Integration-of-Mender-boot-code-into-U-Boot.patch \
 "
 
+# If you want to use the U-Boot's legacy version in thud,
+# please set PREFERRED_VERSION_u-boot-at91 = "v2018.07%".
+
 SRC_URI_append_sama5d27-som1-ek-sd += "\
-	file://0001-ARM-sama5d27_som1_ek-Add-support-to-mender.patch \
-"
+	${@bb.utils.contains('PREFERRED_VERSION_u-boot-at91', \
+	'v2018.07%', \
+	'file://0001-ARM-sama5d27_som1_ek-Add-support-to-mender.patch', \
+	'file://0001-ARM-sama5d27_som1_ek-Add-support-to-mender-for-U-Boo.patch', \
+	d)}"
 
 SRC_URI_append_sama5d3-xplained-sd += "\
 	file://0001-Arm-Atmel-Add-mender-support-for-sama5d3-xplained.patch \

--- a/meta-mender-atmel/templates/local.conf.append
+++ b/meta-mender-atmel/templates/local.conf.append
@@ -11,3 +11,7 @@ MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 = "0x2000"
 # Redundant environment
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 = "0x4000"
+
+# The U-Boot env file is not needed with Mender (CONFIG_ENV_IS_IN_MMC)
+# Furthermore, this fixes an error during 'do_image_sdimg' step.
+IMAGE_BOOT_FILES_remove_sama5d27-som1-ek-sd = "uboot.env"


### PR DESCRIPTION
Update for U-Boot 2019.04.

See [Mender Hub](https://hub.mender.io/t/first-time-build-fails-for-microchip-sama5d27-som1-ek1-127/748/17)