### PR TITLE
Add meta openembedded to beaglebone

### DIFF
--- a/meta-mender-beaglebone/scripts/manifest-beaglebone.xml
+++ b/meta-mender-beaglebone/scripts/manifest-beaglebone.xml
@@ -2,8 +2,10 @@
 <manifest>
 
   <remote fetch="https://git.yoctoproject.org/git" name="yocto"/>
+  <remote fetch="https://github.com/openembedded"  name="oe"/>
 
   <project name="poky" remote="yocto" revision="dunfell" path="sources/poky"/>
+  <project name="meta-openembedded" remote="oe" revision="dunfell" path="sources/meta-openembedded"/>
 
   <include name="scripts/mender.xml"/>
 

--- a/meta-mender-beaglebone/templates/bblayers.conf.sample
+++ b/meta-mender-beaglebone/templates/bblayers.conf.sample
@@ -12,4 +12,5 @@ BBLAYERS ?= " \
   ${TOPDIR}/../sources/meta-mender/meta-mender-core \
   ${TOPDIR}/../sources/meta-mender/meta-mender-demo \
   ${TOPDIR}/../sources/meta-mender-community/meta-mender-beaglebone \
+  ${TOPDIR}/../sources/meta-openembedded/meta-oe \
 "


### PR DESCRIPTION
This is the requirement to build mender demo images which require `jq`.