### PR TITLE
Remove artifact name for imx6ull

### DIFF
--- a/meta-mender-toradex-nxp/templates/local.conf.append.colibri-imx6ull
+++ b/meta-mender-toradex-nxp/templates/local.conf.append.colibri-imx6ull
@@ -16,7 +16,6 @@ MENDER_MTDIDS = "nand0=gpmi-nand"
 MENDER_MTDPARTS = "gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,-(ubi)"
 
 
-MENDER_ARTIFACT_NAME_colibri-imx6ull = "xpac-mender"
 MENDER_STORAGE_TOTAL_SIZE_MB_colibri-imx6ull = "512"
 MENDER_STORAGE_PEB_SIZE_colibri-imx6ull = "131072"
 


### PR DESCRIPTION
I'm assuming @rickyricksanchez used this snippet from my [mender hub topic](https://hub.mender.io/t/ubifs-ecc-errors-after-adding-mender-to-toradex-imx6ull-image/1767) about a year ago, and it got merged in #205.

I don't believe there's a functional need for the name to be there, as it's already set to `release-1` in the main local.conf.append anyways. 