### PR TITLE
Bsp v5.4.24

### DIFF
--- a/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch
+++ b/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch
@@ -1,30 +1,38 @@
-From d4c479e70130dcb2b636b8066719bb276d8717d6 Mon Sep 17 00:00:00 2001
+From 9c29bea35bcc6de2678e2cbba624a8f7b3c8e986 Mon Sep 17 00:00:00 2001
 From: Drew Moseley <drew.moseley@northern.tech>
 Date: Wed, 16 Sep 2020 13:49:16 -0400
-Subject: [PATCH 1/2] Switch to CONFIG_DISTRO_DEFAULTS for bootcmd.
+Subject: [PATCH] Switch to CONFIG_DISTRO_DEFAULTS for bootcmd.
 
 Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
 ---
- configs/imx8mn_var_som_defconfig |  3 +-
- include/configs/imx8mn_var_som.h | 86 +++++++-------------------------
- 2 files changed, 19 insertions(+), 70 deletions(-)
+ configs/imx8mn_var_som_defconfig |  4 +-
+ include/configs/imx8mn_var_som.h | 83 ++++++--------------------------
+ 2 files changed, 19 insertions(+), 68 deletions(-)
 
 diff --git a/configs/imx8mn_var_som_defconfig b/configs/imx8mn_var_som_defconfig
-index 18e091a646..0d108a0958 100644
+index ca354a4ed8..0e93b6f77e 100644
 --- a/configs/imx8mn_var_som_defconfig
 +++ b/configs/imx8mn_var_som_defconfig
-@@ -56,4 +56,5 @@ CONFIG_USB_GADGET_MANUFACTURER="Variscite"
- CONFIG_USB_GADGET_VENDOR_NUM=0x0525
+@@ -3,7 +3,7 @@ CONFIG_SPL_SYS_ICACHE_OFF=y
+ CONFIG_SPL_SYS_DCACHE_OFF=y
+ CONFIG_ARCH_IMX8M=y
+ CONFIG_SYS_TEXT_BASE=0x40200000
+-CONFIG_ENV_SIZE=0x1000
++CONFIG_ENV_SIZE=0x2000
+ CONFIG_ENV_OFFSET=0x400000
+ CONFIG_DM_GPIO=y
+ CONFIG_TARGET_IMX8MN_VAR_SOM=y
+@@ -84,3 +84,5 @@ CONFIG_USB_GADGET_VENDOR_NUM=0x0525
  CONFIG_USB_GADGET_PRODUCT_NUM=0xa4a5
  CONFIG_CI_UDC=y
--# CONFIG_EFI_LOADER is not set
+ CONFIG_OF_LIBFDT_OVERLAY=y
 +CONFIG_EFI_LOADER=y
 +CONFIG_DISTRO_DEFAULTS=y
 diff --git a/include/configs/imx8mn_var_som.h b/include/configs/imx8mn_var_som.h
-index 0eb8d094a4..49daedadd3 100644
+index c554a9da63..71060e95d1 100644
 --- a/include/configs/imx8mn_var_som.h
 +++ b/include/configs/imx8mn_var_som.h
-@@ -61,6 +61,7 @@
+@@ -60,6 +60,7 @@
  
  #define CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
  
@@ -32,7 +40,7 @@ index 0eb8d094a4..49daedadd3 100644
  #endif /* CONFIG_SPL_BUILD */
  
  #define CONFIG_CMD_READ
-@@ -108,21 +109,18 @@
+@@ -109,21 +110,18 @@
  /* Initial environment variables */
  #define CONFIG_EXTRA_ENV_SETTINGS \
  	CONFIG_MFG_ENV_SETTINGS \
@@ -57,7 +65,7 @@ index 0eb8d094a4..49daedadd3 100644
  	"mmcpart=1\0" \
  	"m7_addr=0x7e0000\0" \
  	"m7_bin=hello_world.bin\0" \
-@@ -136,66 +134,19 @@
+@@ -138,65 +136,19 @@
  			"dcache flush; " \
  		"fi; " \
  		"bootaux ${m7_addr};\0" \
@@ -111,7 +119,6 @@ index 0eb8d094a4..49daedadd3 100644
 -			"setenv get_cmd tftp; " \
 -		"fi; " \
 -		"${get_cmd} ${img_addr} ${image}; unzip ${img_addr} ${loadaddr};" \
--		"run ramsize_check; " \
 -		"run netargs; " \
 -		"run optargs; " \
 -		"if test ${boot_fdt} = yes || test ${boot_fdt} = try; then " \
@@ -127,7 +134,7 @@ index 0eb8d094a4..49daedadd3 100644
  		"fi;\0"
  
  #define CONFIG_BOOTCOMMAND \
-@@ -205,18 +156,11 @@
+@@ -206,18 +158,11 @@
  		"if test ${use_m7} = yes && run loadm7bin; then " \
  			"run runm7bin; " \
  		"fi; " \
@@ -151,16 +158,7 @@ index 0eb8d094a4..49daedadd3 100644
  
  /* Link Definitions */
  #define CONFIG_LOADADDR			0x40480000
-@@ -234,7 +178,7 @@
- 
- /* Default ENV offset is 4MB for SD/EMMC/FSPI, but NAND uses 60MB offset, overridden by env_get_offset */
- #define CONFIG_ENV_OFFSET		(64 * SZ_64K)
--#define CONFIG_ENV_SIZE			0x1000
-+#define CONFIG_ENV_SIZE			SZ_8K
- #define CONFIG_ENV_SECT_SIZE		(64 * 1024)
- #define CONFIG_SYS_MMC_ENV_DEV		1 /* USDHC2 */
- 
-@@ -300,6 +244,10 @@
+@@ -301,6 +246,10 @@
  #define CONFIG_USB_GADGET_MASS_STORAGE
  #define CONFIG_USB_FUNCTION_MASS_STORAGE
  
@@ -172,5 +170,5 @@ index 0eb8d094a4..49daedadd3 100644
  
  #define CONFIG_USB_GADGET_VBUS_DRAW 2
 -- 
-2.28.0
+2.29.2
 

--- a/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0002-Store-Env-in-eMMC.patch
+++ b/meta-mender-variscite/recipes-bsp/u-boot/files/imx8mn-var-som/0002-Store-Env-in-eMMC.patch
@@ -1,7 +1,7 @@
-From 9720407c334a9762ed9418c6051c52a925226291 Mon Sep 17 00:00:00 2001
+From 88ef678ef5e50adb6d356a062bde5791741e589e Mon Sep 17 00:00:00 2001
 From: Drew Moseley <drew.moseley@northern.tech>
 Date: Thu, 24 Sep 2020 15:43:47 -0400
-Subject: [PATCH 2/2] Store Env in eMMC
+Subject: [PATCH] Store Env in eMMC
 
 Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
 ---
@@ -9,12 +9,12 @@ Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/include/configs/imx8mn_var_som.h b/include/configs/imx8mn_var_som.h
-index 49daedadd3..c2c37ea46a 100644
+index 71060e95d1..885aa068e3 100644
 --- a/include/configs/imx8mn_var_som.h
 +++ b/include/configs/imx8mn_var_som.h
 @@ -180,7 +180,7 @@
- #define CONFIG_ENV_OFFSET		(64 * SZ_64K)
- #define CONFIG_ENV_SIZE			SZ_8K
+ 
+ /* Default ENV offset is 4MB for SD/EMMC/FSPI, but NAND uses 60MB offset, overridden by env_get_offset */
  #define CONFIG_ENV_SECT_SIZE		(64 * 1024)
 -#define CONFIG_SYS_MMC_ENV_DEV		1 /* USDHC2 */
 +#define CONFIG_SYS_MMC_ENV_DEV		2 /* USDHC2 */

--- a/meta-mender-variscite/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/meta-mender-variscite/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,7 @@
+do_compile() {
+	oe_runmake -C ${S} sandbox_defconfig O=${B}
+	for config in ${SED_CONFIG_DISABLE}; do
+		sed -i -e "s/$config=.*/# $config is not set/" ${B}/.config
+	done
+	oe_runmake -C ${S} cross_tools NO_SDL=1 O=${B}
+}

--- a/meta-mender-variscite/recipes-bsp/u-boot/u-boot-variscite.bbappend
+++ b/meta-mender-variscite/recipes-bsp/u-boot/u-boot-variscite.bbappend
@@ -1,10 +1,12 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
-SRC_URI_append_imx6ul-var-dart = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
-SRC_URI_append_imx8mm-var-dart = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
-SRC_URI_append_imx8mm-var-dart = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.getVar('VARISCITE_UBOOT_ENV_IN_EMMC', True) == '1' else ''}"
-SRC_URI_append_imx8mn-var-som = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
-SRC_URI_append_imx8mn-var-som = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.getVar('VARISCITE_UBOOT_ENV_IN_EMMC', True) == '1' else ''}"
+include ${@mender_feature_is_enabled("mender-uboot","recipes-bsp/u-boot/u-boot-mender.inc","",d)}
+
+SRC_URI_append_imx6ul-var-dart_mender-grub = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
+SRC_URI_append_imx8mm-var-dart_mender-grub = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
+SRC_URI_append_imx8mm-var-dart_mender-grub = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.getVar('VARISCITE_UBOOT_ENV_IN_EMMC', True) == '1' else ''}"
+SRC_URI_append_imx8mn-var-som_mender-grub = " file://0001-Switch-to-CONFIG_DISTRO_DEFAULTS-for-bootcmd.patch "
+SRC_URI_append_imx8mn-var-som_mender-grub = " ${@'file://0002-Store-Env-in-eMMC.patch' if d.getVar('VARISCITE_UBOOT_ENV_IN_EMMC', True) == '1' else ''}"
 
 PROVIDES += "u-boot"
 RPROVIDES_${PN} += "u-boot"
@@ -19,3 +21,14 @@ make_u_boot_spl_image() {
 do_deploy_append_imx6ul-var-dart() {
     make_u_boot_spl_image
 }
+
+MENDER_UBOOT_AUTO_CONFIGURE_mender-uboot = "1"
+MENDER_UBOOT_PRE_SETUP_COMMANDS_mender-uboot = " \
+    if test \\\"\${ramsize_check}\\\" != \\\"\\\"; then run ramsize_check; fi; \
+    if test \\\"\${mmcargs}\\\" != \\\"\\\"; then run mmcargs; fi; \
+    if test \\\"\${videoargs}\\\" != \\\"\\\"; then run videoargs; fi; \
+    if test \\\"\${optargs}\\\" != \\\"\\\"; then run optargs; fi; \
+    run findfdt; \
+    setenv mender_dtb_name \${fdt_file}; \
+    setenv kernel_addr_r \${loadaddr}; \
+"

--- a/meta-mender-variscite/templates/local-emmc.conf.append
+++ b/meta-mender-variscite/templates/local-emmc.conf.append
@@ -12,7 +12,7 @@ MENDER_UBOOT_STORAGE_DEVICE_imx8mm-var-dart = "1"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
 
 MENDER_STORAGE_DEVICE_imx8mn-var-som = "/dev/mmcblk2"
-MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "1"
+MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "2"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
  
 MENDER_BOOT_PART_SIZE_MB_mender-uboot = "0"

--- a/meta-mender-variscite/templates/local-emmc.conf.append
+++ b/meta-mender-variscite/templates/local-emmc.conf.append
@@ -14,3 +14,6 @@ UBOOT_CONFIG_imx8mm-var-dart = "sd"
 MENDER_STORAGE_DEVICE_imx8mn-var-som = "/dev/mmcblk2"
 MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "1"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
+ 
+MENDER_BOOT_PART_SIZE_MB_mender-uboot = "0"
+KERNEL_IMAGETYPE_mender-uboot = "Image"

--- a/meta-mender-variscite/templates/local-sdcard.conf.append
+++ b/meta-mender-variscite/templates/local-sdcard.conf.append
@@ -12,7 +12,7 @@ MENDER_UBOOT_STORAGE_DEVICE_imx8mm-var-dart = "0"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
 
 MENDER_STORAGE_DEVICE_imx8mn-var-som = "/dev/mmcblk1"
-MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "0"
+MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "1"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
 
 MENDER_BOOT_PART_SIZE_MB_mender-uboot = "0"

--- a/meta-mender-variscite/templates/local-sdcard.conf.append
+++ b/meta-mender-variscite/templates/local-sdcard.conf.append
@@ -14,3 +14,6 @@ UBOOT_CONFIG_imx8mm-var-dart = "sd"
 MENDER_STORAGE_DEVICE_imx8mn-var-som = "/dev/mmcblk1"
 MENDER_UBOOT_STORAGE_DEVICE_imx8mn-var-som = "0"
 UBOOT_CONFIG_imx8mm-var-dart = "sd"
+
+MENDER_BOOT_PART_SIZE_MB_mender-uboot = "0"
+KERNEL_IMAGETYPE_mender-uboot = "Image"

--- a/meta-mender-variscite/templates/local.conf.append
+++ b/meta-mender-variscite/templates/local.conf.append
@@ -32,7 +32,3 @@ MENDER_FEATURES_DISABLE_append = " mender-image-uefi "
 
 # Make sure we don't include u-boot-fw-utils; we are using grub-mender-grubenv instead
 MACHINE_EXTRA_RDEPENDS_remove = "u-boot-fw-utils"
-
-# Do not use the bbappend provided by meta-imx. It does not not use
-# the right ${B} and ${S} settings and causes build failures with Mender
-BBMASK += "meta-imx/meta-bsp/recipes-bsp/u-boot/u-boot-tools_%.bbappend"


### PR DESCRIPTION
This fixes up the imx8mn-var-som machine so that it works with the 5.4.24 BSP from Variscite.
It also enabled mender-uboot integration in addition to the standard mender-grub integration.