### PR TITLE
imx: fix missing "do_mender_tar_src" task

### DIFF
--- a/meta-mender-imx/recipes-bsp/u-boot-imx/u-boot-imx_%.bbappend
+++ b/meta-mender-imx/recipes-bsp/u-boot-imx/u-boot-imx_%.bbappend
@@ -1,6 +1,10 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
+include ${@mender_feature_is_enabled("mender-uboot","u-boot-mender.inc","",d)}
+
 RPROVIDES_${PN}_mender-grub += "u-boot"
 RPROVIDES_${PN}_mender-uboot += "u-boot"
 
 SRC_URI_append_imx8mnevk = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
+
+MENDER_UBOOT_AUTO_CONFIGURE = "0"


### PR DESCRIPTION
Hi @drewmoseley ,

I'm really new on Mender architecture.

I tried to add a new board using meta-mender-imx layer for testing and I got this the following error:
"do_mender_tar_src" is missing.

it looks like the u-boot-imx_% is missing u-boot-mender.inc

Could you review it, thanks for your help :)