### PR TITLE
Bug fixes and improvements for verdin-imx8mp and Toradex BSP 5.6

### DIFF
--- a/meta-mender-toradex-nxp/README.md
+++ b/meta-mender-toradex-nxp/README.md
@@ -5,7 +5,7 @@ Mender integration layer for Toradex family of boards.
 The supported and tested boards are:
 
 - [Toradex Verdin iMX8M Mini](https://hub.mender.io/t/toradex-verdin-imx8m-mini/2908)
-- Toradex Verdin iMX8M Plus
+- [Toradex Verdin iMX8M Plus](https://hub.mender.io/t/toradex-verdin-imx8m-plus/5026)
 
 Visit the individual board links above for more information on status of the
 integration and more detailed instructions on how to build and use images

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.6.0/0001-Adapt-boot.cmd.in-to-Mender.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.6.0/0001-Adapt-boot.cmd.in-to-Mender.patch
@@ -1,12 +1,10 @@
---- boot.cmd.in.orig	2022-06-13 07:29:05.128770364 +0000
-+++ boot.cmd.in	2022-06-13 15:14:30.754269214 +0000
-@@ -1,35 +1,11 @@
- # SPDX-License-Identifier: GPL-2.0+ OR MIT
- #
+--- boot.cmd.in.orig	2022-05-04 17:11:45.617164243 -0400
++++ boot.cmd.in	2022-05-04 17:17:32.098033569 -0400
+@@ -3,33 +3,9 @@
  # Copyright 2020 Toradex
-+# With Mender integration.
  #
  # Toradex boot script.
++# With Mender integration.
  #
 -# Allows to change boot and rootfs devices independently.
 -# Supports:
@@ -83,7 +81,7 @@
  
  if test -n ${setup}; then
      run setup
-@@ -79,52 +41,17 @@
+@@ -79,52 +41,18 @@
      env set bootcmd_unzip 'unzip ${kernel_addr_load} ${kernel_addr_r}'
  else
      env set bootcmd_unzip ';'
@@ -91,20 +89,20 @@
 -    then
 -        env set kernel_addr_load ${ramdisk_addr_r}
 -    else
--        env set kernel_addr_load ${kernel_addr_r}
+         env set kernel_addr_load ${kernel_addr_r}
 -    fi
 -fi
 -
 -# Set dynamic commands
 -env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${kernel_image}"'
--env set set_load_overlays_file 'env set load_overlays_file "${load_cmd} \\${loadaddr} \\${overlays_file}; env import -t \\${loadaddr} \\${filesize}"'
+-env set set_load_overlays_file 'env set load_overlays_file "${load_cmd} \\${loadaddr} \\${overlays_file} && env import -t \\${loadaddr} \\${filesize}"'
 -if test ${kernel_image} = "fitImage"
 -then
 -    env set fdt_high
 -    env set fdt_resize true
 -    env set set_bootcmd_dtb 'env set bootcmd_dtb "true"'
--    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \"\\${fdt_overlays}\"; do env set fitconf_fdt_overlays \"\\"\\${fitconf_fdt_overlays}#conf@\\${overlay_file}\\"\"; env set overlay_file; done; true"'
--    env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && bootm ${ramdisk_addr_r}#conf@\${fdtfile}\${fitconf_fdt_overlays}'
+-    env set set_apply_overlays 'env set apply_overlays "for overlay_file in \"\\${fdt_overlays}\"; do env set fitconf_fdt_overlays \"\\"\\${fitconf_fdt_overlays}#conf-\\${overlay_file}\\"\"; env set overlay_file; done; true"'
+-    env set bootcmd_boot 'echo "Bootargs: \${bootargs}" && bootm ${ramdisk_addr_r}#conf-\${fdtfile}\${fitconf_fdt_overlays}'
 -else
 -    env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'
 -    env set set_bootcmd_dtb 'env set bootcmd_dtb "echo Loading DeviceTree: \\${fdtfile}; ${load_cmd} \\${fdt_addr_r} \\${fdtfile}"'
@@ -122,7 +120,6 @@
 -        env set uuid_set 'part uuid ${root_devtype} ${root_devnum}:${root_part} uuid'
 -        env set rootfsargs_set 'run uuid_set && env set rootfsargs root=PARTUUID=${uuid} ro rootwait'
 -    fi
-+    env set kernel_addr_load ${kernel_addr_r}
  fi
  
 +env set rootfsargs_set 'env set rootfsargs root=${mender_kernel_root} ro rootwait'
@@ -134,7 +131,7 @@
 -fi
 +env set bootcmd_overlays 'run load_overlays_file && run fdt_resize && run apply_overlays'
  env set bootcmd_prepare 'run set_bootcmd_kernel; run set_bootcmd_dtb; run set_load_overlays_file; run set_apply_overlays'
--env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_overlays && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!" && false'
+ env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_overlays && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!" && false'
 +env set bootcmd_run 'run m4boot; run bootcmd_dtb && run bootcmd_overlays && run bootcmd_args && run bootcmd_kernel && run bootcmd_unzip && run bootcmd_boot; echo "Booting from ${devtype} failed!"'
  
  run bootcmd_prepare

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mp/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mp/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,0 +1,67 @@
+From b5efb76a9017e9217a03c890b70b7b3f32b293e8 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Fri, 10 Jun 2022 14:22:11 +0000
+Subject: [PATCH] configs: verdin-imx8mp: mender integration
+
+Apply configuration changes for Mender.
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ configs/verdin-imx8mp_defconfig |  7 ++++---
+ include/configs/verdin-imx8mp.h | 14 +++-----------
+ 2 files changed, 7 insertions(+), 14 deletions(-)
+
+diff --git a/configs/verdin-imx8mp_defconfig b/configs/verdin-imx8mp_defconfig
+index ba98e49515..7464b0d33f 100644
+--- a/configs/verdin-imx8mp_defconfig
++++ b/configs/verdin-imx8mp_defconfig
+@@ -11,9 +11,11 @@ CONFIG_SYS_I2C_MXC_I2C1=y
+ CONFIG_SYS_I2C_MXC_I2C2=y
+ CONFIG_SYS_I2C_MXC_I2C3=y
+ CONFIG_SYS_I2C_MXC_I2C4=y
+-CONFIG_ENV_SIZE=0x2000
++CONFIG_ENV_SIZE=0x4000
++CONFIG_ENV_OFFSET=0x800000
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ # Bogus, gets overwritten in include/configs/verdin-imx8mp.h
+-CONFIG_ENV_OFFSET=0x400000
+ CONFIG_DM_GPIO=y
+ CONFIG_TARGET_VERDIN_IMX8MP=y
+ CONFIG_SPL_SERIAL_SUPPORT=y
+@@ -68,7 +70,6 @@ CONFIG_CMD_EXT4_WRITE=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_DEFAULT_DEVICE_TREE="imx8mp-verdin"
+ # SPL recovery crashes otherwise
+-CONFIG_ENV_IS_NOWHERE=y
+ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+diff --git a/include/configs/verdin-imx8mp.h b/include/configs/verdin-imx8mp.h
+index e854ef6d2d..138d00a559 100644
+--- a/include/configs/verdin-imx8mp.h
++++ b/include/configs/verdin-imx8mp.h
+@@ -124,17 +124,9 @@
+ 	(CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
+ 
+ #define CONFIG_ENV_OVERWRITE
+-#if defined(CONFIG_ENV_IS_IN_MMC)
+-/* Environment in eMMC, before config block at the end of 1st "boot sector" */
+-#undef CONFIG_ENV_SIZE
+-#undef CONFIG_ENV_OFFSET
+-
+-#define CONFIG_ENV_SIZE		0x2000
+-#define CONFIG_ENV_OFFSET		(-CONFIG_ENV_SIZE + \
+-					 CONFIG_TDX_CFG_BLOCK_OFFSET)
+-#define CONFIG_SYS_MMC_ENV_DEV		2
+-#define CONFIG_SYS_MMC_ENV_PART		1
+-#endif
++
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
+ 
+ #define CONFIG_SYS_BOOTM_LEN		SZ_64M /* Increase max gunzip size */
+ 
+-- 
+2.30.2
+

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -24,6 +24,16 @@ MENDER_BOOT_PART_SIZE_MB_verdin-imx8mm = "32"
 OFFSET_SPL_PAYLOAD_verdin-imx8mm = ""
 
 #
+# Settings for verdin-imx8mp
+#
+MENDER_BOOT_PART_SIZE_MB_verdin-imx8mp = "32"
+OFFSET_SPL_PAYLOAD_verdin-imx8mp = ""
+MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_verdin-imx8mp = "0"
+MENDER_UBOOT_STORAGE_INTERFACE_verdin-imx8mp = "mmc"
+MENDER_UBOOT_STORAGE_DEVICE_verdin-imx8mp = "2"
+MENDER_STORAGE_DEVICE_verdin-imx8mp = "/dev/mmcblk2"
+
+#
 # Settings for colibri-imx6ull
 #
 INHERIT_remove_colibri-imx6ull = " mender-full "


### PR DESCRIPTION
Hi,

Unfortunately my previous commit for Toradex BSP 5.6 had some issues which are now fixed:

* Added `0001-configs-toradex-board-specific-mender-integration.patch` for `verdin-imx8mp` and `toradex-bsp-5.6.0`.
* Reverted `0001-Adapt-boot.cmd.in-to-Mender.patch` to the previous version which is actually correct for BSP 5.6.
* Added a link to https://hub.mender.io/t/toradex-verdin-imx8m-plus/5026
* Added configurations for machine verdin-imx8mp to the template `local.conf.append` in sub-layer `meta-mender-toradex-nxp`.

Best regards,
Leon