### PR TITLE
[dunfell] Change repo sync manifest form git protocol to https

### DIFF
--- a/meta-mender-amlogic/scripts/manifest-amlogic.xml
+++ b/meta-mender-amlogic/scripts/manifest-amlogic.xml
@@ -2,9 +2,9 @@
   <manifest>
   <default sync-j="4" revision="dunfell"/>
 
-  <remote fetch="git://git.yoctoproject.org"        name="yocto"/>
-  <remote fetch="git://git.openembedded.org"        name="oe"/>
-  <remote fetch="git://github.com"		    name="github"/>
+  <remote fetch="https://git.yoctoproject.org"  name="yocto"/>
+  <remote fetch="https://git.openembedded.org"  name="oe"/>
+  <remote fetch="https://github.com"		name="github"/>
 
   <project name="poky" remote="yocto" path="sources/poky"/>
   <project name="meta-openembedded" remote="oe" path="sources/meta-openembedded"/>


### PR DESCRIPTION
GitHub dropped support for the legacy git protocol,
use https instead.

Signed-off-by: Neil Armstrong <narmstrong@baylibre.com>