### PR TITLE
Allow configuration of TEZI image.json properties.

### DIFF
--- a/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
+++ b/meta-mender-toradex-nxp/classes/image_type_mender_tezi.bbclass
@@ -16,6 +16,9 @@ FULL_IMAGE_SUFFIX_mender-image-uefi = "uefiimg"
 FULL_IMAGE_SUFFIX_mender-image-bios = "biosimg"
 FULL_IMAGE_SUFFIX_mender-image-gpt = "gptimg"
 
+TEZI_AUTO_INSTALL ??= "false"
+TEZI_CONFIG_FORMAT ??= "2"
+
 # Do not include these image types:
 IMAGE_FSTYPES_remove = "${SOC_DEFAULT_IMAGE_FSTYPES} tar.xz ${FULL_IMAGE_SUFFIX}.bz2"
 
@@ -116,7 +119,7 @@ python rootfs_mender_tezi_json() {
     from collections import OrderedDict
     from datetime import datetime
 
-    data = OrderedDict({ "config_format": 2, "autoinstall": False })
+    data = OrderedDict({ "config_format": d.getVar('TEZI_CONFIG_FORMAT'), "autoinstall": oe.types.boolean(d.getVar('TEZI_AUTO_INSTALL')) })
 
     data["name"] = d.getVar('SUMMARY')
     data["description"] = d.getVar('DESCRIPTION')


### PR DESCRIPTION
Allow configuration of image.json "config_format" and "autoinstall"
properties.

Code taken from image_type_tezi.bbclass: It allows user to change these
settings via .conf file if required by using the following variables:
TEZI_AUTO_INSTALL changes "autoinstall"
TEZI_CONFIG_FORMAT changes "config_format"

Signed-off-by: Jorge Solla <jorgesolla@gmail.com>