### PR TITLE
meta-mender-tegra: dunfell nano development board partition layout fixes

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-nano-qspi-sd/flash_mender.xml
@@ -48,21 +48,22 @@
               binary. </description>
         </partition>
 
-        <!-- This is padding to ensure VER is at the end of flash -->
-        <partition name="PAD" id="6" type="data">
+        <partition name="UBENV" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 3342336 </size>
+	    <start_location> 0x3B0000 </start_location>
+            <size> 131072 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <allocation_attribute> 8 </allocation_attribute>
             <percent_reserved> 0 </percent_reserved>
-            <description> Empty padding. </description>
+            <description> U-Boot environment area  </description>
         </partition>
 
-        <partition name="VER_b" id="7" type="data">
+        <partition name="VER_b" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 65536 </size>
+	    <start_location> 0x3E0000 </start_location>
+            <size> 32768 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>
@@ -72,10 +73,11 @@
               information. </description>
         </partition>
 
-        <partition name="VER" id="8" type="data">
+        <partition name="VER" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
-            <size> 65536 </size>
+	    <start_location> 0x3F0000 </start_location>
+            <size> 32768 </size>
             <file_system_attribute> 0 </file_system_attribute>
             <partition_attribute> 0 </partition_attribute>
             <allocation_attribute> 8 </allocation_attribute>

--- a/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch
+++ b/meta-mender-tegra/recipes-bsp/u-boot/patches/0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch
@@ -1,0 +1,29 @@
+From 00d2500c1a78e3b49d70256e5cbea6aedb3ebe83 Mon Sep 17 00:00:00 2001
+From: Matt Madison <matt@madison.systems>
+Date: Mon, 2 Nov 2020 08:24:14 -0800
+Subject: [PATCH] Reduce env size on p3450-0000 to 64KiB
+
+Signed-off-by: Matt Madison <matt@madison.systems>
+---
+ configs/p3450-0000_defconfig | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/configs/p3450-0000_defconfig b/configs/p3450-0000_defconfig
+index c3200216b9..c6dfbc79d8 100644
+--- a/configs/p3450-0000_defconfig
++++ b/configs/p3450-0000_defconfig
+@@ -58,9 +58,9 @@ CONFIG_ENV_SECT_SIZE=0x1000
+ CONFIG_BOOTP_PREFER_SERVERIP=y
+ CONFIG_POSITION_INDEPENDENT=y
+ CONFIG_DISABLE_SDMMC1_EARLY=y
+-CONFIG_ENV_SIZE=0x20000
++CONFIG_ENV_SIZE=0x10000
+ CONFIG_ENV_OFFSET=0x3b0000
+-CONFIG_ENV_OFFSET_REDUND=0x3d0000
++CONFIG_ENV_OFFSET_REDUND=0x3c0000
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ # CONFIG_ENV_IS_NOWHERE is not set
+ # CONFIG_ENV_IS_IN_EEPROM is not set
+-- 
+2.25.1
+

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra-vars.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra-vars.inc
@@ -1,6 +1,10 @@
 MENDER_UBOOT_AUTO_CONFIGURE = "0"
 MENDER_UBOOT_CONFIG_SYS_MMC_ENV_PART = "2"
 
+TEGRA_MENDER_BOOTENV_SIZE_DEFAULT = "0x20000"
+TEGRA_MENDER_BOOTENV_SIZE_DEFAULT_tegra210 = "${@'0x10000' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '0x20000'}"
+BOOTENV_SIZE ?= "${TEGRA_MENDER_BOOTENV_SIZE_DEFAULT}"
+
 # Calculate this offset by adding up the offsets of each partition preceeding the uboot_env partition in sdmmc_boot and aligning to the next
 # 4096 byte boundary, then subtracting 4 MiB (4194304) since the sdmmc_boot represents the combined boot0 and boot1 partitions
 # Please note the suggestions in the nvidia thread at https://devtalk.nvidia.com/default/topic/1063652/jetson-tx2/mmcblk0boot1-usage-at-address-4177408-and-u-boot-parameter-storage-space-availability/

--- a/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
+++ b/meta-mender-tegra/recipes-bsp/u-boot/u-boot-mender-tegra.inc
@@ -2,6 +2,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/patches:"
 
 SRC_URI_append_mender-uboot = " file://0010-tegra-mender-auto-configured-modified.patch"
 SRC_URI_append_mender-uboot = " file://0011-Jetson-TX2-mender-boot-commands.patch"
+SRC_URI_append_mender-uboot = " file://0013-Reduce-env-size-on-p3450-0000-to-64KiB.patch"
 
 do_provide_mender_defines_append_tegra210() {
     if [ "${TEGRA_SPIFLASH_BOOT}" = "1" ]; then


### PR DESCRIPTION
Per discussion at https://github.com/OE4T/meta-mender-community/pull/5

As of r32.3.1 (or possibly earlier) NVIDIA has defined a UBENV partition at offset 0x3D8000 for `jetson-nano-qspi-sd` partition layout, which is the layout used for the Nano development board with SD card.  Previously this area was defined as a `PAD` partition and we had stored our uboot environment in that location.  However, we'd also accidentally overflowed into the `VER_b` location with our definition of uboot storage environment from 0x3B0000 to 0x3F0000.  This might be a problem if/when we add support for [Nano redundant boot](https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%20Linux%20Driver%20Package%20Development%20Guide/bootloader_update_nano_tx1.html) for bootloader components.

The area defined by NVIDIA for `UBENV` is too small to store dual redundant copies of mender variables, so we need to stretch our area back into what was known as the `PAD` partition on previous releases and the unused space between `NXC_R` and `VER_b` partitions.

After some discussion in the previously mentioned thread, we've settled on keeping the `UBENV` starting at `0x3B0000` and reducing the size to 131072 bytes instead of 262144 of so we could continue to make the first uboot environment boundary at the same start location and complete both copies of uboot environment before the `VER_b` sector starts.  This means the u-boot environment for existing sdcard based Nano builds on the dunfell branch will move on the next tegraflash or `dosdcard.sh`  based update.  In the cvase of a `dosdcard.sh` based update the existing SPI flash u-boot environment will be invalid and replaced with defaults.

This alignment will be shared with the Jetson Nano 2GB hardware which will be brought in during gatesgarth/L4T+next (unless someone volunteers to add and backport it sooner in https://github.com/OE4T/meta-mender-community/issues/4) and the patches here were rebased from those in the above linked PR.

I've started a sheet at [this link](https://docs.google.com/spreadsheets/d/14zVltS2LTwCNywoje6_8wzFzHQ3sYVhY6C7T0DkOnx0/edit?usp=sharing) which I plan to try to update with each new release and platform to make sure we don't miss these layout changes going forward with new L4T releases.

I've completed the uboot integration tests at [this link](https://github.com/OE4T/tegra-demo-distro/wiki/Mender-Integration-Tests) for `jetson-nano-qspi-sd` with these changes.