### PR TITLE
toradex: Use mender_dtb_name consistently.

### DIFF
--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx6/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx6/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,12 +1,12 @@
-From d89ac1a7f228f957e22ccc2d0421d379f1650f49 Mon Sep 17 00:00:00 2001
+From 3e9f1c1bb6d32e5087aead5473e4e21eaeaccddc Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
- configs/apalis_imx6_defconfig | 6 ++++--
- include/configs/apalis_imx6.h | 8 --------
- 2 files changed, 4 insertions(+), 10 deletions(-)
+ configs/apalis_imx6_defconfig |  6 ++++--
+ include/configs/apalis_imx6.h | 12 ++----------
+ 2 files changed, 6 insertions(+), 12 deletions(-)
 
 diff --git a/configs/apalis_imx6_defconfig b/configs/apalis_imx6_defconfig
 index 02167536d4b..71c0e8560da 100644
@@ -26,9 +26,22 @@ index 02167536d4b..71c0e8560da 100644
  CONFIG_TARGET_APALIS_IMX6=y
  CONFIG_DM_GPIO=y
 diff --git a/include/configs/apalis_imx6.h b/include/configs/apalis_imx6.h
-index d77b8ab5060..bbd4a7aaa59 100644
+index d77b8ab5060..17c873690ae 100644
 --- a/include/configs/apalis_imx6.h
 +++ b/include/configs/apalis_imx6.h
+@@ -126,10 +126,10 @@
+ 	"scriptaddr=0x17000000\0"
+ 
+ #ifndef CONFIG_TDX_APALIS_IMX6_V1_0
+-#define FDT_FILE "imx6q-apalis-eval.dtb"
++#define FDT_FILE "${mender_dtb_name}"
+ #define FDT_FILE_V1_0 "imx6q-apalis_v1_0-eval.dtb"
+ #else
+-#define FDT_FILE "imx6q-apalis_v1_0-eval.dtb"
++#define FDT_FILE "${mender_dtb_name}"
+ #endif
+ 
+ #if defined(CONFIG_TDX_EASY_INSTALLER)
 @@ -193,12 +193,4 @@
  #define CONFIG_SYS_INIT_SP_ADDR \
  	(CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
@@ -43,5 +56,5 @@ index d77b8ab5060..bbd4a7aaa59 100644
 -
  #endif	/* __CONFIG_H */
 -- 
-2.33.0
+2.25.1
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/apalis-imx8/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From cdcef7f862ddac91472f62314646a6d3977929d5 Mon Sep 17 00:00:00 2001
+From fe1c77a6e14a8d4c5cc09857a91448725b6b3a73 Mon Sep 17 00:00:00 2001
 From: pagi <paul.giangrossi@qamcom.se>
 Date: Fri, 9 Jul 2021 08:29:09 +0200
 Subject: [PATCH] 0001-configs-toradex-board-specific-mender-integration
 
 ---
- configs/apalis-imx8_defconfig | 6 ++++--
+ configs/apalis-imx8_defconfig | 8 +++++---
  include/configs/apalis-imx8.h | 6 +-----
- 2 files changed, 5 insertions(+), 7 deletions(-)
+ 2 files changed, 6 insertions(+), 8 deletions(-)
 
 diff --git a/configs/apalis-imx8_defconfig b/configs/apalis-imx8_defconfig
-index 42700e4571..d0acca8dd2 100644
+index 42700e45715..47ed2118197 100644
 --- a/configs/apalis-imx8_defconfig
 +++ b/configs/apalis-imx8_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -25,8 +25,17 @@ index 42700e4571..d0acca8dd2 100644
  CONFIG_DM_GPIO=y
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
+@@ -17,7 +19,7 @@ CONFIG_FIT=y
+ CONFIG_FIT_VERBOSE=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="setenv fdtfile ${soc}-apalis${variant}-${fdt_board}.dtb"
++CONFIG_PREBOOT="setenv fdtfile ${mender_dtb_name}"
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=board/toradex/apalis-imx8/apalis-imx8-imximage.cfg"
+ CONFIG_BOOTDELAY=1
+ CONFIG_LOG=y
 diff --git a/include/configs/apalis-imx8.h b/include/configs/apalis-imx8.h
-index 5532f8e03f..b590835d33 100644
+index 5532f8e03ff..b590835d336 100644
 --- a/include/configs/apalis-imx8.h
 +++ b/include/configs/apalis-imx8.h
 @@ -111,7 +111,7 @@
@@ -50,5 +59,5 @@ index 5532f8e03f..b590835d33 100644
  
  /* On Apalis iMX8 USDHC1 is eMMC, USDHC2 is 8-bit and USDHC3 is 4-bit MMC/SD */
 -- 
-2.37.3
+2.25.1
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/colibri-imx8x/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/colibri-imx8x/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,15 +1,15 @@
-From 371c2ba438dbe451d90dff7026bd85af845d6015 Mon Sep 17 00:00:00 2001
+From fc1e5be974ec5aa546a20d244aa4253accd2898e Mon Sep 17 00:00:00 2001
 From: Adrian Antonana <adrian.antonana@plating.de>
 Date: Fri, 9 Sep 2022 07:54:14 +0200
 Subject: [PATCH] configs toradex board specific mender integration
 
 ---
- configs/colibri-imx8x_defconfig |  6 ++++--
+ configs/colibri-imx8x_defconfig |  8 +++++---
  include/configs/colibri-imx8x.h | 10 ++--------
- 2 files changed, 6 insertions(+), 10 deletions(-)
+ 2 files changed, 7 insertions(+), 11 deletions(-)
 
 diff --git a/configs/colibri-imx8x_defconfig b/configs/colibri-imx8x_defconfig
-index 256159b0608..156f9d00f27 100644
+index 256159b0608..8b910142858 100644
 --- a/configs/colibri-imx8x_defconfig
 +++ b/configs/colibri-imx8x_defconfig
 @@ -2,8 +2,10 @@ CONFIG_ARM=y
@@ -25,6 +25,15 @@ index 256159b0608..156f9d00f27 100644
  CONFIG_DM_GPIO=y
  CONFIG_BOOTAUX_RESERVED_MEM_BASE=0x88000000
  CONFIG_BOOTAUX_RESERVED_MEM_SIZE=0x08000000
+@@ -17,7 +19,7 @@ CONFIG_FIT=y
+ CONFIG_FIT_VERBOSE=y
+ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="setenv fdtfile ${soc}-colibri-${fdt_board}.dtb"
++CONFIG_PREBOOT="setenv fdtfile ${mender_dtb_name}"
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=board/toradex/colibri-imx8x/colibri-imx8x-imximage.cfg"
+ CONFIG_BOOTDELAY=1
+ CONFIG_LOG=y
 diff --git a/include/configs/colibri-imx8x.h b/include/configs/colibri-imx8x.h
 index fbb811cbb78..e2b49d54a99 100644
 --- a/include/configs/colibri-imx8x.h
@@ -61,5 +70,5 @@ index fbb811cbb78..e2b49d54a99 100644
  #define CONFIG_SYS_FSL_USDHC_NUM	2
  
 -- 
-2.37.3
+2.25.1
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mm/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mm/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,19 +1,19 @@
-From e1cef1b71ffa402ce355c2bf7287b9a7888020d2 Mon Sep 17 00:00:00 2001
+From 5fae5b0ef943bb5b6ed8df6e7889da1af6e36b55 Mon Sep 17 00:00:00 2001
 From: Mirza Krak <mirza.krak@northern.tech>
 Date: Mon, 30 Nov 2020 09:53:07 +0100
 Subject: [PATCH] configs: verdin-imx8mm: mender integration
 
 Signed-off-by: Mirza Krak <mirza.krak@northern.tech>
 ---
- configs/verdin-imx8mm_defconfig |  6 ++++--
+ configs/verdin-imx8mm_defconfig |  8 +++++---
  include/configs/verdin-imx8mm.h | 14 +++-----------
- 2 files changed, 7 insertions(+), 13 deletions(-)
+ 2 files changed, 8 insertions(+), 14 deletions(-)
 
 diff --git a/configs/verdin-imx8mm_defconfig b/configs/verdin-imx8mm_defconfig
-index f3a7e006e93..c42b25c6df7 100644
+index ff4febcd33f..58155ba633e 100644
 --- a/configs/verdin-imx8mm_defconfig
 +++ b/configs/verdin-imx8mm_defconfig
-@@ -10,8 +10,10 @@ CONFIG_SYS_MALLOC_F_LEN=0x10000
+@@ -10,14 +10,16 @@ CONFIG_SYS_MALLOC_F_LEN=0x10000
  CONFIG_SYS_I2C_MXC_I2C1=y
  CONFIG_SYS_I2C_MXC_I2C2=y
  CONFIG_SYS_I2C_MXC_I2C3=y
@@ -26,11 +26,18 @@ index f3a7e006e93..c42b25c6df7 100644
  CONFIG_DM_GPIO=y
  CONFIG_TARGET_VERDIN_IMX8MM=y
  CONFIG_SPL_MMC_SUPPORT=y
+ CONFIG_SPL_SERIAL_SUPPORT=y
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="setenv fdtfile imx8mm-verdin-${variant}-${fdt_board}.dtb"
++CONFIG_PREBOOT="setenv fdtfile ${mender_dtb_name}"
+ CONFIG_SPL_DRIVERS_MISC_SUPPORT=y
+ CONFIG_NR_DRAM_BANKS=1
+ CONFIG_SPL=y
 diff --git a/include/configs/verdin-imx8mm.h b/include/configs/verdin-imx8mm.h
-index 72e758ec8aa..aa2e3be305c 100644
+index 87e73c26a7b..06fb01787fc 100644
 --- a/include/configs/verdin-imx8mm.h
 +++ b/include/configs/verdin-imx8mm.h
-@@ -121,17 +121,9 @@
+@@ -135,17 +135,9 @@
          (CONFIG_SYS_INIT_RAM_ADDR + CONFIG_SYS_INIT_SP_OFFSET)
  
  #define CONFIG_ENV_OVERWRITE
@@ -52,5 +59,5 @@ index 72e758ec8aa..aa2e3be305c 100644
  #define CONFIG_SYS_BOOTM_LEN		(64 << 20) /* Increase max gunzip size */
  
 -- 
-2.33.0
+2.25.1
 

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mp/0001-configs-toradex-board-specific-mender-integration.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot/files/toradex-bsp-5.6.0/verdin-imx8mp/0001-configs-toradex-board-specific-mender-integration.patch
@@ -1,4 +1,4 @@
-From b5efb76a9017e9217a03c890b70b7b3f32b293e8 Mon Sep 17 00:00:00 2001
+From fc8ba43eda469411e5a436d3ae5fc6f6eeaff3b2 Mon Sep 17 00:00:00 2001
 From: Leon Anavi <leon.anavi@konsulko.com>
 Date: Fri, 10 Jun 2022 14:22:11 +0000
 Subject: [PATCH] configs: verdin-imx8mp: mender integration
@@ -7,12 +7,12 @@ Apply configuration changes for Mender.
 
 Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
 ---
- configs/verdin-imx8mp_defconfig |  7 ++++---
+ configs/verdin-imx8mp_defconfig |  9 +++++----
  include/configs/verdin-imx8mp.h | 14 +++-----------
- 2 files changed, 7 insertions(+), 14 deletions(-)
+ 2 files changed, 8 insertions(+), 15 deletions(-)
 
 diff --git a/configs/verdin-imx8mp_defconfig b/configs/verdin-imx8mp_defconfig
-index ba98e49515..7464b0d33f 100644
+index ba98e49515c..acce33cc248 100644
 --- a/configs/verdin-imx8mp_defconfig
 +++ b/configs/verdin-imx8mp_defconfig
 @@ -11,9 +11,11 @@ CONFIG_SYS_I2C_MXC_I2C1=y
@@ -29,6 +29,15 @@ index ba98e49515..7464b0d33f 100644
  CONFIG_DM_GPIO=y
  CONFIG_TARGET_VERDIN_IMX8MP=y
  CONFIG_SPL_SERIAL_SUPPORT=y
+@@ -36,7 +38,7 @@ CONFIG_OF_SYSTEM_SETUP=y
+ CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=board/toradex/verdin-imx8mp/imximage.cfg"
+ CONFIG_BOOTDELAY=1
+ CONFIG_USE_PREBOOT=y
+-CONFIG_PREBOOT="setenv fdtfile imx8mp-verdin-${variant}-${fdt_board}.dtb"
++CONFIG_PREBOOT="setenv fdtfile  ${mender_dtb_name}"
+ CONFIG_LOG=y
+ CONFIG_BOARD_LATE_INIT=y
+ # CONFIG_DISPLAY_BOARDINFO is not set
 @@ -68,7 +70,6 @@ CONFIG_CMD_EXT4_WRITE=y
  CONFIG_OF_CONTROL=y
  CONFIG_DEFAULT_DEVICE_TREE="imx8mp-verdin"
@@ -38,7 +47,7 @@ index ba98e49515..7464b0d33f 100644
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
 diff --git a/include/configs/verdin-imx8mp.h b/include/configs/verdin-imx8mp.h
-index e854ef6d2d..138d00a559 100644
+index e854ef6d2db..138d00a559b 100644
 --- a/include/configs/verdin-imx8mp.h
 +++ b/include/configs/verdin-imx8mp.h
 @@ -124,17 +124,9 @@
@@ -63,5 +72,5 @@ index e854ef6d2d..138d00a559 100644
  #define CONFIG_SYS_BOOTM_LEN		SZ_64M /* Increase max gunzip size */
  
 -- 
-2.30.2
+2.25.1
 

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -22,6 +22,7 @@ IMAGE_BOOT_FILES_remove_mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
 #
 MENDER_BOOT_PART_SIZE_MB_verdin-imx8mm = "32"
 OFFSET_SPL_PAYLOAD_verdin-imx8mm = ""
+KERNEL_DEVICETREE_verdin-imx8mm = "freescale/imx8mm-verdin-wifi-dahlia.dtb"
 
 #
 # Settings for verdin-imx8mp
@@ -32,6 +33,7 @@ MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET_verdin-imx8mp = "0"
 MENDER_UBOOT_STORAGE_INTERFACE_verdin-imx8mp = "mmc"
 MENDER_UBOOT_STORAGE_DEVICE_verdin-imx8mp = "2"
 MENDER_STORAGE_DEVICE_verdin-imx8mp = "/dev/mmcblk2"
+KERNEL_DEVICETREE_verdin-imx8mp = "freescale/imx8mp-verdin-wifi-dahlia.dtb"
 
 #
 # Settings for colibri-imx8x
@@ -41,6 +43,7 @@ MENDER_BOOT_PART_SIZE_MB_colibri-imx8x = "32"
 OFFSET_SPL_PAYLOAD_colibri-imx8x = ""
 MENDER_STORAGE_DEVICE_colibri-imx8x = "/dev/mmcblk0"
 MENDER_STORAGE_TOTAL_SIZE_MB_colibri-imx8x = "2048"
+KERNEL_DEVICETREE_colibri-imx8x = "freescale/imx8qxp-colibri-iris-v2.dtb"
 
 #
 # Settings for colibri-imx6ull
@@ -55,6 +58,9 @@ MENDER_STORAGE_PEB_SIZE_colibri-imx6ull = "131072"
 MKUBIFS_ARGS_colibri-imx6ull = "-m ${MENDER_FLASH_MINIMUM_IO_UNIT} -e ${MENDER_UBI_LEB_SIZE} -c ${MENDER_MAXIMUM_LEB_COUNT} --space-fixup"
 MENDER_FEATURES_ENABLE_remove_colibri-imx6ull = " mender-image-sd mender-image-grub mender-image-uefi"
 MENDER_FEATURES_DISABLE_append_colibri-imx6ull = " mender-grub mender-image-uefi mender-image-sd"
+KERNEL_DEVICETREE_colibri-imx6ull = "imx6ull-colibri-wifi-eval-v3.dtb"
+# meta-freescale-3rdparty appends to KERNEL_DEVICETREE so explicitly remove those.
+KERNEL_DEVICETREE_remove_colibri-imx6ull = "imx6ull-colibri-aster.dtb imx6ull-colibri-iris.dtb imx6ull-colibri-iris-v2.dtb imx6ull-colibri-wifi-aster.dtb imx6ull-colibri-wifi-iris.dtb imx6ull-colibri-wifi-iris-v2.dtb"
 
 #
 # Settings for apalis-imx8
@@ -64,6 +70,7 @@ MENDER_BOOT_PART_SIZE_MB_apalis-imx8 = "32"
 OFFSET_SPL_PAYLOAD_apalis-imx8 = ""
 MENDER_STORAGE_DEVICE_apalis-imx8 = "/dev/mmcblk0"
 MENDER_STORAGE_TOTAL_SIZE_MB_apalis-imx8 = "2048"
+KERNEL_DEVICETREE_apalis-imx8 = "freescale/imx8qm-apalis-v1.1-ixora-v1.2.dtb"
 
 #
 # Settings for apalis-imx6
@@ -72,6 +79,7 @@ TEZI_STORAGE_DEVICE_apalis-imx6 = "mmcblk0"
 MENDER_STORAGE_DEVICE_apalis-imx6 = "/dev/mmcblk2"
 MENDER_UBOOT_STORAGE_DEVICE_apalis-imx6 = "0"
 MENDER_STORAGE_TOTAL_SIZE_MB_apalis-imx6 = "2048"
+KERNEL_DEVICETREE_apalis-imx6 = "imx6q-apalis-ixora-v1.1.dtb"
 
 # Append the Mender provided bootargs to tdxargs
 # the Toradex boot.scr will overwrite bootargs so we stash the context in tdxargs


### PR DESCRIPTION
Make sure we use the mender_dtb_name variable consistently across all support Toradex platforms. This loses the ability to define it dynamically which is the default (sort of) for Toradex but is better inline with standard Mender/Yocto integrations.

Changelog: Title
Signed-off-by: Drew Moseley <drew@moseleynet.net>