### PR TITLE
Update documentation and scripts for dunfell

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -6,8 +6,8 @@ The supported and tested boards are:
 
 - [Jetson TX2](https://hub.mender.io/t/nvidia-tegra-jetson-tx2/123)
 - [Jetson Nano](https://hub.mender.io/t/nvidia-tegra-jetson-nano/1360)
-- Jetson Xavier - No mender hub page for this yet, but known working as of the Zeus branch.  If anyone would
-like to volunteer to maintain this hardware platform please [contact me](https://github.com/dwalkes)
+- [Jetson Xavier NX](https://hub.mender.io/t/nvidia-tegra-jetson-xavier-nx/2615)
+- [Jetson AGX Xavier](https://hub.mender.io/t/nvidia-tegra-agx-xavier/2616)
 
 Visit the individual board links above for more information on status of the
 integration and more detailed instructions on how to build and use images
@@ -21,44 +21,23 @@ This layer depends on:
 ```
 URI: https://github.com/madisongh/meta-tegra.git
 layers: meta-tegra
-branch: zeus-l4t-r32.3.1
+branch: dunfell-l4t-r32.4.3
 revision: HEAD
 ```
 
 ```
 URI: https://github.com/mendersoftware/meta-mender.git
 layers: meta-mender-core
-branch: zeus
+branch: dunfell
 revision: HEAD
 ```
 
 
 ## Quick start
 
-The following commands will setup the environment and allow you to build images
-that have Mender integrated.
-
-
-```
-mkdir mender-tegra && cd mender-tegra
-repo init -u https://github.com/mendersoftware/meta-mender-community \
-           -m meta-mender-tegra/scripts/manifest-tegra.xml \
-           -b zeus
-repo sync
-source setup-environment tegra
-```
-
-Finally, run the build with a command like:
-
-```
-MACHINE=jetson-tx2 bitbake core-image-base
-or:
-MACHINE=jetson-nano bitbake core-image-base
-or
-MACHINE=jetson-nano-qspi-sd bitbake core-image-base
-```
-
-depending on the hardware platform in use.  See [meta-tegra release notes](https://github.com/madisongh/meta-tegra/wiki/L4T-R32.3.1-Notes) for details.
+See the mender hub pages and the documentation for the `tegrademo-mender`
+distro on the [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) repository
+for the most up to date instructions on starting out with mender and tegra.
 
 ## Maintainer
 
@@ -70,5 +49,9 @@ Always include the maintainers when suggesting code changes to this layer.
 
 ## Acknowlegements
 
-Special thanks to [Matt Madison](https://github.com/madisongh) for his contributions to support zeus and later branches,
-and his work on meta-tegra which makes this mender integration possible.
+Special thanks to [Matt Madison](https://github.com/madisongh) for his contributions to
+support zeus and later branches and his work on meta-tegra which makes this mender
+integration possible.
+
+Thanks also to [Kurt Keifer](https://github.com/kekiefer/) for his contributions and
+cleanup to support additional platforms and the tegra-demo-distro on the dunfell release.

--- a/meta-mender-tegra/scripts/deploy.sh
+++ b/meta-mender-tegra/scripts/deploy.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
+# Set your machine type here
 machine=jetson-tx2
+# Set your image type here
+image=demo-image-base
+echo "Using machine ${machine} image ${image}"
+deployfile=${image}-${machine}.tegraflash.tar.gz
 scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
-deployfile=core-image-base-${machine}.tegraflash.zip
 tmpdir=`mktemp`
 rm -rf $tmpdir
 mkdir -p $tmpdir
 echo "Using temp directory $tmpdir"
 pushd $tmpdir
-cp $scriptdir/build/tmp/deploy/images/${machine}/$deployfile .
-unzip $deployfile
+cp $scriptdir/../../../../build/tmp/deploy/images/${machine}/$deployfile .
+tar -xvf $deployfile
 set -e
 sudo ./doflash.sh
 popd


### PR DESCRIPTION
Reference tegra-demo-distro deployment scheme for dunfell and
later builds.

Update deploy.sh to default to tegra-demo-distro deployment and
use tar.gz file.