### PR TITLE
mender-tezi: Move sanity checks into an event handler.

### DIFF
--- a/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
+++ b/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
@@ -15,10 +15,6 @@ FULL_IMAGE_SUFFIX_mender-image-ubi = "ubimg"
 FULL_IMAGE_SUFFIX_mender-image-uefi = "uefiimg"
 FULL_IMAGE_SUFFIX_mender-image-bios = "biosimg"
 FULL_IMAGE_SUFFIX_mender-image-gpt = "gptimg"
-python () {
-   if d.getVar('FULL_IMAGE_SUFFIX') == "":
-       bb.fatal("Unable to determine FULL_IMAGE_SUFFIX for use with mender_tezi images.")
-}
 
 # Do not include these image types:
 IMAGE_FSTYPES_remove = "${SOC_DEFAULT_IMAGE_FSTYPES} tar.xz"
@@ -27,14 +23,6 @@ WKS_FILE_DEPENDS_append = " mender-tezi-metadata "
 
 do_image_mender_tezi[recrdeptask] += "do_deploy"
 RM_WORK_EXCLUDE += "${PN}"
-
-python() {
-  menderOffset = d.getVar("MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET")
-  bootromPayload = d.getVar("OFFSET_BOOTROM_PAYLOAD")
-  if (menderOffset != None) and (bootromPayload != None) and (menderOffset != bootromPayload):
-      bb.fatal("Error.  MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET (%s) != OFFSET_BOOTROM_PAYLOAD (%s)" % \
-                  (d.getVar("MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET"), d.getVar("OFFSET_BOOTROM_PAYLOAD")))
-}
 
 def rootfs_mender_tezi_emmc(d):
     from collections import OrderedDict

--- a/meta-mender-toradex-nxp/classes/mender-toradex.bbclass
+++ b/meta-mender-toradex-nxp/classes/mender-toradex.bbclass
@@ -8,3 +8,16 @@ toradex_mender_update_fstab_file() {
     grep -v /dev/boot-part ${IMAGE_ROOTFS}${sysconfdir}/fstab > ${IMAGE_ROOTFS}${sysconfdir}/fstab.toradex
     mv ${IMAGE_ROOTFS}${sysconfdir}/fstab.toradex ${IMAGE_ROOTFS}${sysconfdir}/fstab
 }
+
+addhandler mender_tezi_sanity_handler
+mender_tezi_sanity_handler[eventmask] = "bb.event.ParseCompleted"
+python mender_tezi_sanity_handler() {
+  if d.getVar('FULL_IMAGE_SUFFIX') == "":
+    bb.fatal("Unable to determine FULL_IMAGE_SUFFIX for use with mender_tezi images.")
+
+  menderOffset = d.getVar("MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET")
+  bootromPayload = d.getVar("OFFSET_BOOTROM_PAYLOAD")
+  if (menderOffset != None) and (bootromPayload != None) and (menderOffset != bootromPayload):
+    bb.fatal("Error.  MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET (%s) != OFFSET_BOOTROM_PAYLOAD (%s)" % \
+             (d.getVar("MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET"), d.getVar("OFFSET_BOOTROM_PAYLOAD")))
+}


### PR DESCRIPTION
When using a combination of multiconfig and bbmask to enable builds both
with and without Mender in a single build dir, the existing sanity checks
would run even if all the Mender layers were masked out since they happened
at part time.  Moving them into an event handler allows them to be run
only when building with the Mender multiconfig.

Changelog: Title
Signed-off-by: Drew Moseley <drew@moseleynet.net>