### PR TITLE
meta-mender-tn-imx-bsp: Add support for the PICO-IMX8M platform

### DIFF
--- a/meta-mender-tn-imx-bsp/README.md
+++ b/meta-mender-tn-imx-bsp/README.md
@@ -1,0 +1,40 @@
+# meta-mender-tn-imx-bsp
+
+Mender integration layer for TechNexion family of boards.
+
+The supported and tested boards are:
+
+- [PICO-IMX8M](https://hub.mender.io/t/technexion-pico-imx8m/)
+
+Visit the individual board links above for more information on status of the
+integration and more detailed instructions on how to build and use images
+together with Mender for the mentioned boards.
+
+## Dependencies
+
+This layer depends on [TechNexion Yocto 2.5 Sumo 4.14.y GA BSP](https://github.com/TechNexion/tn-imx-yocto-manifest/tree/sumo_4.14.y_GA-stable)
+
+
+## Quick start
+
+The following commands will setup the environment and allow you to build images
+that have Mender integrated.
+
+
+```
+mkdir mender-tn-imx-bsp && cd mender-tn-imx-bsp
+repo init -u https://github.com/TechNexion/tn-imx-yocto-manifest.git -b sumo_4.14.y_GA-stable -m imx-4.14.98-2.0.1_patch.xml
+wget --directory-prefix .repo/local_manifests https://raw.githubusercontent.com/mendersoftware/meta-mender-community/sumo/meta-mender-tn-imx-bsp/scripts/mender-technexion.xml
+repo sync -j$(nproc)
+DISTRO=fsl-imx-xwayland MACHINE=pico-imx8mq source tn-setup-mender.sh -b build-xwayland-imx8mq
+bitbake core-image-base
+```
+
+
+## Maintainer
+
+The authors and maintainers of this layer are:
+
+- Tom Rini <trini@konsulko.com>
+
+Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-tn-imx-bsp/conf/layer.conf
+++ b/meta-mender-tn-imx-bsp/conf/layer.conf
@@ -1,0 +1,17 @@
+# Copyright 2020 Northern.tech AS
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-tn-imx-bsp"
+BBFILE_PATTERN_mender-tn-imx-bsp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-tn-imx-bsp = "10"
+
+LAYERSERIES_COMPAT_mender-tn-imx-bsp = "sumo"
+
+LAYERDEPENDS_mender-tn-imx-bsp = "meta-tn-imx-bsp mender"
+

--- a/meta-mender-tn-imx-bsp/recipes-bsp/u-boot/u-boot-edm/pico-imx8mq/0001-configs-pico-imx8mq-add-Mender-support.patch
+++ b/meta-mender-tn-imx-bsp/recipes-bsp/u-boot/u-boot-edm/pico-imx8mq/0001-configs-pico-imx8mq-add-Mender-support.patch
@@ -1,0 +1,78 @@
+From: Tom Rini <trini@konsulko.com>
+Date: Mon, 28 Dec 2020 08:19:10 -0500
+Subject: [PATCH 1/1] configs: pico-imx8mq: add Mender support
+
+Signed-off-by: Tom Rini <trini@konsulko.com>
+---
+
+Index: git/configs/pico-imx8mq_defconfig
+===================================================================
+--- git.orig/configs/pico-imx8mq_defconfig
++++ git/configs/pico-imx8mq_defconfig
+@@ -33,6 +33,7 @@ CONFIG_EFI_PARTITION=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_SAVED_DRAM_TIMING_BASE=0x40000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_DM_GPIO=y
+ CONFIG_DM_I2C=y
+ CONFIG_SYS_I2C_MXC=y
+Index: git/include/configs/pico-imx8mq.h
+===================================================================
+--- git.orig/include/configs/pico-imx8mq.h
++++ git/include/configs/pico-imx8mq.h
+@@ -150,13 +150,13 @@
+ 	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"mmcroot=" CONFIG_MMCROOT " rootwait rw\0" \
+ 	"mmcautodetect=yes\0" \
+-	"mmcargs=setenv bootargs ${jh_clk} console=${console} root=${mmcroot}\0 " \
++	"mmcargs=setenv bootargs ${jh_clk} console=${console} root=${mender_kernel_root} rootwait\0 " \
+ 	"UMS=ums 0 mmc ${mmcdev}\0" \
+ 	"loadbootscript=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${script};\0" \
+ 	"bootscript=echo Running bootscript from mmc ...; " \
+ 		"source\0" \
+-	"loadimage=fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}\0" \
+-	"loadfdt=fatload mmc ${mmcdev}:${mmcpart} ${fdt_addr} ${fdt_file}\0" \
++	"loadimage=ext4load ${mender_uboot_root} ${loadaddr} /boot/${image}\0" \
++	"loadfdt=ext4load ${mender_uboot_root} ${fdt_addr} /boot/${fdt_file}\0" \
+ 	"bootenv=uEnv.txt\0" \
+ 	"loadbootenv=fatload mmc ${mmcdev} ${loadaddr} ${bootenv}\0" \
+ 	"importbootenv=echo Importing environment from mmc ...; " \
+@@ -222,13 +222,19 @@
+ 		   "if run loadfit; then " \
+ 			   "run fitboot; " \
+ 		   "fi; " \
++	   	   "run mender_setup; " \
+ 		   "if run loadimage; then " \
+ 			   "run mmcboot; " \
++			   "run mender_try_to_recover; " \
+ 		   "else " \
++			   "run mender_try_to_recover; " \
+ 			   "echo WARN: Cannot load kernel from boot media; " \
+ 		   "fi; " \
+ 	   "else run netboot; fi"
+ 
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
++
+ /* Link Definitions */
+ #define CONFIG_LOADADDR			0x40480000
+ 
+@@ -242,13 +248,13 @@
+         (CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
+ 
+ #define CONFIG_ENV_OVERWRITE
+-#define CONFIG_ENV_OFFSET               (64 * SZ_64K)
+-#define CONFIG_ENV_SIZE			0x1000
+-#define CONFIG_SYS_MMC_ENV_DEV		1   /* USDHC2 */
++#define CONFIG_ENV_OFFSET               0x800000
++#define CONFIG_ENV_OFFSET_REDUND	0x1000000
++#define CONFIG_ENV_SIZE			0x8000
+ #define CONFIG_MMCROOT			"/dev/mmcblk1p2"  /* USDHC2 */
+ 
+ /* Size of malloc() pool */
+-#define CONFIG_SYS_MALLOC_LEN		((CONFIG_ENV_SIZE + (2*1024) + (16*1024)) * 1024)
++#define CONFIG_SYS_MALLOC_LEN		(((CONFIG_ENV_SIZE*2) + (2*1024) + (16*1024)) * 1024)
+ 
+ #define CONFIG_SYS_SDRAM_BASE           0x40000000
+ #define PHYS_SDRAM                      0x40000000

--- a/meta-mender-tn-imx-bsp/recipes-bsp/u-boot/u-boot-edm_2018.03.bbappend
+++ b/meta-mender-tn-imx-bsp/recipes-bsp/u-boot/u-boot-edm_2018.03.bbappend
@@ -1,0 +1,11 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+require recipes-bsp/u-boot/u-boot-mender.inc
+
+SRC_URI_append_pico-imx8mq = " \
+    file://0001-configs-pico-imx8mq-add-Mender-support.patch \
+"
+
+BOOTENV_SIZE_pico-imx8mq = "0x8000"
+
+MENDER_UBOOT_AUTO_CONFIGURE = "0"

--- a/meta-mender-tn-imx-bsp/scripts/mender-technexion.xml
+++ b/meta-mender-tn-imx-bsp/scripts/mender-technexion.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <remote fetch="https://github.com/mendersoftware" name="mender"/>
+
+  <project name="meta-mender" remote="mender" revision="sumo" path="sources/meta-mender"/>
+  <project name="meta-mender-community" remote="mender" revision="sumo" path="sources/meta-mender-community">
+    <linkfile src="meta-mender-tn-imx-bsp/scripts/tn-setup-mender.sh" dest="tn-setup-mender.sh"/>
+  </project>
+
+</manifest>

--- a/meta-mender-tn-imx-bsp/scripts/tn-setup-mender.sh
+++ b/meta-mender-tn-imx-bsp/scripts/tn-setup-mender.sh
@@ -1,0 +1,23 @@
+# Mender Integration Setup Script
+#
+# Copyright 2020 Northern.tech
+
+. edm-setup-release.sh $@
+
+if [ $? != 0 ]; then
+  echo ""
+  echo "Failed to setup mender build environment"
+  echo ""
+  return 1
+fi
+
+echo "BBLAYERS += \" \${BSPDIR}/sources/meta-mender/meta-mender-core \"" >> conf/bblayers.conf
+echo "BBLAYERS += \" \${BSPDIR}/sources/meta-mender/meta-mender-demo \"" >> conf/bblayers.conf
+echo "BBLAYERS += \" \${BSPDIR}/sources/meta-mender-community/meta-mender-tn-imx-bsp \"" >> conf/bblayers.conf
+
+cat ../sources/meta-mender-community/templates/local.conf.append >> conf/local.conf
+cat ../sources/meta-mender-community/meta-mender-tn-imx-bsp/templates/local.conf.append >> conf/local.conf
+
+echo ""
+echo "Mender integration complete."
+echo ""

--- a/meta-mender-tn-imx-bsp/templates/local.conf.append
+++ b/meta-mender-tn-imx-bsp/templates/local.conf.append
@@ -1,0 +1,26 @@
+
+# Appended fragment from meta-mender-community/meta-mender-tn-imx-bsp/templates
+
+MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
+MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
+
+# SD Card
+#MENDER_STORAGE_DEVICE_pico-imx8mq = "/dev/mmcblk1"
+
+# eMMC Card
+MENDER_STORAGE_DEVICE_pico-imx8mq = "/dev/mmcblk0"
+
+IMAGE_FSTYPES_remove = "tar.bz2 ext4 sdcard.bz2 sdcard.xz sdcard.md5sum"
+
+# Disable boot partition
+MENDER_BOOT_PART_SIZE_MB = "0"
+IMAGE_BOOT_FILES = ""
+
+MENDER_IMAGE_BOOTLOADER_FILE = "imx-boot-${MACHINE}-sd.bin"
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "66"
+
+do_image_sdimg[depends] += "imx-boot:do_deploy"
+
+IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
+
+MENDER_STORAGE_TOTAL_SIZE_MB = "1024"


### PR DESCRIPTION
Based heavily on the meta-mender-tn-imx-bsp layer in zeus as of revision
4d0df63278a7 add support for the PICO-IMX8M platform.

Signed-off-by: Tom Rini <trini@konsulko.com>