### PR TITLE
raspberrypi: remove custom partition alignment

### DIFF
--- a/meta-mender-raspberrypi/templates/local.conf.append
+++ b/meta-mender-raspberrypi/templates/local.conf.append
@@ -4,7 +4,6 @@
 MACHINE ?= "raspberrypi3"
 
 RPI_USE_U_BOOT = "1"
-MENDER_PARTITION_ALIGNMENT = "4194304"
 MENDER_BOOT_PART_SIZE_MB = "40"
 IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
 IMAGE_FSTYPES_remove += " rpi-sdimg"


### PR DESCRIPTION
Raspberry Pi devices should use the default (8MB).

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>