### PR TITLE
Tegra fixes for dunfell

### DIFF
--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -19,9 +19,9 @@ ARTIFACTIMG_FSTYPE = "ext4"
 IMAGE_TYPEDEP_tegraflash += " dataimg"
 IMAGE_FSTYPES += "dataimg"
 PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
-PREFERRED_PROVIDER_libubootenv_tegra = "${'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv'}"
+PREFERRED_PROVIDER_libubootenv_tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv'}"
 PREFERRED_RPROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
-PREFERRED_RPROVIDER_libubootenv-bin_tegra = "${'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv-bin'}"
+PREFERRED_RPROVIDER_libubootenv-bin_tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv-bin'}"
 # Note: this isn't really a boot file, just put it here to keep the mender build from
 # complaining about empty IMAGE_BOOT_FILES.  We won't use the full image anyway, just the mender file
 IMAGE_BOOT_FILES = "u-boot-dtb.bin"

--- a/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -18,6 +18,10 @@ while [ -n "$1" ]; do
             [ -n "$quiet" ] || echo -n "$1="
             nvbootctrl get-current-slot
             ;;
+        mender_uboot_separator)
+            [ -n "$quiet" ] || echo -n "$1="
+            echo "something other than just 1"
+            ;;
         upgrade_available)
             [ -n "$quiet" ] || echo -n "$1="
 	    if [ -e "/var/lib/mender/upgrade_available" ]; then


### PR DESCRIPTION
* Fix typos in tegra-mender-setup
* Update the libubootenv-fake implementation of fw_printenv to work with the separator probe checks in mender-client 2.4.1