### PR TITLE
imx8mmevk/imx8mqevk: Fix boot from eMMC

### DIFF
--- a/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0003-Allow-Mender-to-live-in-eMMC.patch
+++ b/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx/imx8mmevk/0003-Allow-Mender-to-live-in-eMMC.patch
@@ -1,0 +1,25 @@
+From 177be3cde2725cf67e064734f3a8fc224742fe6a Mon Sep 17 00:00:00 2001
+From: Tom Kuparowitz <tomas.kuparowitz@invasys.com>
+Date: Fri, 24 Jan 2020 12:53:33 +0100
+Subject: [PATCH] Allow Mender to live in eMMC
+
+Remove option binding Mender exclusively to SD Card on imx8mm_evk.
+---
+ include/configs/imx8mm_evk.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/configs/imx8mm_evk.h b/include/configs/imx8mm_evk.h
+index 68d0643..c053ed3 100644
+--- a/include/configs/imx8mm_evk.h
++++ b/include/configs/imx8mm_evk.h
+@@ -249,7 +249,6 @@
+ #define CONFIG_ENV_OFFSET       (60 << 20)
+ #endif
+ #define CONFIG_ENV_SIZE			0x1000
+-#define CONFIG_SYS_MMC_ENV_DEV		0   /* USDHC2 */
+ #define CONFIG_MMCROOT			"/dev/mmcblk1p2"  /* USDHC2 */
+ 
+ /* Size of malloc() pool */
+-- 
+2.7.4
+

--- a/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx/imx8mqevk/0003-Allow-Mender-to-live-in-eMMC.patch
+++ b/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx/imx8mqevk/0003-Allow-Mender-to-live-in-eMMC.patch
@@ -1,0 +1,27 @@
+From 2de93c238e8125b3c65c4e909663b352321bab3e Mon Sep 17 00:00:00 2001
+From: Mirza Krak <mirza.krak@northern.tech>
+Date: Fri, 24 Jan 2020 16:28:28 +0100
+Subject: [PATCH 3/3] Allow Mender to live in eMMC
+
+Remove option binding Mender exclusively to SD Card on imx8mm_evk.
+
+Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
+---
+ include/configs/imx8mq_evk.h | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/include/configs/imx8mq_evk.h b/include/configs/imx8mq_evk.h
+index dc5da3bfc0..9758527680 100644
+--- a/include/configs/imx8mq_evk.h
++++ b/include/configs/imx8mq_evk.h
+@@ -207,7 +207,6 @@
+ #define CONFIG_ENV_OVERWRITE
+ #define CONFIG_ENV_OFFSET               (64 * SZ_64K)
+ #define CONFIG_ENV_SIZE			0x1000
+-#define CONFIG_SYS_MMC_ENV_DEV		1   /* USDHC2 */
+ #define CONFIG_MMCROOT			"/dev/mmcblk1p2"  /* USDHC2 */
+ 
+ /* Size of malloc() pool */
+-- 
+2.24.1
+

--- a/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-mender-imx/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -5,6 +5,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += "file://0001-Add-Mender-support.patch"
 SRC_URI += "file://0002-Improve-boot-startup-time.patch"
+SRC_URI += "file://0003-Allow-Mender-to-live-in-eMMC.patch"
 
 # Set machine-specific variables per the definitions found in include/configs/MACHINE.h
 # | VARIABLE                                 | DEFINITION             |
@@ -13,7 +14,7 @@ SRC_URI += "file://0002-Improve-boot-startup-time.patch"
 # | MENDER_UBOOT_STORAGE_DEVICE              | CONFIG_SYS_MMC_ENV_DEV |
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1_imx8mmevk = "0x400000"
 BOOTENV_SIZE_imx8mmevk                             = "0x1000"
-MENDER_UBOOT_STORAGE_DEVICE_imx8mmevk              = "0"
+MENDER_UBOOT_STORAGE_DEVICE_imx8mmevk             ?= "0"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1_imx8mqevk = "0x400000"
 BOOTENV_SIZE_imx8mqevk                             = "0x1000"
-MENDER_UBOOT_STORAGE_DEVICE_imx8mqevk              = "1"
+MENDER_UBOOT_STORAGE_DEVICE_imx8mqevk              ?= "1"

--- a/meta-mender-imx/templates/local.conf.append
+++ b/meta-mender-imx/templates/local.conf.append
@@ -4,5 +4,14 @@ MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 PREFERRED_PROVIDER_u-boot = "u-boot-imx"
 IMAGE_CLASSES += "mender-setup-imx"
 
+# Boot from SD
 MENDER_STORAGE_DEVICE_imx8mmevk = "/dev/mmcblk1"
 MENDER_STORAGE_DEVICE_imx8mqevk = "/dev/mmcblk1"
+
+# Boot from eMMC on imx8mmevk
+# MENDER_STORAGE_DEVICE_imx8mmevk = "/dev/mmcblk2"
+# MENDER_UBOOT_STORAGE_DEVICE_imx8mmevk = "1"
+
+# Boot from eMMC on imx8mqevk
+# MENDER_STORAGE_DEVICE_imx8mqevk = "/dev/mmcblk0"
+# MENDER_UBOOT_STORAGE_DEVICE_imx8mqevk = "0"


### PR DESCRIPTION
Allow imx8mmevk/imx8mqevk to boot from eMMC through MENDER_UBOOT_STORAGE_DEVICE
variable. The default remains SD card for backward compatibility.

Signed-off-by: Tom Kuparowitz <tomas.kuparowitz@invasys.com>
Signed-off-by: Mirza Krak <mirza.krak@northern.tech>