### PR TITLE
Remove maintainer from readme

### DIFF
--- a/meta-mender-atmel/README.md
+++ b/meta-mender-atmel/README.md
@@ -46,11 +46,3 @@ MACHINE=sama5d27-som1-ek-sd bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer are:
-
-- Pierre-Jean Texier - <pjtexier@koncepto.io> - [texierp](https://github.com/texierp)
-- Joris Offouga - <offougajoris@gmail.com> - [jorisoffouga](https://github.com/jorisoffouga)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-coral/README.md
+++ b/meta-mender-coral/README.md
@@ -44,10 +44,3 @@ MACHINE=coral-dev bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-imx/README.md
+++ b/meta-mender-imx/README.md
@@ -65,10 +65,3 @@ To contribute to the development of this BSP and/or submit patches for new board
   Path: sources/meta-mender-community/meta-mender-imx  
   GIT: https://github.com/mendersoftware/meta-mender-community.git
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer is(are):
-
-- Daniel Selvan D - <daniel.selvan@jasmin-infotech.com> - [danie007](https://github.com/danie007)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-nxp/README.md
+++ b/meta-mender-nxp/README.md
@@ -53,11 +53,3 @@ MACHINE=imx7s-warp bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author(s) and maintainer(s) of this layer are:
-
-- Pierre-Jean Texier - <pjtexier@koncepto.io> - [texierp](https://github.com/texierp)
-- Joris Offouga - <offougajoris@gmail.com> - [jorisoffouga](https://github.com/jorisoffouga)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-odroid/README.md
+++ b/meta-mender-odroid/README.md
@@ -44,10 +44,3 @@ MACHINE=odroid-c2 bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-raspberrypi/README.md
+++ b/meta-mender-raspberrypi/README.md
@@ -51,11 +51,3 @@ MACHINE=raspberrypi3 bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Drew Moseley - <drew.moseley@northern.tech> - [drewmoseley](https://github.com/drewmoseley)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-sunxi/README.md
+++ b/meta-mender-sunxi/README.md
@@ -51,11 +51,3 @@ MACHINE=orange-pi-zeo bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Mirza Krak - <mirza.krak@northern.tech> - [mirzak](https://github.com/mirzak)
-- Marek Belisko - <marek.belisko@gmail.com> - [nandra](https://github.com/nandra)
-
-Always include the maintainers when suggesting code changes to this layer. Mender integration for SUNXI boards

--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -51,10 +51,3 @@ MACHINE=jetson-nano bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The author and maintainer of this layer is:
-
-- Dan Walkes - <danwalkes@trellis-logic.com> - [dwalkes](https://github.com/dwalkes)
-
-Always include the maintainers when suggesting code changes to this layer.

--- a/meta-mender-variscite/README.md
+++ b/meta-mender-variscite/README.md
@@ -59,10 +59,3 @@ bitbake core-image-base
 ```
 
 
-## Maintainer
-
-The authors and maintainers of this layer are:
-
-- Drew Moseley - <drew.moseley@northern.tech> - [drewmoseley](https://github.com/drewmoseley)
-
-Always include the maintainers when suggesting code changes to this layer.


### PR DESCRIPTION
Maintainers list as well as the responsibilities will now lives in the wiki.
https://github.com/mendersoftware/meta-mender-community/wiki/Community-maintainers