### PR TITLE
toradex: Add bsp 5.7.0 support.

### DIFF
--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.7.0
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.7.0
@@ -1,0 +1,1 @@
+toradex-bsp-5.6.0

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.3.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.3.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From e5afdc987426f1feb07c4378e0670af9d7cd8d99 Mon Sep 17 00:00:00 2001
+From cdcef7f862ddac91472f62314646a6d3977929d5 Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
  configs/apalis-imx8_defconfig | 6 ++++--
- include/configs/apalis-imx8.h | 4 ----
- 2 files changed, 4 insertions(+), 6 deletions(-)
+ include/configs/apalis-imx8.h | 6 +-----
+ 2 files changed, 5 insertions(+), 7 deletions(-)
 
 diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
-index 1cd29946228..44cc7ea6148 100644
+index 42700e4571..d0acca8dd2 100644
 --- a/configs/apalis-imx8_defconfig
 +++ b/configs/apalis-imx8_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -26,10 +26,19 @@ index 1cd29946228..44cc7ea6148 100644
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
 diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index ad859cb6b62..2b5989ba31f 100644
+index 5532f8e03f..b590835d33 100644
 --- a/include/configs/apalis-imx8.h
 +++ b/include/configs/apalis-imx8.h
-@@ -133,10 +133,6 @@
+@@ -111,7 +111,7 @@
+ 	"loadhdp=${load_cmd} ${hdp_addr} ${hdp_file}\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
+-		"root=PARTUUID=${uuid} rootwait " \
++		"rootwait " \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"panel=NULL\0" \
+@@ -134,10 +134,6 @@
  #define CONFIG_SYS_MEMTEST_START	0x90000000
  #define CONFIG_SYS_MEMTEST_END		0xc0000000
  
@@ -41,5 +50,5 @@ index ad859cb6b62..2b5989ba31f 100644
  
  /* On Apalis iMX8 USDHC1 is eMMC, USDHC2 is 8-bit and USDHC3 is 4-bit MMC/SD */
 -- 
-2.33.0
+2.37.3
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.4.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.4.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From e5afdc987426f1feb07c4378e0670af9d7cd8d99 Mon Sep 17 00:00:00 2001
+From cdcef7f862ddac91472f62314646a6d3977929d5 Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
  configs/apalis-imx8_defconfig | 6 ++++--
- include/configs/apalis-imx8.h | 4 ----
- 2 files changed, 4 insertions(+), 6 deletions(-)
+ include/configs/apalis-imx8.h | 6 +-----
+ 2 files changed, 5 insertions(+), 7 deletions(-)
 
 diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
-index 1cd29946228..44cc7ea6148 100644
+index 42700e4571..d0acca8dd2 100644
 --- a/configs/apalis-imx8_defconfig
 +++ b/configs/apalis-imx8_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -26,10 +26,19 @@ index 1cd29946228..44cc7ea6148 100644
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
 diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index ad859cb6b62..2b5989ba31f 100644
+index 5532f8e03f..b590835d33 100644
 --- a/include/configs/apalis-imx8.h
 +++ b/include/configs/apalis-imx8.h
-@@ -133,10 +133,6 @@
+@@ -111,7 +111,7 @@
+ 	"loadhdp=${load_cmd} ${hdp_addr} ${hdp_file}\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
+-		"root=PARTUUID=${uuid} rootwait " \
++		"rootwait " \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"panel=NULL\0" \
+@@ -134,10 +134,6 @@
  #define CONFIG_SYS_MEMTEST_START	0x90000000
  #define CONFIG_SYS_MEMTEST_END		0xc0000000
  
@@ -41,5 +50,5 @@ index ad859cb6b62..2b5989ba31f 100644
  
  /* On Apalis iMX8 USDHC1 is eMMC, USDHC2 is 8-bit and USDHC3 is 4-bit MMC/SD */
 -- 
-2.33.0
+2.37.3
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.5.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.5.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From e5afdc987426f1feb07c4378e0670af9d7cd8d99 Mon Sep 17 00:00:00 2001
+From cdcef7f862ddac91472f62314646a6d3977929d5 Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
  configs/apalis-imx8_defconfig | 6 ++++--
- include/configs/apalis-imx8.h | 4 ----
- 2 files changed, 4 insertions(+), 6 deletions(-)
+ include/configs/apalis-imx8.h | 6 +-----
+ 2 files changed, 5 insertions(+), 7 deletions(-)
 
 diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
-index 1cd29946228..44cc7ea6148 100644
+index 42700e4571..d0acca8dd2 100644
 --- a/configs/apalis-imx8_defconfig
 +++ b/configs/apalis-imx8_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -26,10 +26,19 @@ index 1cd29946228..44cc7ea6148 100644
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
 diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index ad859cb6b62..2b5989ba31f 100644
+index 5532f8e03f..b590835d33 100644
 --- a/include/configs/apalis-imx8.h
 +++ b/include/configs/apalis-imx8.h
-@@ -133,10 +133,6 @@
+@@ -111,7 +111,7 @@
+ 	"loadhdp=${load_cmd} ${hdp_addr} ${hdp_file}\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
+-		"root=PARTUUID=${uuid} rootwait " \
++		"rootwait " \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"panel=NULL\0" \
+@@ -134,10 +134,6 @@
  #define CONFIG_SYS_MEMTEST_START	0x90000000
  #define CONFIG_SYS_MEMTEST_END		0xc0000000
  
@@ -41,5 +50,5 @@ index ad859cb6b62..2b5989ba31f 100644
  
  /* On Apalis iMX8 USDHC1 is eMMC, USDHC2 is 8-bit and USDHC3 is 4-bit MMC/SD */
 -- 
-2.33.0
+2.37.3
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From e5afdc987426f1feb07c4378e0670af9d7cd8d99 Mon Sep 17 00:00:00 2001
+From cdcef7f862ddac91472f62314646a6d3977929d5 Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
  configs/apalis-imx8_defconfig | 6 ++++--
- include/configs/apalis-imx8.h | 4 ----
- 2 files changed, 4 insertions(+), 6 deletions(-)
+ include/configs/apalis-imx8.h | 6 +-----
+ 2 files changed, 5 insertions(+), 7 deletions(-)
 
 diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
-index 1cd29946228..44cc7ea6148 100644
+index 42700e4571..d0acca8dd2 100644
 --- a/configs/apalis-imx8_defconfig
 +++ b/configs/apalis-imx8_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -26,10 +26,19 @@ index 1cd29946228..44cc7ea6148 100644
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
 diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index ad859cb6b62..2b5989ba31f 100644
+index 5532f8e03f..b590835d33 100644
 --- a/include/configs/apalis-imx8.h
 +++ b/include/configs/apalis-imx8.h
-@@ -133,10 +133,6 @@
+@@ -111,7 +111,7 @@
+ 	"loadhdp=${load_cmd} ${hdp_addr} ${hdp_file}\0" \
+ 	"mmcautodetect=yes\0" \
+ 	"mmcargs=setenv bootargs console=${console},${baudrate} " \
+-		"root=PARTUUID=${uuid} rootwait " \
++		"rootwait " \
+ 	"mmcdev=" __stringify(CONFIG_SYS_MMC_ENV_DEV) "\0" \
+ 	"mmcpart=" __stringify(CONFIG_SYS_MMC_IMG_LOAD_PART) "\0" \
+ 	"panel=NULL\0" \
+@@ -134,10 +134,6 @@
  #define CONFIG_SYS_MEMTEST_START	0x90000000
  #define CONFIG_SYS_MEMTEST_END		0xc0000000
  
@@ -41,5 +50,5 @@ index ad859cb6b62..2b5989ba31f 100644
  
  /* On Apalis iMX8 USDHC1 is eMMC, USDHC2 is 8-bit and USDHC3 is 4-bit MMC/SD */
 -- 
-2.33.0
+2.37.3
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.7.0
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.7.0
@@ -1,0 +1,1 @@
+toradex-bsp-5.6.0


### PR DESCRIPTION
This is just a symlink to 5.6.0 files since they work with 5.7.0 as well.

Signed-off-by: Drew Moseley <drew@moseleynet.net>