### PR TITLE
Speed up installation

### DIFF
--- a/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
+++ b/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
@@ -2,11 +2,11 @@
 # Based largely on meta-toradex-bsp-common/classes/image_type_tezi.bbclass
 
 # Make sure the full Mender multi-partition image is available
-IMAGE_TYPEDEP_mender_tezi_append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg.bz2', '', d)} \
-                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'ubimg', ' ubimg.bz2', '', d)} \
-                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'gptimg', ' gptimg.bz2', '', d)} \
-                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg.bz2', '', d)} \
-                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg.bz2', '', d)}"
+IMAGE_TYPEDEP_mender_tezi_append = "${@bb.utils.contains('IMAGE_FSTYPES', 'sdimg', ' sdimg', '', d)} \
+                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'ubimg', ' ubimg', '', d)} \
+                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'gptimg', ' gptimg', '', d)} \
+                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'uefiimg', ' uefiimg', '', d)} \
+                                       ${@bb.utils.contains('IMAGE_FSTYPES', 'biosimg', ' biosimg', '', d)}"
 
 # Figure out what type of image we are basing this on
 FULL_IMAGE_SUFFIX = ""
@@ -53,7 +53,7 @@ def rootfs_mender_tezi_emmc(d):
                   "rawfiles": [
                       {
                           "dd_options": "bs=8M",
-                          "filename": "%s.%s.bz2" % (imagename, image_suffix)
+                          "filename": "%s.%s" % (imagename, image_suffix)
                       }
                   ]
               }
@@ -103,7 +103,7 @@ def rootfs_mender_tezi_rawnand(d):
           "content": {
             "rawfile": {
               "dd_options": "bs=8M",
-              "filename": "%s.%s.bz2" % (d.getVar("IMAGE_LINK_NAME"), d.getVar("FULL_IMAGE_SUFFIX"))
+              "filename": "%s.%s" % (d.getVar("IMAGE_LINK_NAME"), d.getVar("FULL_IMAGE_SUFFIX"))
             }
           }
         })
@@ -158,7 +158,7 @@ IMAGE_CMD_mender_tezi () {
 		     -chf ${IMGDEPLOYDIR}/${IMAGE_NAME}.mender_tezi.tar \
 		     ${WORKDIR}/image-json/image.json ${DEPLOY_DIR_IMAGE}/mender-tezi-metadata/* \
 		     $uboot_files \
-		     ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${FULL_IMAGE_SUFFIX}.bz2
+		     ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${FULL_IMAGE_SUFFIX}
     ln -sf ${IMAGE_NAME}.mender_tezi.tar ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mender_tezi.tar
 }
 do_image_mender_tezi[dirs] += "${WORKDIR}/image-json ${DEPLOY_DIR_IMAGE}"

--- a/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
+++ b/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
@@ -52,6 +52,7 @@ def rootfs_mender_tezi_emmc(d):
               "content": {
                   "rawfiles": [
                       {
+                          "dd_options": "bs=8M",
                           "filename": "%s.%s.bz2" % (imagename, image_suffix)
                       }
                   ]
@@ -101,6 +102,7 @@ def rootfs_mender_tezi_rawnand(d):
           "name": "ubi",
           "content": {
             "rawfile": {
+              "dd_options": "bs=8M",
               "filename": "%s.%s.bz2" % (d.getVar("IMAGE_LINK_NAME"), d.getVar("FULL_IMAGE_SUFFIX"))
             }
           }


### PR DESCRIPTION
These two changes make a huge difference in some cases. I have an image that I am installing using Toradex Easy Installer on an apalis-im6. Before these changes, the install took about 30 min.  After this change it was about 6 min.
