### PR TITLE
toradex-nxp: set OFFSET_SPL_PAYLOAD as empty string

### DIFF
--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -23,4 +23,4 @@ IMAGE_BOOT_FILES = ""
 IMAGE_BOOT_FILES_remove_mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
 
 # No SPL, otherwise this gets included in tezi image
-OFFSET_SPL_PAYLOAD_verdin-imx8mm = "0"
+OFFSET_SPL_PAYLOAD_verdin-imx8mm = ""


### PR DESCRIPTION
It is treated as a string in image_type_mender_tezi, so
setting "0" does not disable it, and it should be empty.

Fixes bd849438920 ("toradex-nxp: disable OFFSET_SPL_PAYLOAD for verdin-imx8mm")

Signed-off-by: Mirza Krak <mirza@maneoz.tech>