### PR TITLE
tegra zeus-test patches

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -43,7 +43,7 @@ that have Mender integrated.
 mkdir mender-tegra && cd mender-tegra
 repo init -u https://github.com/mendersoftware/meta-mender-community \
            -m meta-mender-tegra/scripts/manifest-tegra.xml \
-           -b zeus
+           -b zeus-test
 repo sync
 source setup-environment tegra
 ```

--- a/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
+++ b/meta-mender-tegra/classes/image_types_mender_tegra.bbclass
@@ -7,10 +7,10 @@ tegraflash_custom_pre() {
     ln -s ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.dataimg ./${DATAFILE}
 }
 
-tegraflash_create_flash_config_append() {
-    if [ -n "$bupgen" ]; then
-        sed -i -e'/DATAFILE/d' $destdir/flash.xml.in
-    else
-        sed -i -e"s,DATAFILE,${DATAFILE}," $destdir/flash.xml.in
-    fi
+tegraflash_generate_bupgen_script_append() {
+    sed -i -e"1a sed -i -e'/DATAFILE/d' ./flash.xml.in" $outfile
+}
+
+tegraflash_custom_post_append() {
+    sed -i -e"s,DATAFILE,${DATAFILE}," ${WORKDIR}/tegraflash/flash.xml.in
 }

--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -66,8 +66,8 @@ ROOTFSPART_SIZE = "${@tegra_mender_set_rootfs_partsize(${MENDER_CALC_ROOTFS_SIZE
 # Default for thud and later is grub integration but we need to use u-boot integration already included.
 # Leave out sdimg since we don't use this with tegra (instead use
 # tegraflash)
-MENDER_FEATURES_ENABLE_append = "${@tegra_mender_uboot_feature(d)}"
-MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
+MENDER_FEATURES_ENABLE_append_tegra = "${@tegra_mender_uboot_feature(d)}"
+MENDER_FEATURES_DISABLE_append_tegra = " mender-grub mender-image-uefi"
 
 # Use these variables to adjust your total rootfs size across both
 # images. Rootfs size will be approximately 1/2 of
@@ -100,10 +100,12 @@ def tegra_mender_calc_total_size(d):
 
 MENDER_IMAGE_ROOTFS_SIZE_DEFAULT = "${@tegra_mender_image_rootfs_size(d)}"
 TEGRA_MENDER_RESERVED_SPACE_MB ?= "1024"
-MENDER_STORAGE_TOTAL_SIZE_MB ??= "${@tegra_mender_calc_total_size(d)}"
+TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB = "${MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT}"
+TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB_tegra = "${@tegra_mender_calc_total_size(d)}"
+MENDER_STORAGE_TOTAL_SIZE_MB ??= "${TEGRA_MENDER_STORAGE_TOTAL_SIZE_MB}"
 
 def tegra_mender_uboot_feature(d):
-    if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot'):
+    if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot'):
         return " mender-persist-systemd-machine-id"
     return " mender-uboot mender-persist-systemd-machine-id"
 

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-bootfiles_%.bbappend
@@ -1,7 +1,5 @@
 MENDER_DEP = "mender-custom-flash-layout"
-MENDER_DEP_jetson-nano = ""
 MENDER_PARTITION_FILE = "${STAGING_DATADIR}/mender-flash-layout/flash_mender.xml"
-MENDER_PARTITION_FILE_jetson-nano = ""
 DEPENDS += "${MENDER_DEP}"
 
 python() {

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0001-Move-jetson-nano-env-to-SDcard.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0001-Move-jetson-nano-env-to-SDcard.patch
@@ -1,17 +1,17 @@
-From 3c56a8582e9c4a268c932f8c42a62ae43bf11aba Mon Sep 17 00:00:00 2001
+From 0ca8cf728807766f9bc36fe8551b96f3295273b5 Mon Sep 17 00:00:00 2001
 From: Matt Madison <matt@madison.systems>
 Date: Fri, 10 Jan 2020 12:19:14 -0800
-Subject: [PATCH 1/1] Move jetson-nano env to SDcard
+Subject: [PATCH] Move jetson-nano env to SDcard
 
 ---
- include/configs/p3450-porg.h | 14 ++++----------
- 1 file changed, 4 insertions(+), 10 deletions(-)
+ include/configs/p3450-porg.h | 16 ++++++----------
+ 1 file changed, 6 insertions(+), 10 deletions(-)
 
-Index: git/include/configs/p3450-porg.h
-===================================================================
---- git.orig/include/configs/p3450-porg.h
-+++ git/include/configs/p3450-porg.h
-@@ -45,18 +45,12 @@
+diff --git a/include/configs/p3450-porg.h b/include/configs/p3450-porg.h
+index c3e709d44d..89ce624a8c 100644
+--- a/include/configs/p3450-porg.h
++++ b/include/configs/p3450-porg.h
+@@ -47,18 +47,14 @@
  	func(PXE, pxe, na) \
  	func(DHCP, dhcp, na)
  
@@ -31,6 +31,11 @@ Index: git/include/configs/p3450-porg.h
 +#define CONFIG_ENV_IS_IN_MMC		1
 +#define CONFIG_SYS_MMC_ENV_DEV		1
 +#define CONFIG_SYS_MMC_ENV_PART		0
++#define CONFIG_ENV_OFFSET (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1)
++#define CONFIG_ENV_OFFSET_REDUND (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2)
  
  /* SPI */
  #define CONFIG_SF_DEFAULT_MODE		SPI_MODE_0
+-- 
+2.25.1
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0014-Handle-pre-v2020-u-boot-env-redundancy-for-tegra-pla.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0014-Handle-pre-v2020-u-boot-env-redundancy-for-tegra-pla.patch
@@ -1,0 +1,64 @@
+From 6fe0f7406b526153df63c4ba89dc1655d5763a70 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Sun, 24 May 2020 05:23:01 -0700
+Subject: [PATCH] Handle pre-v2020 u-boot env redundancy for tegra platforms
+
+---
+ include/config_mender.h      | 2 +-
+ include/configs/p2371-2180.h | 2 ++
+ include/configs/p2771-0000.h | 2 ++
+ include/configs/p3450-porg.h | 2 ++
+ 4 files changed, 7 insertions(+), 1 deletion(-)
+
+diff --git a/include/config_mender.h b/include/config_mender.h
+index c6a0eb2c23..68bf420cfa 100644
+--- a/include/config_mender.h
++++ b/include/config_mender.h
+@@ -37,7 +37,7 @@
+ # error CONFIG_BOOTCOUNT_ENV is required for Mender to work. Make sure that: 1) All the instructions at docs.mender.io/devices/integrating-with-u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>
+ #endif
+ 
+-#ifndef CONFIG_SYS_REDUNDAND_ENVIRONMENT
++#if (defined(CONFIG_ENV_IS_IN_MMC) && !defined(CONFIG_ENV_OFFSET_REDUND)) || (defined(CONFIG_ENV_IS_IN_SPI_FLASH) && !defined(CONFIG_SYS_REDUNDAND_ENVIRONMENT))
+ # error CONFIG_SYS_REDUNDAND_ENVIRONMENT is required for Mender to work. Make sure that: 1) All the instructions at docs.mender.io/devices/integrating-with-u-boot have been followed. 2) All required layers are included in bblayers.conf, including any board specific layers such as meta-mender-<board>. Check also https://docs.mender.io/troubleshooting/yocto-project-build for Known Issues when upgrading.
+ #endif
+ 
+diff --git a/include/configs/p2371-2180.h b/include/configs/p2371-2180.h
+index 069aae225c..f06d130dff 100644
+--- a/include/configs/p2371-2180.h
++++ b/include/configs/p2371-2180.h
+@@ -31,6 +31,8 @@
+ #define CONFIG_ENV_IS_IN_MMC
+ #define CONFIG_SYS_MMC_ENV_DEV		0
+ #define CONFIG_SYS_MMC_ENV_PART		2
++#define CONFIG_ENV_OFFSET (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1)
++#define CONFIG_ENV_OFFSET_REDUND (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2)
+ 
+ /* SPI */
+ #define CONFIG_SF_DEFAULT_MODE		SPI_MODE_0
+diff --git a/include/configs/p2771-0000.h b/include/configs/p2771-0000.h
+index 3010e2f5d4..59da53ce13 100644
+--- a/include/configs/p2771-0000.h
++++ b/include/configs/p2771-0000.h
+@@ -26,6 +26,8 @@
+ #define CONFIG_ENV_IS_IN_MMC
+ #define CONFIG_SYS_MMC_ENV_DEV		0
+ #define CONFIG_SYS_MMC_ENV_PART		2
++#define CONFIG_ENV_OFFSET (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1)
++#define CONFIG_ENV_OFFSET_REDUND (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2)
+ 
+ /* PCI host support */
+ #define CONFIG_PCI
+diff --git a/include/configs/p3450-porg.h b/include/configs/p3450-porg.h
+index 8ea416128d..c3e709d44d 100644
+--- a/include/configs/p3450-porg.h
++++ b/include/configs/p3450-porg.h
+@@ -36,6 +36,8 @@
+ #define CONFIG_ENV_IS_IN_MMC
+ #define CONFIG_SYS_MMC_ENV_DEV		0
+ #define CONFIG_SYS_MMC_ENV_PART		2
++#define CONFIG_ENV_OFFSET (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1)
++#define CONFIG_ENV_OFFSET_REDUND (MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2)
+ 
+ #define DEFAULT_MMC_DEV "0"
+ #else

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -38,6 +38,7 @@ SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modifie
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
 SRC_URI_append_mender-uboot = " file://0012-Update-environment-defaults-for-tegra.patch"
 SRC_URI_append_mender-uboot = " file://0013-Move-env-offset-for-tegra210-platforms.patch"
+SRC_URI_append_mender-uboot = " file://0014-Handle-pre-v2020-u-boot-env-redundancy-for-tegra-pla.patch"
 SRC_URI_append_mender-uboot_tegra210 = " ${@' file://0001-Move-jetson-nano-env-to-SDcard.patch' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' and (d.getVar('TEGRA_MENDER_UBOOT_ENV_IN_SPIFLASH') or '') != '1' else ''}"
 SRC_URI_remove = " file://0003-Integration-of-Mender-boot-code-into-U-Boot.patch"
 SRC_URI_remove = " file://0006-env-Kconfig-Add-descriptions-so-environment-options-.patch"
@@ -46,4 +47,11 @@ do_provide_mender_defines_append_tegra210() {
     if [ "${TEGRA_MENDER_UBOOT_ENV_IN_SPIFLASH}" = "1" ]; then
         sed -i -e'/^CONFIG_SYS_MMC_ENV/d' ${S}/mender_Kconfig_fragment
     fi
+}
+
+mender_get_clean_kernel_devicetree_tegra() {
+    # Singleton device tree is not required on all platforms,
+    # and the value is not used on tegra platforms, so just provide a
+    # dummy value.
+    echo "dummy"
 }

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-tegra_%.bbappend
@@ -5,3 +5,4 @@ BUPDEP = ""
 BUPDEP_tegra186 = "mender-tegra-bup-payload-install"
 BUPDEP_tegra194 = "mender-tegra-bup-payload-install"
 RDEPENDS_${PN} += "${BUPDEP}"
+

--- a/meta-mender-tegra/scripts/manifest-tegra.xml
+++ b/meta-mender-tegra/scripts/manifest-tegra.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
   <manifest>
-  <default sync-j="4" revision="warrior"/>
 
   <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
   <remote fetch="https://github.com/madisongh"        name="madisongh"/>


### PR DESCRIPTION
These patches didn't make it into the original PR at https://github.com/mendersoftware/meta-mender-community/pull/147/commits.

Resolves errors with latest meta-tegra zeus branch and `signing images failed` errors from tegraparser.

See discussion in [this comment](https://hub.mender.io/t/jetson-tx2-updating-device-tree/2124/18) on mender hub.
