### PR TITLE
toradex-nxp: use U-boot integration as default for Toradex Verdin iMX8MM

### DIFF
--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -1,7 +1,7 @@
 
 # Appended fragment from meta-mender-community/meta-mender-toradex-nxp/templates
 
-MACHINE ?= "verdin-imx8mm"
+MACHINE = "verdin-imx8mm"
 
 # Comment/remove below to enable GRUB integration instead of U-Boot
 MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -3,9 +3,9 @@
 
 MACHINE ?= "verdin-imx8mm"
 
-# Uncomment to enable U-Boot integration instead of GRUB
-#MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
-#MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
+# Comment/remove below to enable GRUB integration instead of U-Boot
+MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
+MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 
 IMAGE_CLASSES += "image_type_mender_tezi"
 IMAGE_FSTYPES_append = " mender_tezi"


### PR DESCRIPTION
Signed-off-by: Mirza Krak <mirza.krak@northern.tech>