### PR TITLE
kirkstone fixes for meta-mender-tegra

### DIFF
--- a/meta-mender-tegra/classes/sanity-meta-mender-tegra.bbclass
+++ b/meta-mender-tegra/classes/sanity-meta-mender-tegra.bbclass
@@ -1,8 +1,0 @@
-addhandler tegra_bbappend_layercheck
-tegra_bbappend_layercheck[eventmask] = "bb.event.SanityCheck"
-python tegra_bbappend_layercheck() {
-    bb.fatal("The layer meta-mender-tegra has been automatically \
-syntax converted and is not validated for kirkstone yet. Please disable \
-this message, verify correct operation and submit a PR removing the \
-sanity check.")
-}

--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -32,9 +32,9 @@ ARTIFACTIMG_FSTYPE = "ext4"
 IMAGE_TYPEDEP:tegraflash += " dataimg"
 IMAGE_FSTYPES += "dataimg"
 PREFERRED_PROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
-PREFERRED_PROVIDER_libubootenv_tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv'}"
+PREFERRED_PROVIDER_libubootenv:tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv'}"
 PREFERRED_RPROVIDER_u-boot-fw-utils = "u-boot-fw-utils-tegra"
-PREFERRED_RPROVIDER_libubootenv-bin_tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv-bin'}"
+PREFERRED_RPROVIDER_libubootenv-bin:tegra = "${@'libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else 'libubootenv-bin'}"
 # Note: this isn't really a boot file, just put it here to keep the mender build from
 # complaining about empty IMAGE_BOOT_FILES.  We won't use the full image anyway, just the mender file
 IMAGE_BOOT_FILES = "u-boot-dtb.bin"
@@ -43,27 +43,27 @@ IMAGE_BOOT_FILES = "u-boot-dtb.bin"
 # You will need to update these partition values when you update the flash layout.  One way to find the correct number is to
 # boot into an emergency shell and examine the /dev/mmcblk* devices,
 # or use the uboot console to look at mtdparts
-MENDER_DATA_PART_NUMBER_DEFAULT_tegra186 = "34"
-MENDER_DATA_PART_NUMBER_DEFAULT_tegra194 = "43"
-MENDER_DATA_PART_NUMBER_DEFAULT_tegra210 = "${@'16' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '23'}"
-MENDER_DATA_PART_NUMBER_DEFAULT_jetson-nano-emmc = "19"
-MENDER_DATA_PART_NUMBER_DEFAULT_xavier-nx = "12"
+MENDER_DATA_PART_NUMBER_DEFAULT:tegra186 = "34"
+MENDER_DATA_PART_NUMBER_DEFAULT:tegra194 = "43"
+MENDER_DATA_PART_NUMBER_DEFAULT:tegra210 = "${@'16' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '23'}"
+MENDER_DATA_PART_NUMBER_DEFAULT:jetson-nano-emmc = "19"
+MENDER_DATA_PART_NUMBER_DEFAULT:xavier-nx = "12"
 MENDER_ROOTFS_PART_A_NUMBER_DEFAULT = "1"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_tegra186 = "33"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_tegra194 = "42"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_tegra210 = "${@'15' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '22'}"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_jetson-nano-emmc = "18"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_xavier-nx = "11"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:tegra186 = "33"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:tegra194 = "42"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:tegra210 = "${@'15' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '22'}"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:jetson-nano-emmc = "18"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:xavier-nx = "11"
 
 # Machine name and flash layout changed for SDcard Nanos in L4T R32.5.x
 MENDER_DATA_PART_NUMBER_DEFAULT_jetson-nano-devkit = "3"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_jetson-nano-devkit = "2"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:jetson-nano-devkit = "2"
 # Machine name changed for Nano-eMMC in L4T R32.5.x
 MENDER_DATA_PART_NUMBER_DEFAULT_jetson-nano-devkit-emmc = "19"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_jetson-nano-devkit-emmc = "18"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:jetson-nano-devkit-emmc = "18"
 # Added in L4T R32.5.x
 MENDER_DATA_PART_NUMBER_DEFAULT_jetson-nano-2gb-devkit = "4"
-MENDER_ROOTFS_PART_B_NUMBER_DEFAULT_jetson-nano-2gb-devkit = "2"
+MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:jetson-nano-2gb-devkit = "2"
 
 # Use a 4096 byte alignment for support of tegraflash scheme and default partition locations
 MENDER_PARTITION_ALIGNMENT = "4096"
@@ -90,8 +90,8 @@ ROOTFSPART_SIZE = "${@tegra_mender_set_rootfs_partsize(${MENDER_CALC_ROOTFS_SIZE
 # Default for thud and later is grub integration but we need to use u-boot integration already included.
 # Leave out sdimg since we don't use this with tegra (instead use
 # tegraflash)
-MENDER_FEATURES_ENABLE:append_tegra = "${@tegra_mender_uboot_feature(d)}"
-MENDER_FEATURES_DISABLE:append_tegra = " mender-grub mender-image-uefi"
+MENDER_FEATURES_ENABLE:append:tegra = "${@tegra_mender_uboot_feature(d)}"
+MENDER_FEATURES_DISABLE:append:tegra = " mender-grub mender-image-uefi"
 
 # Use these variables to adjust your total rootfs size across both
 # images. Rootfs size will be approximately 1/2 of
@@ -122,9 +122,9 @@ def tegra_mender_calc_total_size(d):
 
 MENDER_IMAGE_ROOTFS_SIZE_DEFAULT = "${@tegra_mender_image_rootfs_size(d)}"
 TEGRA_MENDER_RESERVED_SPACE_MB_DEFAULT = "1024"
-TEGRA_MENDER_RESERVED_SPACE_MB_DEFAULT_jetson-nano-2gb-devkit = "5120"
+TEGRA_MENDER_RESERVED_SPACE_MB_DEFAULT:jetson-nano-2gb-devkit = "5120"
 TEGRA_MENDER_RESERVED_SPACE_MB ?= "${TEGRA_MENDER_RESERVED_SPACE_MB_DEFAULT}"
-MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT_tegra = "${@tegra_mender_calc_total_size(d)}"
+MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT:tegra = "${@tegra_mender_calc_total_size(d)}"
 
 def tegra_mender_uboot_feature(d):
     if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot'):
@@ -132,23 +132,23 @@ def tegra_mender_uboot_feature(d):
     return " mender-uboot mender-persist-systemd-machine-id"
 
 _MENDER_IMAGE_DEPS_EXTRA = ""
-_MENDER_IMAGE_DEPS_EXTRA_tegra = "tegra-state-scripts:do_deploy"
+_MENDER_IMAGE_DEPS_EXTRA:tegra = "tegra-state-scripts:do_deploy"
 do_image_mender[depends] += "${_MENDER_IMAGE_DEPS_EXTRA}"
 
 # mender-setup-image adds kernel-image and kernel-devicetree
 # to MACHINE_ESSENTIAL_EXTRA_RDEPENDS, but they should *not*
 # be included by default on cboot platforms.
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove_tegra194 = "kernel-image kernel-devicetree"
-MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove_tegra186 = "${@'kernel-image kernel-devicetree' if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot') else ''}"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:tegra194 = "kernel-image kernel-devicetree"
+MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:tegra186 = "${@'kernel-image kernel-devicetree' if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot') else ''}"
 
 # Compatibility settings for handling the machine name changes
 # made in L4T R32.5.x, to allow for upgrades.  This does not
 # include jetson-nano-qspi-sd (now jetson-nano-devkit) due to
 # major changes in the flash layout.
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-tx1-devkit = " jetson-tx1"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-tx2-devkit = " jetson-tx2"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-tx2-devkit-tx2i = " jetson-tx2i"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-tx2-devkit-4gb = " jetson-tx2-4gb"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-agx-xavier-devkit = " jetson-xavier"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-agx-xavier-devkit-8gb = " jetson-xavier-8gb"
-MENDER_DEVICE_TYPES_COMPATIBLE:append_jetson-nano-devkit-emmc = " jetson-nano-emmc"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-tx1-devkit = " jetson-tx1"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-tx2-devkit = " jetson-tx2"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-tx2-devkit-tx2i = " jetson-tx2i"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-tx2-devkit-4gb = " jetson-tx2-4gb"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-agx-xavier-devkit = " jetson-xavier"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-agx-xavier-devkit-8gb = " jetson-xavier-8gb"
+MENDER_DEVICE_TYPES_COMPATIBLE:append:jetson-nano-devkit-emmc = " jetson-nano-emmc"

--- a/meta-mender-tegra/conf/layer.conf
+++ b/meta-mender-tegra/conf/layer.conf
@@ -10,5 +10,3 @@ BBFILE_PRIORITY_meta-mender-tegra = "10"
 LAYERVERSION_meta-mender-tegra = "1"
 LAYERSERIES_COMPAT_meta-mender-tegra = "kirkstone"
 LAYERDEPENDS_meta-mender-tegra = "tegra"
-
-INHERIT += "sanity-meta-mender-tegra"

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides_1.0.bb
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/redundant-boot-overrides_1.0.bb
@@ -3,7 +3,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
 COMPATIBLE_MACHINE = "(tegra)"
-COMPATIBLE_MACHINE_tegra210 = "(-)"
+COMPATIBLE_MACHINE:tegra210 = "(-)"
 
 SRC_URI = "\
     file://update-nvbootctrl.service.in \

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
@@ -1,4 +1,4 @@
 EXTRADEPS = "redundant-boot-overrides"
-EXTRADEPS_tegra210 = ""
+EXTRADEPS:tegra210 = ""
 RDEPENDS:${PN} += "${EXTRADEPS}"
 

--- a/meta-mender-tegra/recipes-bsp/u-boot/libubootenv_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/u-boot/libubootenv_%.bbappend
@@ -2,12 +2,12 @@ include recipes-bsp/u-boot/u-boot-mender-tegra-vars.inc
 
 # Stash an extra copy of fw_env.config in the rootfs so we
 # can handle a change in the env offset/size during an upgrade
-do_install:append_tegra() {
+do_install:append:tegra() {
     install -d ${D}${datadir}/u-boot
     install -m 0644 ${WORKDIR}/fw_env.config ${D}${datadir}/u-boot/
 }
-FILES:${PN}:append_tegra = " ${datadir}/u-boot"
+FILES:${PN}:append:tegra = " ${datadir}/u-boot"
 
 # The default environment must be provided by the
 # u-boot recipe
-RPROVIDES:${PN}:remove_tegra = "u-boot-default-env"
+RPROVIDES:${PN}:remove:tegra = "u-boot-default-env"

--- a/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init_%.bbappend
+++ b/meta-mender-tegra/recipes-core/initrdscripts/tegra-minimal-init_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 EXTRADEPS = ""
-EXTRADEPS_tegra = "tegra-boot-tools-earlyboot"
-EXTRADEPS_tegra210 = ""
+EXTRADEPS:tegra = "tegra-boot-tools-earlyboot"
+EXTRADEPS:tegra210 = ""
 RDEPENDS:${PN} += "${EXTRADEPS}"

--- a/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
@@ -1,4 +1,4 @@
 EXTRADEPS = ""
-EXTRADEPS_tegra = "tegra-bup-payload tegra-boot-tools tegra-boot-tools-nvbootctrl tegra-boot-tools-lateboot${@' libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
-EXTRADEPS_tegra210 = "tegra-bup-payload tegra-boot-tools"
+EXTRADEPS:tegra = "tegra-bup-payload tegra-boot-tools tegra-boot-tools-nvbootctrl tegra-boot-tools-lateboot${@' libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
+EXTRADEPS:tegra210 = "tegra-bup-payload tegra-boot-tools"
 RDEPENDS:${PN} += "${EXTRADEPS}"

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_1.0.bb
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/tegra-state-scripts_1.0.bb
@@ -22,7 +22,7 @@ copy_install_script() {
     sed -e's,@COPY_MACHINE_ID@,${PERSIST_MACHINE_ID},' ${S}/redundant-boot-install-script > ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
 }
 
-copy_install_script_mender-uboot() {
+copy_install_script:mender-uboot() {
     cp ${S}/redundant-boot-install-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
     cp ${S}/redundant-boot-commit-check-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Enter_80_bl-check-update
 }
@@ -31,15 +31,15 @@ do_compile() {
     :
 }
 
-do_compile_tegra194() {
+do_compile:tegra194() {
     copy_install_script
 }
 
-do_compile_tegra186() {
+do_compile:tegra186() {
     copy_install_script
 }
 
-do_compile_tegra210() {
+do_compile:tegra210() {
     cp ${S}/redundant-boot-install-script-uboot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_80_bl-update
 }
 


### PR DESCRIPTION
This branch includes the following trivial changes:

- manually updates various tegra-related overrides to use BitBake's new syntax
- removes the sanity check

With these changes and those on the `master-next` branch for `meta-mender` provided by @TheYoctoJester, I have built a mender artifact for the TX2 devkit board and successfully updated a board running `dunfell` using that artifact.

I have not tried flashing fresh, but that has lower priority than being able to update our units in the field.  This is a substantial step in the right direction.