### PR TITLE
Update odroid manifest revision on warrior branch

### DIFF
--- a/meta-mender-odroid/scripts/manifest-odroid.xml
+++ b/meta-mender-odroid/scripts/manifest-odroid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
   <manifest>
-  <default sync-j="4" revision="thud"/>
+  <default sync-j="4" revision="warrior"/>
 
   <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
   <remote fetch="https://github.com/akuster"        name="odroid"/>


### PR DESCRIPTION
Attempting to build on warrior for odroid-c2 - although still complains:
```ERROR: Layer mender is not compatible with the core layer which only supports these series: thud (layer is compatible with warrior)```