### PR TITLE
Fix patch so that it build with the latest NXP BSP

### DIFF
--- a/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch
+++ b/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch
@@ -1,30 +1,28 @@
-From d4c479e70130dcb2b636b8066719bb276d8717d6 Mon Sep 17 00:00:00 2001
-From: Drew Moseley <drew.moseley@northern.tech>
-Date: Wed, 16 Sep 2020 13:49:16 -0400
-Subject: [PATCH 1/2] Switch to CONFIG_DISTRO_DEFAULTS for bootcmd.
+From 150b0d7ffa9e32e37440753678c6dcc7c7ee706d Mon Sep 17 00:00:00 2001
+From: Gareth Phillips <gphillips@a2etech.com>
+Date: Tue, 10 Nov 2020 14:01:18 +0000
+Subject: [PATCH] Switch to CONFIG_DISTRO_DEFAULTS for bootcmd
 
-Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
 ---
- configs/imx8mn_var_som_defconfig |  3 +-
- include/configs/imx8mn_var_som.h | 86 +++++++-------------------------
- 2 files changed, 19 insertions(+), 70 deletions(-)
+ configs/imx8mn_var_som_defconfig |  2 +
+ include/configs/imx8mn_var_som.h | 84 +++++++-------------------------
+ 2 files changed, 19 insertions(+), 67 deletions(-)
 
 diff --git a/configs/imx8mn_var_som_defconfig b/configs/imx8mn_var_som_defconfig
-index 18e091a646..0d108a0958 100644
+index ca354a4ed8..96ae23d6aa 100644
 --- a/configs/imx8mn_var_som_defconfig
 +++ b/configs/imx8mn_var_som_defconfig
-@@ -56,4 +56,5 @@ CONFIG_USB_GADGET_MANUFACTURER="Variscite"
- CONFIG_USB_GADGET_VENDOR_NUM=0x0525
+@@ -84,3 +84,5 @@ CONFIG_USB_GADGET_VENDOR_NUM=0x0525
  CONFIG_USB_GADGET_PRODUCT_NUM=0xa4a5
  CONFIG_CI_UDC=y
--# CONFIG_EFI_LOADER is not set
+ CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_EFI_LOADER=y
 +CONFIG_DISTRO_DEFAULTS=y
 diff --git a/include/configs/imx8mn_var_som.h b/include/configs/imx8mn_var_som.h
-index 0eb8d094a4..49daedadd3 100644
+index c554a9da63..0a0d2f5584 100644
 --- a/include/configs/imx8mn_var_som.h
 +++ b/include/configs/imx8mn_var_som.h
-@@ -61,6 +61,7 @@
+@@ -60,6 +60,7 @@
  
  #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
  
@@ -32,7 +30,7 @@ index 0eb8d094a4..49daedadd3 100644
  #endif /* CONFIG_SPL_BUILD */
  
  #define CONFIG_CMD_READ
-@@ -108,21 +109,18 @@
+@@ -109,21 +110,18 @@
  /* Initial environment variables */
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	CONFIG_MFG_ENV_SETTINGS \
@@ -57,7 +55,7 @@ index 0eb8d094a4..49daedadd3 100644
  	"mmcpart=1\0" \
  	"m7_addr=0x7e0000\0" \
  	"m7_bin=hello_world.bin\0" \
-@@ -136,66 +134,19 @@
+@@ -138,65 +136,19 @@
  			"dcache flush; " \
  		"fi; " \
  		"bootaux ${m7_addr};\0" \
@@ -111,7 +109,6 @@ index 0eb8d094a4..49daedadd3 100644
 -			"setenv get_cmd tftp; " \
 -		"fi; " \
 -		"${get_cmd} ${img_addr} ${image}; unzip ${img_addr} ${loadaddr};" \
--		"run ramsize_check; " \
 -		"run netargs; " \
 -		"run optargs; " \
 -		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
@@ -127,7 +124,7 @@ index 0eb8d094a4..49daedadd3 100644
  		"fi;\0"
  
  #define CONFIG_BOOTCOMMAND \
-@@ -205,18 +156,11 @@
+@@ -206,18 +158,11 @@
  		"if test ${use_m7} = yes && run loadm7bin; then " \
  			"run runm7bin; " \
  		"fi; " \
@@ -151,16 +148,15 @@ index 0eb8d094a4..49daedadd3 100644
  
  /* Link Definitions */
  #define CONFIG_LOADADDR			0x40480000
-@@ -234,7 +178,7 @@
+@@ -234,6 +179,7 @@
+ #define CONFIG_ENV_OVERWRITE
  
  /* Default ENV offset is 4MB for SD/EMMC/FSPI, but NAND uses 60MB offset, overridden by env_get_offset */
- #define CONFIG_ENV_OFFSET		(64 * SZ_64K)
--#define CONFIG_ENV_SIZE			0x1000
 +#define CONFIG_ENV_SIZE			SZ_8K
  #define CONFIG_ENV_SECT_SIZE		(64 * 1024)
  #define CONFIG_SYS_MMC_ENV_DEV		1 /* USDHC2 */
  
-@@ -300,6 +244,10 @@
+@@ -301,6 +247,10 @@
  #define CONFIG_USB_GADGET_MASS_STORAGE
  #define CONFIG_USB_FUNCTION_MASS_STORAGE
  
@@ -172,5 +168,5 @@ index 0eb8d094a4..49daedadd3 100644
  
  #define CONFIG_USB_GADGET_VBUS_DRAW 2
 -- 
-2.28.0
+2.17.1
 


### PR DESCRIPTION
Submitting this as requested in https://hub.mender.io/t/variscite-var-som-mx8m-nano-nxp-i-mx-8m-nano/1928/3.
I am not confident of the changes as I don't know the code, and I am experiencing problems when running the image it generates.