### PR TITLE
scritps: add mender-no-setup-layers.xml

### DIFF
--- a/scripts/mender-no-setup-layers.xml
+++ b/scripts/mender-no-setup-layers.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+
+  <remote fetch="https://github.com/mendersoftware" name="mender"/>
+
+  <project name="meta-mender" remote="mender" revision="dunfell" path="layers/meta-mender"/>
+  <project name="meta-mender-community" remote="mender" revision="dunfell" path="layers/meta-mender-community">
+  </project>
+
+  </manifest>


### PR DESCRIPTION
THis manifest clones Mender layers to layers/ sub-directory, which
is used by some BSP's, e.g Toradex.

Signed-off-by: Mirza Krak <mirza.krak@northern.tech>