### PR TITLE
imx: Fix include path to u-boot-mender.inc

### DIFF
--- a/meta-mender-imx/recipes-bsp/u-boot-imx/u-boot-imx_%.bbappend
+++ b/meta-mender-imx/recipes-bsp/u-boot-imx/u-boot-imx_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-include ${@mender_feature_is_enabled("mender-uboot","u-boot-mender.inc","",d)}
+include ${@mender_feature_is_enabled("mender-uboot","recipes-bsp/u-boot/u-boot-mender.inc","",d)}
 
 RPROVIDES_${PN}_mender-grub += "u-boot"
 RPROVIDES_${PN}_mender-uboot += "u-boot"


### PR DESCRIPTION
When switching to mender_feature_is_enabled function the include path was wrong.

As we have an include and not a require this doesn't trig any error.

Fix this by giving the correct include path to u-boot-mender.inc

Signed-off-by: Clément Péron <peron.clem@gmail.com>