### PR TITLE
Support Jetpack 4.6

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-xavier-nx-devkit-emmc/flash_mender.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/mender-custom-flash-layout/jetson-xavier-nx-devkit-emmc/flash_mender.xml
@@ -214,7 +214,7 @@
             <description> **Required.** Slot B; contains slot status for A/B boot and A/B
               update. </description>
         </partition>
-        <partition name="xusb-fw" type="xusb_fw">
+        <partition name="xusb-fw" type="xusb_fw" oem_sign="true">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>
@@ -226,7 +226,7 @@
             <description> **Required.** Slot A; contains XUSB module’s firmware file, making XUSB
               a true USB 3.0 compliant host controller. </description>
         </partition>
-        <partition name="xusb-fw_b" type="xusb_fw">
+        <partition name="xusb-fw_b" type="xusb_fw" oem_sign="true">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 196608 </size>


### PR DESCRIPTION
For this to work with OpenEmbedded4Tegra, as per the [release notes for L4T 32.6.1](https://github.com/OE4T/meta-tegra/wiki/L4T-R32.6.1-Notes#flash-layout-file-changes-for-t194-xavier-platforms)

> The flash layout XML files for the Xavier platforms in the L4T BSP have been modified to include new attributes (but no location/size changes). In particular, the xusb-fw partition is now marked oem_signed="true", as cboot now performs signature validation on the USB controller firmware.

I've added that in the file to have `meta-mender-community` still build for Jetpack 4.6 targets.