### PR TITLE
Allow equal sign as key value separation

### DIFF
--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0002-env-tool-fix-missing-equals.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0002-env-tool-fix-missing-equals.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/env/fw_env.c b/tools/env/fw_env.c
+index 6b71acb28fe1c47451e84e80ef31bb5fd7867436..0e3e34321f6467b9889295aaf9b46b3bee158e57 100644
+--- a/tools/env/fw_env.c
++++ b/tools/env/fw_env.c
+@@ -357,7 +357,7 @@ static int get_config (char *);
+ static char *skip_chars(char *s)
+ {
+ 	for (; *s != '\0'; s++) {
+-		if (isblank(*s))
++		if (isblank(*s) || *s == '=')
+ 			return s;
+ 	}
+ 	return NULL;

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -21,6 +21,7 @@ MENDER_UBOOT_STORAGE_DEVICE_tegra210 = "1"
 
 SRC_URI += " file://0001-env-tool-add-command-line-option-to-input-lockfile-p.patch"
 SRC_URI += " file://0003-tegra-Integration-of-Mender-boot-code-into-U-Boot.patch"
+SRC_URI_append_mender-uboot = " file://0002-env-tool-fix-missing-equals.patch"
 SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
 SRC_URI_append_mender-uboot = " file://0012-Update-environment-defaults-for-tegra.patch"


### PR DESCRIPTION
Maybe I am missing something obvious here, but after pulling the latest commits on the warrior
branches I got a warning that u-boot was missing a patch.
I didn't see the warning and continued deploying the latest Mender artifact on two (luckily)
in-house devices for test. This bricked them. By applying this patch everything worked.
Branches and commits used to get the warning:
meta-tegra, warrior-l4t-32.2: c1cbc55
meta-mender, warrior: 36d0201
meta-openembedded, warrior: a24acf9
meta-mender-community, warrior: 8c8f5bc
poky, warrior: c8c383d

Message displayed without the patch applied:
WARNING: u-boot-tegra-2016.07+gitAUTOINC+8e576d3000-r0 do_provide_mender_defines:
Detected missing fix for '=' sign in fw_setenv script files. You may need to include
this patch from the U-Boot project:
https://gitlab.denx.de/u-boot/u-boot/-/commit/cd655514aa044c77fe3b895a51677ba47b26ba89

Signed-off-by: Arnstein Kleven <arnsteinkleven@gmail.com>