### PR TITLE
Fix mender build for toradex colibri-im6ull module.

### DIFF
--- a/meta-mender-toradex-nxp/README.md
+++ b/meta-mender-toradex-nxp/README.md
@@ -65,7 +65,7 @@ MACHINE=verdin-imx8mm bitbake tdx-reference-minimal-image
 
 ## For colibri-imx6ull use the following procedure
 ```
-cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append.colibri-imx6ull >> conf/local.conf
+cat ../layers/meta-mender-community/meta-mender-toradex-nxp/templates/local.conf.append  >> conf/local.conf
 
 MACHINE=colibri-imx6ull bitbake tdx-reference-minimal-image
 ```

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -36,6 +36,9 @@ MENDER_STORAGE_PEB_SIZE_colibri-imx6ull = "131072"
 MKUBIFS_ARGS_colibri-imx6ull = "-m ${MENDER_FLASH_MINIMUM_IO_UNIT} -e ${MENDER_UBI_LEB_SIZE} -c ${MENDER_MAXIMUM_LEB_COUNT} --space-fixup"
 MENDER_FEATURES_ENABLE_remove_colibri-imx6ull = " mender-image-sd mender-image-grub mender-image-uefi"
 MENDER_FEATURES_DISABLE_append_colibri-imx6ull = " mender-grub mender-image-uefi mender-image-sd"
+MENDER_RESERVED_SPACE_BOOTLOADER_DATA_colibri-imx6ull ="0x40000"
+MENDER_DATA_PART_SIZE_MB_colibri-imx6ull = "16"
+
 #
 # Settings for apalis-imx8
 #


### PR DESCRIPTION
- Include missing variables in meta-mender-toradex-nxp/templates/local.conf.append
- Update README.md to describe current procedure for adding configuration to local.conf

At some point a cleanup was done on the git repository and two critical variables were not added to the final configuration:
MENDER_RESERVED_SPACE_BOOTLOADER_DATA_colibri-imx6ull ="0x40000"
MENDER_DATA_PART_SIZE_MB_colibri-imx6ull = "16"

Without these settings the build doesn't boot when flashed as the volume u-boot-env is not present in the final image.