### PR TITLE
Change repo sync manifest form ssh to https

### DIFF
--- a/meta-mender-atmel/scripts/manifest-atmel.xml
+++ b/meta-mender-atmel/scripts/manifest-atmel.xml
@@ -2,8 +2,8 @@
   <manifest>
   <default sync-j="4" revision="dunfell"/>
 
-  <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
-  <remote fetch="git://github.com/linux4sam"        name="atmel"/>
+  <remote fetch="https://git.yoctoproject.org"        name="yocto"/>
+  <remote fetch="https://github.com/linux4sam"        name="atmel"/>
   <remote fetch="https://github.com/openembedded"   name="oe"/>
 
   <project name="poky" remote="yocto" revision="dunfell" path="sources/poky"/>


### PR DESCRIPTION
Changelog: There was a recent change to the repo configuration for metal atmel
and does not allows ssh connections, only https.

Signed-off-by: Jaime Arrocha <jarrocha.dev@gmail.com>