### PR TITLE
Delta updates fix: don't mount newly flashed root filesystem as read-write

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Update bootloader on successful boot
 ConditionPathExists=!@LOCALSTATEDIR@/lib/mender/dont-mark-next-boot-successful
+After=setup-nv-boot-control.service
+Requires=setup-nv-boot-control.service
 Before=network.target
 
 [Service]

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -4,7 +4,7 @@ mnt=
 
 cleanup() {
     [ -n "$mnt" ] || return
-    for d in sys proc dev; do
+    for d in sys proc dev var/lib var/volatile; do
 	if mountpoint -q "${mnt}/${d}"; then
 	    umount "${mnt}/${d}" >/dev/null 2>&1 || true
 	fi
@@ -35,7 +35,7 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-mount /dev/mmcblk0p${new_boot_part} "$mnt"
+mount -o ro /dev/mmcblk0p${new_boot_part} "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup
@@ -46,12 +46,16 @@ fi
 mount --bind /sys "${mnt}/sys"
 mount --bind /proc "${mnt}/proc"
 mount --bind /dev "${mnt}/dev"
+
+# Mount an overlay for /var/lib so the /var/lib/nv_boot_control.conf file becomes writable
+mount -t tmpfs tmpfs ${mnt}/var/volatile
+mount-copybind ${mnt}/var/volatile/lib ${mnt}/var/lib/
+
 # Run the update engine in the context of the just-installed rootfs
 # to ensure that the TNSPEC in the config file it uses matches the
 # TNSPEC in the update payload. But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
-    rm "${mnt}/etc/nv_boot_control.conf"
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
 	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi


### PR DESCRIPTION
Signed-off-by: Niels Avonds <niels@nobi.life>