### PR TITLE
Update Jetson Nano Mender environment in MMC patch

### DIFF
--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Jetson-Nano-mender-environment-in-mmc.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Jetson-Nano-mender-environment-in-mmc.patch
@@ -1,24 +1,13 @@
-From 0972c8b7ecc95ac27ef69bd4441154f422413bfd Mon Sep 17 00:00:00 2001
-From: Moritz Marquardt <moritz.marquardt@zeiss.com>
-Date: Thu, 5 Dec 2019 14:26:57 +0000
-Subject: [PATCH] Configure u-boot env. in sd-card for jetson-nano
-
----
- include/configs/p3450-porg.h | 4 ++--
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
 diff --git a/include/configs/p3450-porg.h b/include/configs/p3450-porg.h
-index e8a7ead5bb..b818aae159 100644
+index 7be05f3dae..2e97052610 100644
 --- a/include/configs/p3450-porg.h
 +++ b/include/configs/p3450-porg.h
-@@ -34,8 +34,8 @@
- 	func(PXE, pxe, na) \
+@@ -35,7 +35,7 @@
  	func(DHCP, dhcp, na)
  
--/* Environment s/b at end of SPI, fix it later */
--#define CONFIG_ENV_IS_NOWHERE
-+/* Env is located in a partition of the sd-card (mmc device in u-boot) */
+ /* Environment s/b at end of SPI, fix it later */
+-#define CONFIG_ENV_IS_IN_SPI_FLASH
 +#define CONFIG_ENV_IS_IN_MMC
- 
- /* SPI */
- #define CONFIG_SF_DEFAULT_MODE		SPI_MODE_0
+ /* 64KB at end of SPI flash is used, so position at 128K from end
+    in the padding area */
+ #define CONFIG_ENV_OFFSET		(CONFIG_SPI_FLASH_SIZE-131072)


### PR DESCRIPTION
OE4T/meta-tegra#437 updated SRCREV for meta-tegra-uboot, and after that this patch didn't apply.
This one should work.
DISCLAIMER: I do not have a Nano to test this on.
Also, with OE4T/meta-tegra#438 we might see
a similar problem on the zeus-l4t-r32.3.1 branch. I am unfortunately not able to test this.

Signed-off-by: Arnstein Kleven <arnsteinkleven@gmail.com>