### PR TITLE
update-modules: bump git srcrev

### DIFF
--- a/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
+++ b/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
@@ -4,6 +4,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/mendersoftware/mender-update-modules.git"
 
-SRCREV = "66f58596b23dee9cd88d4ea3c8ad09ce941482d4"
+SRCREV = "7631f32b54d06c56f786b1459e5fce158efba14a"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

7631f32 dir-overlay: fail if update module is not executed by a superuser
dda8192 dir-overlay: preserve file/directory ownership and mode permissions
3176c72 module/dir-overlay: fix bashism in rollback state

Signed-off-by: Pierre-Jean Texier <pjtexier@koncepto.io>