### PR TITLE
meta-mender-intel: change README.md to dunfell

### DIFF
--- a/meta-mender-intel/README.md
+++ b/meta-mender-intel/README.md
@@ -23,14 +23,14 @@ This layer depends on:
 
 ```
 URI: https://git.yoctoproject.org/git/meta-intel
-branch: zeus
+branch: dunfell
 revision: HEAD
 ```
 
 ```
 URI: https://github.com/mendersoftware/meta-mender.git
 layers: meta-mender-core
-branch: zeus
+branch: dunfell
 revision: HEAD
 ```
 
@@ -45,7 +45,7 @@ that have Mender integrated.
 mkdir mender-intel && cd mender-intel
 repo init -u https://github.com/mendersoftware/meta-mender-community \
            -m meta-mender-intel/scripts/manifest-intel.xml \
-           -b zeus
+           -b dunfell
 repo sync
 source setup-environment intel
 bitbake core-image-base


### PR DESCRIPTION
In a few spots in the README, zeus was still called out.

Signed-off-by: Tim Orling <tim.orling@konsulko.com>