### PR TITLE
clearfog: fix missing $ in local.append template

### DIFF
--- a/meta-mender-clearfog/templates/local.conf.append
+++ b/meta-mender-clearfog/templates/local.conf.append
@@ -13,7 +13,7 @@ UBOOT_BINARY ?= "u-boot-spl-sdhc.kwb"
 
 IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
 
-MENDER_IMAGE_BOOTLOADER_FILE = "u-boot-{MACHINE}.bin"
+MENDER_IMAGE_BOOTLOADER_FILE = "u-boot-${MACHINE}.bin"
 MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "1"
 
 MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"


### PR DESCRIPTION
Missed the $ sign in the ```local.conf.append``` file.

A little surprised since I compiled it prior to saying it's ready, must have had a stale build at the time.

Anyway a quick fix.