### PR TITLE
imx: move MENDER_STORAGE_DEVICE definitions to local.conf.bbappend

### DIFF
--- a/meta-mender-imx/classes/mender-setup-imx.bbclass
+++ b/meta-mender-imx/classes/mender-setup-imx.bbclass
@@ -16,6 +16,3 @@ python __anonymous () {
 do_image_sdimg[depends] += "imx-boot:do_deploy"
 
 IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
-
-MENDER_STORAGE_DEVICE_imx8mmevk = "/dev/mmcblk1"
-MENDER_STORAGE_DEVICE_imx8mqevk = "/dev/mmcblk1"

--- a/meta-mender-imx/templates/local.conf.append
+++ b/meta-mender-imx/templates/local.conf.append
@@ -3,3 +3,6 @@
 MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 PREFERRED_PROVIDER_u-boot = "u-boot-imx"
 IMAGE_CLASSES += "mender-setup-imx"
+
+MENDER_STORAGE_DEVICE_imx8mmevk = "/dev/mmcblk1"
+MENDER_STORAGE_DEVICE_imx8mqevk = "/dev/mmcblk1"


### PR DESCRIPTION
Having the definition in a IMAGE_CLASS will make these only applicable
on the image built, but this is not applied when you build e.g u-boot
which also needs a correct definition of MENDER_STORAGE_DEVICE.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>