### PR TITLE
Remove maintainers from readme

### DIFF
--- a/meta-mender-atmel/README.md
+++ b/meta-mender-atmel/README.md
@@ -46,11 +46,3 @@ MACHINE=sama5d27-som1-ek-sd bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer are:
-
-- Pierre-Jean Texier - <texier.pj2@gmail.com> - [texierp](https://github.com/texierp)
-- Joris Offouga - <offougajoris@gmail.com> - [jorisoffouga](https://github.com/jorisoffouga)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-beaglebone/README.md
+++ b/meta-mender-beaglebone/README.md
@@ -45,11 +45,3 @@ bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Marek Belisko - <marek.belisko@gmail.com> - [nandra](https://github.com/nandra)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-coral/README.md
+++ b/meta-mender-coral/README.md
@@ -44,10 +44,3 @@ MACHINE=coral-dev bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-intel/README.md
+++ b/meta-mender-intel/README.md
@@ -52,11 +52,3 @@ bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Drew Moseley - <drew.moseley@northern.tech> - [drewmoseley](https://github.com/drewmoseley)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-nxp/README.md
+++ b/meta-mender-nxp/README.md
@@ -54,11 +54,3 @@ MACHINE=imx7s-warp bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer are:
-
-- Pierre-Jean Texier - <texier.pj2@gmail.com> - [texierp](https://github.com/texierp)
-- Joris Offouga - <offougajoris@gmail.com> - [jorisoffouga](https://github.com/jorisoffouga)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-odroid/README.md
+++ b/meta-mender-odroid/README.md
@@ -44,10 +44,3 @@ MACHINE=odroid-c2 bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-qemu/README.md
+++ b/meta-mender-qemu/README.md
@@ -51,10 +51,3 @@ bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -51,11 +51,3 @@ MACHINE=raspberrypi3 bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Drew Moseley - <drew.moseley@northern.tech> - [drewmoseley](https://github.com/drewmoseley)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-sunxi/README.md
+++ b/meta-mender-sunxi/README.md
@@ -51,11 +51,3 @@ MACHINE=orange-pi-zeo bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Marek Belisko - <marek.belisko@gmail.com> - [nandra](https://github.com/nandra)
-
-Always include the maintainers when suggesting code changes to this layer. Mender integration for SUNXI boards

--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -39,14 +39,6 @@ See the mender hub pages and the documentation for the `tegrademo-mender`
 distro on the [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) repository
 for the most up to date instructions on starting out with mender and tegra.
 
-## Maintainer
-
-The author and maintainer of this layer is:
-
-- Dan Walkes - <danwalkes@trellis-logic.com> - [dwalkes](https://github.com/dwalkes)
-
-Always include the maintainers when suggesting code changes to this layer.
-
 ## Acknowlegements
 
 Special thanks to [Matt Madison](https://github.com/madisongh) for his contributions to

--- a/meta-mender-toradex-nxp/README.md
+++ b/meta-mender-toradex-nxp/README.md
@@ -73,12 +73,3 @@ MACHINE=colibri-imx6ull bitbake tdx-reference-minimal-image
 - Current mender integration uses ubi volumes to store the redundant environment, this is why the regular u-boot-env partition has been removed from the MTDPARTS
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Drew Moseley - <drew.moseley@toradex.com> - [drewmoseley](https://github.com/drewmoseley)
-- Ricardo Sanchez - <ricardo.sanchez@aerin.es>
-- Adrian Antonana - <adrian.antonana@plating.de>
-
-Always include the maintainers when suggesting code changes to this layer.


### PR DESCRIPTION
Maintainers list as well as the responsibilities will now lives in the wiki.
https://github.com/mendersoftware/meta-mender-community/wiki/Community-maintainers

[Zeus port](https://github.com/mendersoftware/meta-mender-community/pull/239)
[Warrior port](https://github.com/mendersoftware/meta-mender-community/pull/240)

FYI
I've manually run the sed script to remove it on every branch, had some cherry-pick conflicts which weren't worth the manual work.