### PR TITLE
tegra: Use read only mounts for uboot and cboot builds

### DIFF
--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -103,9 +103,6 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT_tegra = "${@tegra_mender_calc_total_size(d)
 
 def tegra_mender_uboot_feature(d):
     if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot'):
-        # Note: mender-persist-systemd-machine-id is currently not compatible with
-        # mender's delta update feature for cboot builds.  See disussion at
-        # https://github.com/mendersoftware/meta-mender-community/pull/208#discussion_r549138930
         return " mender-persist-systemd-machine-id"
     return " mender-uboot mender-persist-systemd-machine-id"
 

--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -103,6 +103,9 @@ MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT_tegra = "${@tegra_mender_calc_total_size(d)
 
 def tegra_mender_uboot_feature(d):
     if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot'):
+        # Note: mender-persist-systemd-machine-id is currently not compatible with
+        # mender's delta update feature for cboot builds.  See disussion at
+        # https://github.com/mendersoftware/meta-mender-community/pull/208#discussion_r549138930
         return " mender-persist-systemd-machine-id"
     return " mender-uboot mender-persist-systemd-machine-id"
 

--- a/meta-mender-tegra/recipes-bsp/cboot/cboot-t18x_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/cboot/cboot-t18x_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append = " machine-id"

--- a/meta-mender-tegra/recipes-bsp/cboot/cboot-t19x_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/cboot/cboot-t19x_%.bbappend
@@ -1,0 +1,1 @@
+PACKAGECONFIG_append = " machine-id"

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
@@ -1,6 +1,8 @@
 [Unit]
 Description=Update bootloader on successful boot
 ConditionPathExists=!@LOCALSTATEDIR@/lib/mender/dont-mark-next-boot-successful
+After=setup-nv-boot-control.service
+Requires=setup-nv-boot-control.service
 Before=network.target
 
 [Service]

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides/update-nvbootctrl.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=Update bootloader on successful boot
 ConditionPathExists=!@LOCALSTATEDIR@/lib/mender/dont-mark-next-boot-successful
-After=setup-nv-boot-control.service
 Requires=setup-nv-boot-control.service
+After=setup-nv-boot-control.service
 Before=network.target
 
 [Service]

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+RDEPENDS_${PN} += "tegra-redundant-boot-nvbootctrl"

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_%.bbappend
@@ -1,0 +1,4 @@
+do_install_append() {
+    # Override the symlink to always target a volatile location for nv_boot_control.conf
+    ln -sf /run/nvbootctrl/nv_boot_control.conf ${D}${sysconfdir}/
+}

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-nv-boot-control-config_%.bbappend
@@ -1,4 +1,3 @@
 do_install_append() {
-    # Override the symlink to always target a volatile location for nv_boot_control.conf
-    ln -sf /run/nvbootctrl/nv_boot_control.conf ${D}${sysconfdir}/
+    ln -sf /run/tegra-nv-bootctrl/nv_boot_control.conf ${D}${sysconfdir}/
 }

--- a/meta-mender-tegra/recipes-bsp/tools/setup-nv-boot-control/target-mkdir.conf
+++ b/meta-mender-tegra/recipes-bsp/tools/setup-nv-boot-control/target-mkdir.conf
@@ -1,0 +1,2 @@
+[Service]
+ExecStartPre=/bin/mkdir -p /run/tegra-nv-bootctrl

--- a/meta-mender-tegra/recipes-bsp/tools/setup-nv-boot-control_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tools/setup-nv-boot-control_%.bbappend
@@ -1,0 +1,10 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+
+SRC_URI += "file://target-mkdir.conf"
+
+do_install_append() {
+    install -d ${D}${sysconfdir}/systemd/system/setup-nv-boot-control.service.d
+    install -m 0644 ${WORKDIR}/target-mkdir.conf ${D}${sysconfdir}/systemd/system/setup-nv-boot-control.service.d/
+}
+
+FILES_${PN}-service += "${sysconfdir}/systemd/system/setup-nv-boot-control.service.d"

--- a/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,1 +1,5 @@
 RDEPENDS_${PN}_append_tegra = "${@' tegra-bup-payload libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
+EXTRADEPS = ""
+EXTRADEPS_tegra = "tegra-boot-tools"
+EXTRADEPS_tegra210 = ""
+RDEPENDS_${PN} += "${EXTRADEPS}"

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
@@ -42,7 +42,8 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-mount "$devnam" "$mnt"
+# Support delta updates by mounting the rootfs read only.
+mount -o ro "$devnam" "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
@@ -6,7 +6,7 @@ COPY_MACHINE_ID=@COPY_MACHINE_ID@
 
 cleanup() {
     [ -n "$mnt" ] || return
-    for d in sys proc dev; do
+    for d in sys proc dev run; do
 	if mountpoint -q "${mnt}/${d}"; then
 	    umount "${mnt}/${d}" >/dev/null 2>&1 || true
 	fi
@@ -42,7 +42,8 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-mount "$devnam" "$mnt"
+# Use a read only mount for compatiblity with delta updates
+mount -o ro "$devnam" "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup
@@ -53,12 +54,14 @@ fi
 mount --bind /sys "${mnt}/sys"
 mount --bind /proc "${mnt}/proc"
 mount --bind /dev "${mnt}/dev"
+# Mount an overlay for /var/run so the /var/lib/nv_boot_control.conf symlink becomes writable
+mount -t tmpfs tmpfs ${mnt}/run
+
 # Run the update engine in the context of the just-installed rootfs
 # to ensure that the TNSPEC in the config file it uses matches the
 # TNSPEC in the update payload.  But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
-    rm "${mnt}/etc/nv_boot_control.conf"
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
 	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi
@@ -70,6 +73,8 @@ if ! chroot "${mnt}" /usr/sbin/nv_update_engine --install no-reboot; then
 fi
 echo "Successful bootloader update"
 if [ -n "$COPY_MACHINE_ID" -a -f /etc/machine-id -a -f "${mnt}/etc/machine-id" ]; then
+    echo "Copying machine ID, this will break delta update support."
+    mount -oremount,rw ${mnt}
     cp /etc/machine-id "${mnt}/etc/machine-id"
     echo "Copied current /etc/machine-id to new rootfs"
 fi

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script
@@ -42,8 +42,7 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-# Use a read only mount for compatiblity with delta updates
-mount -o ro "$devnam" "$mnt"
+mount "$devnam" "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup
@@ -54,14 +53,13 @@ fi
 mount --bind /sys "${mnt}/sys"
 mount --bind /proc "${mnt}/proc"
 mount --bind /dev "${mnt}/dev"
-# Mount an overlay for /var/run so the /var/lib/nv_boot_control.conf symlink becomes writable
-mount -t tmpfs tmpfs ${mnt}/run
-
+mount -t tmpfs tmpfs "${mnt}/run"
 # Run the update engine in the context of the just-installed rootfs
 # to ensure that the TNSPEC in the config file it uses matches the
 # TNSPEC in the update payload.  But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
+    mkdir -p "${mnt}/run/tegra-nv-bootctrl"
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
 	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi
@@ -72,11 +70,13 @@ if ! chroot "${mnt}" /usr/sbin/nv_update_engine --install no-reboot; then
     exit 1
 fi
 echo "Successful bootloader update"
-if [ -n "$COPY_MACHINE_ID" -a -f /etc/machine-id -a -f "${mnt}/etc/machine-id" ]; then
-    echo "Copying machine ID, this will break delta update support."
-    mount -oremount,rw ${mnt}
-    cp /etc/machine-id "${mnt}/etc/machine-id"
-    echo "Copied current /etc/machine-id to new rootfs"
+if [ -n "$COPY_MACHINE_ID" ]; then
+    curid=$(systemd-machine-id-setup --print)
+    storedid=$(chroot "${mnt}" /usr/bin/tegra-bootinfo -n -v machine_id 2>/dev/null)
+    if [ "$curid" != "$storedid" ]; then
+	chroot "${mnt}" /usr/bin/tegra-bootinfo --initialize 2>/dev/null
+	chroot "${mnt}" /usr/bin/tegra-bootinfo -V machine_id "$curid"
+    fi
 fi
 cleanup
 exit 0

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -4,7 +4,7 @@ mnt=
 
 cleanup() {
     [ -n "$mnt" ] || return
-    for d in sys proc dev; do
+    for d in sys proc dev var/lib var/volatile; do
 	if mountpoint -q "${mnt}/${d}"; then
 	    umount "${mnt}/${d}" >/dev/null 2>&1 || true
 	fi
@@ -35,7 +35,7 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
-mount /dev/mmcblk0p${new_boot_part} "$mnt"
+mount -o ro /dev/mmcblk0p${new_boot_part} "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2
     cleanup
@@ -46,12 +46,16 @@ fi
 mount --bind /sys "${mnt}/sys"
 mount --bind /proc "${mnt}/proc"
 mount --bind /dev "${mnt}/dev"
+
+# Mount an overlay for /var/lib so the /var/lib/nv_boot_control.conf file becomes writable
+mount -t tmpfs tmpfs ${mnt}/var/volatile
+mount-copybind ${mnt}/var/volatile/lib ${mnt}/var/lib/
+
 # Run the update engine in the context of the just-installed rootfs
 # to ensure that the TNSPEC in the config file it uses matches the
 # TNSPEC in the update payload. But first we have to set up the
 # configuration file with the TNSPEC.
 if [ -L "${mnt}/etc/nv_boot_control.conf" -a -x "${mnt}/usr/bin/setup-nv-boot-control" ]; then
-    rm "${mnt}/etc/nv_boot_control.conf"
     if ! chroot "${mnt}" /usr/bin/setup-nv-boot-control; then
 	echo "ERR: could not initialize nv_boot_control.conf in new rootfs" >&2
     fi

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -35,6 +35,7 @@ if [ -z "$mnt" -o ! -d "$mnt" ]; then
     echo "ERR: could not create directory for mounting install partition" >&2
     exit 1
 fi
+# Support delta updates by mounting the rootfs read only
 mount -o ro /dev/mmcblk0p${new_boot_part} "$mnt"
 if [ ! -d "${mnt}/opt/ota_package" ]; then
     echo "ERR: Missing /opt/ota_package directory in installed rootfs" >&2

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script-uboot
@@ -4,7 +4,7 @@ mnt=
 
 cleanup() {
     [ -n "$mnt" ] || return
-    for d in sys proc dev var/lib var/volatile; do
+    for d in sys proc dev run; do
 	if mountpoint -q "${mnt}/${d}"; then
 	    umount "${mnt}/${d}" >/dev/null 2>&1 || true
 	fi
@@ -46,10 +46,8 @@ fi
 mount --bind /sys "${mnt}/sys"
 mount --bind /proc "${mnt}/proc"
 mount --bind /dev "${mnt}/dev"
-
-# Mount an overlay for /var/lib so the /var/lib/nv_boot_control.conf file becomes writable
-mount -t tmpfs tmpfs ${mnt}/var/volatile
-mount-copybind ${mnt}/var/volatile/lib ${mnt}/var/lib/
+# Mount an overlay for /var/run so the /var/lib/nv_boot_control.conf symlink becomes writable
+mount -t tmpfs tmpfs ${mnt}/run
 
 # Run the update engine in the context of the just-installed rootfs
 # to ensure that the TNSPEC in the config file it uses matches the

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_%.bbappend
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_%.bbappend
@@ -1,0 +1,1 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"


### PR DESCRIPTION
This PR replaces https://github.com/mendersoftware/meta-mender-community/pull/208 and incorporates changes from @madisongh in https://github.com/OE4T/tegra-demo-distro/pull/31 to support read only rootfs mounts on both uboot and cboot tegra configurations during mender update, including persistent machine-id across updates in cboot.

Mender delta updates have not been specifically tested on cboot or uboot configurations with this PR but should be supported.