### PR TITLE
mender-update-modules: update to current HEAD

### DIFF
--- a/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
+++ b/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
@@ -4,6 +4,6 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/mendersoftware/mender-update-modules.git;branch=master;protocol=https"
 
-SRCREV = "54d3ed08a8b3bd0db8166321970bb1e601c2024f"
+SRCREV = "a9f676eefe2e482ba3f7a6ad2d8c15ab3327a54f"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
This includes the following changes:

a9f676e Merge pull request #20 from pa-innovation/pr-branch 5417ca4 rootfs-version-check: Added mender_boot_part_hex definition to original script since it seems to be a bug there. 795bffe Update IRC links to Libera.

Changelog: Title

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>