### PR TITLE
Upgrade intel manifest to dunfell.

### DIFF
--- a/meta-mender-intel/scripts/manifest-intel.xml
+++ b/meta-mender-intel/scripts/manifest-intel.xml
@@ -3,8 +3,8 @@
 
   <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
 
-  <project name="poky" remote="yocto" revision="zeus" path="sources/poky"/>
-  <project name="meta-intel" remote="yocto" revision="zeus" path="sources/meta-intel"/>
+  <project name="poky" remote="yocto" revision="dunfell" path="sources/poky"/>
+  <project name="meta-intel" remote="yocto" revision="dunfell" path="sources/meta-intel"/>
 
   <include name="scripts/mender.xml"/>
 


### PR DESCRIPTION
In the dunfell branch, these revisions should be pointing to dunfell, right?