### PR TITLE
meta-mender-tegra: Add u-boot-bup-payload support

### DIFF
--- a/meta-mender-tegra/recipes-bsp/mender-tegra-bup-payload-install/mender-tegra-bup-payload-install_1.0.bb
+++ b/meta-mender-tegra/recipes-bsp/mender-tegra-bup-payload-install/mender-tegra-bup-payload-install_1.0.bb
@@ -1,0 +1,16 @@
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+UBOOT_IMAGE ?= "u-boot-${MACHINE}.${UBOOT_SUFFIX}"
+
+do_install() {
+    install -d ${D}/opt/ota_package/
+    install -m 0644 ${DEPLOY_DIR_IMAGE}/${UBOOT_IMAGE}.bup-payload ${D}/opt/ota_package/bl_update_payload_current
+    ln -s /opt/ota_package/bl_update_payload_current ${D}/opt/ota_package/bl_update_payload
+}
+
+do_install[depends] += "u-boot-bup-payload:do_deploy"
+FILES_${PN} += "/opt/ota_package/bl_update_payload_current"
+FILES_${PN} += "/opt/ota_package/bl_update_payload"
+RDEPENDS_${PN} += "tegra186-redundant-boot"
+RDEPENDS_${PN} += "tegra-state-scripts"

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -1,13 +1,4 @@
 require recipes-bsp/u-boot/u-boot-mender.inc
 require recipes-bsp/u-boot/u-boot-mender-tegra.inc
 
-do_install_append() {
-    install -d ${D}/opt/ota_package/
-    install -m 0644 ${WORKDIR}/bup-payload/bl_update_payload ${D}/opt/ota_package/bl_update_payload_current
-    ln -s /opt/ota_package/bl_update_payload_current ${D}/opt/ota_package/bl_update_payload
-}
-
-FILES_${PN} += "/opt/ota_package/bl_update_payload_current"
-FILES_${PN} += "/opt/ota_package/bl_update_payload"
-RDEPENDS_${PN} += "tegra186-redundant-boot"
-RDEPENDS_${PN} += "tegra-state-scripts"
+RDEPENDS_${PN} += "mender-tegra-bup-payload-install"


### PR DESCRIPTION
To match [logic change](https://github.com/madisongh/meta-tegra/issues/204) in meta-tegra we now need to use the u-boot-bup-payload class to generate bup payloads.

Move logic into a new mender-tegra-bup-payload-install class

Signed-off-by: Dan Walkes <danwalkes@trellis-logic.com>