### PR TITLE
meta-mender-tegra: add support for jetson-nano development kit

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -5,6 +5,7 @@ Mender integration layer for NVIDIA Tegra hardware.
 The supported and tested boards are:
 
 - [Jetson TX2](https://hub.mender.io/t/nvidia-tegra-jetson-tx2/123)
+- [Jetson Nano](https://hub.mender.io/t/nvidia-tegra-jetson-nano/1360)
 
 Visit the individual board links above for more information on status of the
 integration and more detailed instructions on how to build and use images
@@ -43,7 +44,10 @@ repo init -u https://github.com/mendersoftware/meta-mender-community \
            -b warrior
 repo sync
 source setup-environment tegra
+# either:
 MACHINE=jetson-tx2 bitbake core-image-base
+# or:
+MACHINE=jetson-nano bitbake core-image-base
 ```
 
 

--- a/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
+++ b/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
@@ -12,3 +12,10 @@ tegraflash_create_flash_config_append() {
         -e"s,DATAFILE,${DATAFILE}," \
         flash.xml.in
 }
+
+tegraflash_create_flash_config_tegra210_append() {
+    sed -i \
+        -e"s,DATAFILE,${DATAFILE}," \
+        -e"s,APPSIZE,$(expr ${IMAGE_ROOTFS_SIZE} '*' 1024),g" \
+        $destdir/sdcard-layout
+}

--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -14,18 +14,22 @@ PREFERRED_RPROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
 # Note: this isn't really a boot file, just put it here to keep the mender build from
 # complaining about empty IMAGE_BOOT_FILES.  We won't use the full image anyway, just the mender file
 IMAGE_BOOT_FILES = "u-boot-dtb.bin"
-# Mender customizations to support jetson tx2.  This needs to match up with flash_l4t_t186.custom.xml scheme
-# You will need to update these partition values when you update the flash layout.  One way to find the correct number is to
+# Mender customizations to support jetson tx2 and jetson nano.  This needs to match up with flash_l4t_t186.custom.xml/sdcard-layout-mender.in scheme
+# You will need to update these partition values when you update the flash/sd-card layout.  One way to find the correct number is to
 # boot into an emergency shell and examine the /dev/mmcblk* devices, or use the uboot console to look at mtdparts
-MENDER_DATA_PART_NUMBER = "31"
+MENDER_DATA_PART_NUMBER = "${@'15' if d.getVar('MACHINE') == 'jetson-nano' else '31'}"
 MENDER_ROOTFS_PART_A_NUMBER = "1"
-MENDER_ROOTFS_PART_B_NUMBER = "30"
+MENDER_ROOTFS_PART_B_NUMBER = "${@'14' if d.getVar('MACHINE') == 'jetson-nano' else '30'}"
 
 # Use a 4096 byte alignment for support of tegraflash scheme and default partition locations
 MENDER_PARTITION_ALIGNMENT = "4096"
 
-# Use no reserved space for bootloader data, since we will store in the partition block for the image
-MENDER_RESERVED_SPACE_BOOTLOADER_DATA = "0"
+# For jetson-tx2, use no reserved space for bootloader data, since we will store u-boot environment in the emmc boot partition and will use 0 bytes of the user
+# part of the emmc
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA_tegra186 = "0"
+
+# For jetson-nano, u-boot environment gets stored in the first partition of the SD-card. Use 2 times u-boot's BOOTENV_SIZE (0x20000)
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA_tegra210 = "262144"
 
 # See note in https://docs.mender.io/1.7/troubleshooting/running-yocto-project-image#i-moved-from-an-older-meta-mender-branch-to-the-thud-branch-and
 # Prevents build failure during mkfs.ext4 step on warrior
@@ -45,4 +49,9 @@ MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 
 # Use this variable to adjust your total rootfs size across both images.  Rootfs size will be approximately 1/2 this value (ignoring alignment)
 # The default is enough to build core-image-base
-MENDER_STORAGE_TOTAL_SIZE_MB ??="6000"
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT_tegra186 = "6000"
+
+# For the Jetson Nano, a fixed layout with 16 GB is used. As the data partition is grown anyways, I'm conservatively setting this to 15 GiB.
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT_tegra210 = "15360"
+# ROOTFS size is 4 GiB on the Jetson Nano
+MENDER_IMAGE_ROOTFS_SIZE_DEFAULT_tegra210 = "4194304"

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0010-tegra-mender-auto-configured-modified.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0010-tegra-mender-auto-configured-modified.patch
@@ -1,4 +1,4 @@
-From 080c857306f422d8fe411edbd9ee81eaf19dd93e Mon Sep 17 00:00:00 2001
+From a9ca40aaa5b33a2c9440d27141b0bd5c1610740a Mon Sep 17 00:00:00 2001
 From: Dan Walkes <danwalkes@trellis-logic.com>
 Date: Sat, 29 Jun 2019 12:17:30 -0600
 Subject: [PATCH] tegra mender auto configured modified
@@ -6,6 +6,7 @@ Subject: [PATCH] tegra mender auto configured modified
 This patch was created after performing [automatic u-boot patching](https://github.com/mendersoftware/meta-mender/blob/master/meta-mender-core/recipes-bsp/u-boot/files/uboot_auto_patch.sh) on sumo and then fixing resulting patch failures.
 
 It was last updated for the warrior release, at which time it looked as though there were no significant changes made to [u-boot patches](https://github.com/mendersoftware/meta-mender/tree/master/meta-mender-core/recipes-bsp/u-boot/patches) since initial port was completed in [November 2018](https://github.com/mendersoftware/meta-mender-community/pull/15)
+
 ---
  include/config_defaults.h         | 8 ++++++++
  include/config_distro_bootcmd.h   | 1 -
@@ -15,7 +16,7 @@ It was last updated for the warrior release, at which time it looked as though t
  5 files changed, 9 insertions(+), 7 deletions(-)
 
 diff --git a/include/config_defaults.h b/include/config_defaults.h
-index ad08c1d..2b503f8 100644
+index ad08c1d335..2b503f807c 100644
 --- a/include/config_defaults.h
 +++ b/include/config_defaults.h
 @@ -21,3 +21,11 @@
@@ -31,7 +32,7 @@ index ad08c1d..2b503f8 100644
 +#define CONFIG_BOOTCOUNT_LIMIT
 +#define CONFIG_BOOTCOUNT_ENV
 diff --git a/include/config_distro_bootcmd.h b/include/config_distro_bootcmd.h
-index d718224..32df04a 100644
+index d7182244cb..32df04aef1 100644
 --- a/include/config_distro_bootcmd.h
 +++ b/include/config_distro_bootcmd.h
 @@ -397,7 +397,6 @@
@@ -43,7 +44,7 @@ index d718224..32df04a 100644
  
  #endif  /* _CONFIG_CMD_DISTRO_BOOTCMD_H */
 diff --git a/include/configs/p2771-0000.h b/include/configs/p2771-0000.h
-index 1c8981b..6e7d8f5 100644
+index 61310fbdf2..f586e340ce 100644
 --- a/include/configs/p2771-0000.h
 +++ b/include/configs/p2771-0000.h
 @@ -23,10 +23,6 @@
@@ -58,7 +59,7 @@ index 1c8981b..6e7d8f5 100644
  /* PCI host support */
  #define CONFIG_PCI
 diff --git a/include/configs/tegra-common.h b/include/configs/tegra-common.h
-index 4c4a1ea..0446ba5 100644
+index 4c4a1ea1c6..0446ba594b 100644
 --- a/include/configs/tegra-common.h
 +++ b/include/configs/tegra-common.h
 @@ -34,7 +34,6 @@
@@ -70,7 +71,7 @@ index 4c4a1ea..0446ba5 100644
  /*
   * NS16550 Configuration
 diff --git a/include/configs/tegra186-common.h b/include/configs/tegra186-common.h
-index 2a78513..86e2f17 100644
+index 3f96a45b18..215aef0b33 100644
 --- a/include/configs/tegra186-common.h
 +++ b/include/configs/tegra186-common.h
 @@ -54,7 +54,7 @@
@@ -80,8 +81,5 @@ index 2a78513..86e2f17 100644
 -	"kernel_addr_r=" __stringify(CONFIG_LOADADDR) "\0" \
 +	"loadaddr=" __stringify(CONFIG_LOADADDR) "\0" \
  	"fdt_addr_r=0x82000000\0" \
- 	"ramdisk_addr_r=0x82100000\0"
- 
--- 
-2.7.4
-
+ 	"ramdisk_addr_r=0x82100000\0" \
+ 	"fdt_copy_node_paths=" \

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Jetson-Nano-mender-environment-in-mmc.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Jetson-Nano-mender-environment-in-mmc.patch
@@ -1,0 +1,24 @@
+From 0972c8b7ecc95ac27ef69bd4441154f422413bfd Mon Sep 17 00:00:00 2001
+From: Moritz Marquardt <moritz.marquardt@zeiss.com>
+Date: Thu, 5 Dec 2019 14:26:57 +0000
+Subject: [PATCH] Configure u-boot env. in sd-card for jetson-nano
+
+---
+ include/configs/p3450-porg.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/configs/p3450-porg.h b/include/configs/p3450-porg.h
+index e8a7ead5bb..b818aae159 100644
+--- a/include/configs/p3450-porg.h
++++ b/include/configs/p3450-porg.h
+@@ -34,8 +34,8 @@
+ 	func(PXE, pxe, na) \
+ 	func(DHCP, dhcp, na)
+ 
+-/* Environment s/b at end of SPI, fix it later */
+-#define CONFIG_ENV_IS_NOWHERE
++/* Env is located in a partition of the sd-card (mmc device in u-boot) */
++#define CONFIG_ENV_IS_IN_MMC
+ 
+ /* SPI */
+ #define CONFIG_SF_DEFAULT_MODE		SPI_MODE_0

--- a/meta-mender-tegra/recipes-bsp/u-boot/sdcard-layout-mender.in
+++ b/meta-mender-tegra/recipes-bsp/u-boot/sdcard-layout-mender.in
@@ -1,0 +1,15 @@
+2,TBC,131072,nvtboot_cpu.bin.encrypt
+3,RP1,458752,DTBFILE
+4,EBT,589824,cboot.bin.encrypt
+5,WB0,65536,warmboot.bin.encrypt
+6,BPF,196608,sc7entry-firmware.bin.encrypt
+7,TOS,589824,tos-mon-only.img.encrypt
+8,EKS,65536,eks.img
+9,LNX,655360,LNXFILE
+10,DTB,458752,DTBFILE
+11,RP4,131072,rp4.blob
+12,BMP,81920,bmp.blob
+13,ENV,196608,/dev/null
+1,APP_A,APPSIZE,APPFILE
+14,APP_B,APPSIZE,APPFILE
+15,DATA,134217728,DATAFILE

--- a/meta-mender-tegra/recipes-bsp/u-boot/sdcard-layout_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/sdcard-layout_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}:"
+SRC_URI = "file://sdcard-layout-mender.in"
+
+do_install_prepend() {
+    cp ${S}/sdcard-layout-mender.in ${S}/sdcard-layout.in
+}

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -1,19 +1,29 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 
 MENDER_UBOOT_AUTO_CONFIGURE = "0"
-# Use the mmcblk0boot1 partition for uboot environment (partition 2 in uboot)
-MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART = "2"
+# On tegra devices with a real emmc, Use the mmcblk0boot1 partition for uboot environment (partition 2 in uboot)
+MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART_tegra186 = "2"
+# On jetson-nano without a real emmc and sd-card instead (no emmc boot partition), use the user area for uboot environment
+MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART_tegra210 = "0"
 
-# Calculate this offset by adding up the offsets of each partition preceeding the uboot_env partition in sdmmc_boot and aligning to the next
+# For devices with real emmc, calculate this offset by adding up the offsets of each partition preceeding the uboot_env partition in sdmmc_boot and aligning to the next
 # 4096 byte boundary, then subtracting 4 MiB (4194304) since the sdmmc_boot represents the combined boot0 and boot1 partitions
 # Please note the suggestions in the nvidia thread at https://devtalk.nvidia.com/default/topic/1063652/jetson-tx2/mmcblk0boot1-usage-at-address-4177408-and-u-boot-parameter-storage-space-availability/
 # regarding suggestions about locating this environment area in mmcblk0boot1 at 0x3BB000 (3911680)
-MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "3911680"
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_tegra186 = "3911680"
+
+# For devices with sd-card, u-boot env is in the ENV partition (see sdcard-layout-mender.in, but keep in mind all partitions 'start block' must be a multiple of
+# 2048 (one block is 512 bytes), thus the easiest way to find out the offset of the ENV partition is to use gptdisk.
+MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_tegra210 = "0xC00000"
+
+# Use the sd-card (mmc device 1 from u-boot numbering scheme's point of view) to store u-boot environment
+MENDER_UBOOT_STORAGE_DEVICE_tegra210 = "1"
 
 SRC_URI += " file://0001-env-tool-add-command-line-option-to-input-lockfile-p.patch"
 SRC_URI += " file://0003-tegra-Integration-of-Mender-boot-code-into-U-Boot.patch"
 SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
 SRC_URI_append_mender-uboot = " file://0012-Update-environment-defaults-for-tegra.patch"
+SRC_URI_append_mender-uboot = " file://0013-Jetson-Nano-mender-environment-in-mmc.patch"
 SRC_URI_remove = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
 SRC_URI_remove = " file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch"

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -1,4 +1,4 @@
 require recipes-bsp/u-boot/u-boot-mender.inc
 require recipes-bsp/u-boot/u-boot-mender-tegra.inc
 
-RDEPENDS_${PN} += "mender-tegra-bup-payload-install"
+RDEPENDS_${PN}_tegra186 += "mender-tegra-bup-payload-install"


### PR DESCRIPTION
Jetson-nano development kit has a SD-card slot and no emmc. It does not support
nvidia redundant boot feature and therefore there is no dependency to the BUP Payload which
is used on jetson-tx2. Nvidia released a production module of the jetson-nano with 16GB emmc,
but this is not supported by this branch.

Even though there is no emmc, the sd-card is referenced as mmc device in u-boot, which is
why we use ENVIRONMENT_IS_IN_MMC.

Changelog: Title

Signed-off-by: Moritz Marquardt <moritz.marquardt@zeiss.com>
Signed-off-by: Etienne Cordonnier <etienne.cordonnier@taurob.com>