### PR TITLE
Toradex Apalis IMX8 display overlay support

### DIFF
--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/apalis-imx8/boot.cmd.in
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/apalis-imx8/boot.cmd.in
@@ -1,0 +1,64 @@
+#
+# Copyright 2020 Toradex
+#
+# Toradex boot script.
+#
+# Only supports booting from mmc.
+
+if test ${devtype} != "mmc"; then
+    echo "This script is not meant to distro boot from anything other than mmc."
+    exit
+fi
+
+env set load_prefix 'boot/'
+
+test -n ${m4boot} || env set m4boot ';'
+test -n ${fdtfile} || env set fdtfile ${fdt_file}
+test -n ${kernel_image} || env set kernel_image @@KERNEL_IMAGETYPE@@
+test -n ${overlays_file} || env set overlays_file "overlays.txt"
+test -n ${overlays_prefix} || env set overlays_prefix "overlays/"
+
+env set load_cmd 'load ${mender_uboot_root}'
+env set load_cmd_boot 'load ${mender_uboot_boot}'
+env set root_devtype ${devtype}
+
+if test -n ${setup}; then
+    run setup
+else
+    env set setupargs 'console=${console},${baudrate} console=tty1 consoleblank=0'
+fi
+
+if test ${kernel_image} = "Image.gz"
+then
+    env set kernel_addr_load ${loadaddr}
+    env set bootcmd_unzip 'unzip ${kernel_addr_load} ${kernel_addr_r}'
+else
+    env set bootcmd_unzip ';'
+    env set kernel_addr_load ${kernel_addr_r}
+fi
+
+# Set dynamic commands
+env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${load_prefix}\\${kernel_image}"'
+env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${load_prefix}\\${fdtfile}"'
+env set set_load_overlays_file 'env set load_overlays_file "${load_cmd_boot} \\${loadaddr} \\${overlays_file}; env import -t \\${loadaddr} \\${filesize}"'
+env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
+env set set_apply_overlays 'env set apply_overlays "for overlay_file in \\${fdt_overlays}; do echo Applying Overlay: \\${overlay_file} && ${load_cmd_boot} \\${loadaddr} \\${overlays_prefix}\\${overlay_file} && fdt apply \\${loadaddr}; env set overlay_file; done; true"'
+env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && booti ${kernel_addr_r} - ${fdt_addr_r}'
+
+# Set static commands
+env set rootfsargs_set 'env set rootfsargs root=${mender_kernel_root} ro rootwait'
+
+env set bootcmd_args 'run rootfsargs_set && env set bootargs ${defargs} ${rootfsargs} ${setupargs} ${vidargs} ${tdxargs}'
+if test ${skip_fdt_overlays} != 1; then
+    env set bootcmd_overlays 'run load_overlays_file && run fdt_resize && run apply_overlays'
+else
+    env set bootcmd_overlays true
+fi
+env set bootcmd_prepare 'run set_bootcmd_kernel; run set_bootcmd_dtb; run set_load_overlays_file; run set_apply_overlays'
+env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_overlays && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!" && false'
+
+run mender_setup
+run bootcmd_prepare
+run bootcmd_run
+run mender_try_to_recover
+

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/colibri-imx6ull/boot.cmd.in
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/colibri-imx6ull/boot.cmd.in
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: GPL-2.0+ OR MIT
+#
+# Copyright 2020 Toradex
+# Copyright 2020 Northern.tech AS
+#
+# Toradex boot script with Mender integration.
+#
+# Only supports booting from mmc, and overlay support is removed as this only
+# applies to Torizon OS which is not the target for this integration.
+
+if test ${devtype} = "ubi"; then
+    echo "This script is not meant to distro boot from raw NAND flash."
+    exit
+fi
+
+env set load_prefix 'boot/'
+
+test -n ${m4boot} || env set m4boot ';'
+test -n ${fdtfile} || env set fdtfile ${fdt_file}
+test -n ${kernel_image} || env set kernel_image @@KERNEL_IMAGETYPE@@
+test -n ${boot_devtype} || env set boot_devtype ${devtype}
+test -n ${root_devtype} || env set root_devtype ${devtype}
+
+env set load_cmd 'load ${mender_uboot_root}'
+
+if test -n ${setup}; then
+    run setup
+else
+    env set setupargs 'console=${console},${baudrate} console=tty1 consoleblank=0'
+fi
+
+if test ${kernel_image} = "Image.gz"
+then
+    env set kernel_addr_load ${loadaddr}
+    env set bootcmd_unzip 'unzip ${kernel_addr_load} ${kernel_addr_r}'
+else
+    env set kernel_addr_load ${kernel_addr_r}
+    env set bootcmd_unzip ';'
+fi
+
+# Set dynamic commands
+env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${load_prefix}\\${kernel_image}"'
+env set set_bootcmd_dtb 'env set bootcmd_dtb "${load_cmd} \\${fdt_addr_r} \\${load_prefix}\\${fdtfile}"'
+
+env set rootfsargs_set 'env set rootfsargs root=${mender_kernel_root} ro rootwait'
+
+env set bootcmd_args 'run rootfsargs_set && env set bootargs ${defargs} ${rootfsargs} ${setupargs} ${vidargs} ${tdxargs}'
+env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
+env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && @@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}'
+env set bootcmd_prepare 'run set_bootcmd_kernel; run set_bootcmd_dtb;'
+env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!"'
+
+run bootcmd_prepare
+run mender_setup
+run bootcmd_run
+run mender_try_to_recover


### PR DESCRIPTION
Update u-boot-distro-boot to support overlays, enabling display
support on the Apalis IMX8.

Signed-off-by: pagi <paul.giangrossi@qamcom.se>