### PR TITLE
scripts: mender-no-setup: remove defaults

### DIFF
--- a/scripts/mender-no-setup.xml
+++ b/scripts/mender-no-setup.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
   <manifest>
-  <default sync-j="4" revision="dunfell"/>
 
   <remote fetch="https://github.com/mendersoftware" name="mender"/>
 


### PR DESCRIPTION
These are provided by upstream manifests.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>