### PR TITLE
u-boot-variscite: Remove unneeded configurations.

### DIFF
--- a/meta-mender-variscite/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/meta-mender-variscite/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -1,7 +1,5 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-require recipes-bsp/u-boot/u-boot-mender.inc
-
 SRC_URI_append_imx6ul-var-dart = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
 SRC_URI_append_imx8mm-var-dart = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
 SRC_URI_append_imx8mm-var-dart = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.getVar('VARISCITE_UBOOT_ENV_IN_EMMC', True) == '1' else ''}"
@@ -10,8 +8,6 @@ SRC_URI_append_imx8mn-var-som = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.
 
 PROVIDES += "u-boot"
 RPROVIDES_${PN} += "u-boot"
-
-DEPENDS_append = " bc-native "
 
 make_u_boot_spl_image() {
     install -m 644 ${B}/${config}/${SPL_BINARY} ${DEPLOYDIR}/u-boot-spl-${PV}-${PR}.img

--- a/meta-mender-variscite/templates/local.conf.append
+++ b/meta-mender-variscite/templates/local.conf.append
@@ -32,3 +32,7 @@ MENDER_FEATURES_DISABLE_append = " mender-image-uefi "
 
 # Make sure we don't include u-boot-fw-utils; we are using grub-mender-grubenv instead
 MACHINE_EXTRA_RDEPENDS_remove = "u-boot-fw-utils"
+
+# Do not use the bbappend provided by meta-imx. It does not not use
+# the right ${B} and ${S} settings and causes build failures with Mender
+BBMASK += "meta-imx/meta-bsp/recipes-bsp/u-boot/u-boot-tools_%.bbappend"


### PR DESCRIPTION
Since we use UEFI/GRUB integration on the Zeus branch, we don't need
u-boot-mender.inc.

Changelog: None
Signed-off-by: Drew Moseley <drew.moseley@northern.tech>