### PR TITLE
001-Adapt-boot.cmd.in-to-Mender.patch: Fix

### DIFF
--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.4.0/0001-Adapt-boot.cmd.in-to-Mender.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.4.0/0001-Adapt-boot.cmd.in-to-Mender.patch
@@ -1,10 +1,12 @@
---- boot.cmd.in.orig	2021-10-11 17:06:18.461108056 -0400
-+++ boot.cmd.in	2021-10-11 17:10:55.952463767 -0400
-@@ -3,33 +3,9 @@
+--- boot.cmd.in.orig	2022-06-13 07:29:05.128770364 +0000
++++ boot.cmd.in	2022-06-13 15:14:30.754269214 +0000
+@@ -1,35 +1,11 @@
+ # SPDX-License-Identifier: GPL-2.0+ OR MIT
+ #
  # Copyright 2020 Toradex
++# With Mender integration.
  #
  # Toradex boot script.
-+# With Mender integration.
  #
 -# Allows to change boot and rootfs devices independently.
 -# Supports:
@@ -36,7 +38,7 @@
  
  if test ${devtype} = "ubi"; then
      echo "This script is not meant to distro boot from raw NAND flash."
-@@ -38,34 +14,20 @@ fi
+@@ -38,34 +14,20 @@
  
  test -n ${m4boot} || env set m4boot ';'
  test -n ${fdtfile} || env set fdtfile ${fdt_file}
@@ -81,7 +83,7 @@
  
  if test -n ${setup}; then
      run setup
-@@ -79,52 +41,17 @@ then
+@@ -79,52 +41,17 @@
      env set bootcmd_unzip 'unzip ${kernel_addr_load} ${kernel_addr_r}'
  else
      env set bootcmd_unzip ';'
@@ -95,7 +97,7 @@
 -
 -# Set dynamic commands
 -env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${kernel_image}"'
--env set set_load_overlays_file 'env set load_overlays_file "${load_cmd} \\${loadaddr} \\${overlays_file} && env import -t \\${loadaddr} \\${filesize}"'
+-env set set_load_overlays_file 'env set load_overlays_file "${load_cmd} \\${loadaddr} \\${overlays_file}; env import -t \\${loadaddr} \\${filesize}"'
 -if test ${kernel_image} = "fitImage"
 -then
 -    env set fdt_high
@@ -140,6 +142,3 @@
  run bootcmd_run
  
 +run mender_try_to_recover
--- 
-2.34.1
-


### PR DESCRIPTION
Fix the patch to affoid the following issues:

Applying patch 0001-Adapt-boot.cmd.in-to-Mender.patch
patching file boot.cmd.in
Hunk #3 FAILED at 41.
1 out of 3 hunks FAILED -- rejects in file boot.cmd.in
Patch 0001-Adapt-boot.cmd.in-to-Mender.patch does not apply (enforce with -f)

Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>