### PR TITLE
meta-mender-nxp: imx7d-pico: rebase patch on kirkstone

### DIFF
--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/imx7d-pico/0001-ARM-Pico-Pi-i.MX7D-support-to-mender.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/imx7d-pico/0001-ARM-Pico-Pi-i.MX7D-support-to-mender.patch
@@ -1,52 +1,41 @@
-From 07b83256cfffb8ad7144ae16c52599aa84821f13 Mon Sep 17 00:00:00 2001
+From 69263d9d8046966ed68288998a2893f8b445a859 Mon Sep 17 00:00:00 2001
 From: Pierre-Jean Texier <texier.pj2@gmail.com>
-Date: Fri, 18 Jun 2021 20:14:34 +0200
+Date: Sun, 13 Nov 2022 16:25:30 +0100
 Subject: [PATCH] ARM Pico-Pi i.MX7D support to mender
 
 Signed-off-by: Joris Offouga <offougajoris@gmail.com>
 [Pierre-Jean Texier: refresh patch for dunfell release]
 Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>
+[Pierre-Jean Texier: refresh patch for kirkstone release]
+Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>
 ---
- configs/pico-pi-imx7d_defconfig | 4 +++-
- include/configs/pico-imx7d.h    | 3 +--
- 2 files changed, 4 insertions(+), 3 deletions(-)
+ configs/pico-pi-imx7d_defconfig | 4 ++++
+ 1 file changed, 4 insertions(+)
 
 diff --git a/configs/pico-pi-imx7d_defconfig b/configs/pico-pi-imx7d_defconfig
-index c9e6abc7d2..c7d603e298 100644
+index 812aa24b09..7fa3aa3365 100644
 --- a/configs/pico-pi-imx7d_defconfig
 +++ b/configs/pico-pi-imx7d_defconfig
-@@ -18,7 +18,7 @@ CONFIG_IMX_BOOTAUX=y
- CONFIG_SPL_TEXT_BASE=0x00911000
- CONFIG_DISTRO_DEFAULTS=y
- CONFIG_SYS_EXTRA_OPTIONS="IMX_CONFIG=arch/arm/mach-imx/spl_sd.cfg"
--CONFIG_BOOTCOMMAND="run findfdt; run finduuid; run distro_bootcmd"
-+# CONFIG_USE_BOOTCOMMAND is not set
- CONFIG_DEFAULT_FDT_FILE="imx7d-pico-pi.dtb"
- CONFIG_BOUNCE_BUFFER=y
- CONFIG_SPL_I2C_SUPPORT=y
-@@ -47,6 +47,8 @@ CONFIG_CMD_EXT4_WRITE=y
+@@ -17,6 +17,7 @@ CONFIG_TARGET_PICO_IMX7D=y
+ CONFIG_SPL_MMC=y
+ CONFIG_SPL_SERIAL=y
+ CONFIG_SPL=y
++CONFIG_ENV_OFFSET_REDUND=0xE0000
+ CONFIG_ARMV7_BOOT_SEC_DEFAULT=y
+ CONFIG_IMX_RDC=y
+ CONFIG_IMX_BOOTAUX=y
+@@ -50,8 +51,11 @@ CONFIG_CMD_CACHE=y
+ CONFIG_CMD_EXT4_WRITE=y
  CONFIG_OF_CONTROL=y
- CONFIG_DEFAULT_DEVICE_TREE="imx7d-pico-pi"
+ CONFIG_ENV_OVERWRITE=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_BOUNCE_BUFFER=y
 +CONFIG_BOOTCOUNT_LIMIT=y
 +CONFIG_BOOTCOUNT_ENV=y
  CONFIG_DFU_MMC=y
  CONFIG_USB_FUNCTION_FASTBOOT=y
  CONFIG_FASTBOOT_BUF_ADDR=0x82000000
-diff --git a/include/configs/pico-imx7d.h b/include/configs/pico-imx7d.h
-index 4dc206566e..18fcee9efc 100644
---- a/include/configs/pico-imx7d.h
-+++ b/include/configs/pico-imx7d.h
-@@ -168,8 +168,7 @@
- 
- #define CONFIG_SYS_FSL_USDHC_NUM		2
- 
--#define CONFIG_SYS_MMC_ENV_DEV			0
--#define CONFIG_SYS_MMC_ENV_PART		0
-+#define CONFIG_SYS_REDUNDAND_ENVIRONMENT
- 
- /* USB Configs */
- #define CONFIG_EHCI_HCD_INIT_AFTER_RESET
 -- 
-2.17.1
+2.25.1
 

--- a/meta-mender-nxp/templates/local.conf.append
+++ b/meta-mender-nxp/templates/local.conf.append
@@ -28,6 +28,7 @@ MENDER_UBOOT_STORAGE_DEVICE:imx7d-pico = "0"
 MENDER_STORAGE_DEVICE:imx7d-pico = "/dev/mmcblk2"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1:imx7d-pico = "0xC0000"
 MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2:imx7d-pico = "0xE0000"
+MENDER_STORAGE_TOTAL_SIZE_MB:imx7d-pico = "2048"
 
 # Specific Configuration for WaRP7
 IMAGE_BOOT_FILES:imx7s-warp = "boot.scr"


### PR DESCRIPTION
Also add MENDER_STORAGE_TOTAL_SIZE_MB to 2048 to fix the following issue:

$: bmaptool copy core-image-base-imx7d-pico.sdimg /dev/sda bmaptool: info: discovered bmap file 'core-image-base-imx7d-pico.sdimg.bmap' bmaptool: ERROR: An error occurred, here is the traceback: Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/bmaptools/CLI.py", line 456, in copy_command
    writer = BmapCopy.BmapBdevCopy(image_obj, dest_obj, bmap_obj,
  File "/usr/lib/python3/dist-packages/bmaptools/BmapCopy.py", line 688, in __init__
    raise Error("the image file '%s' has size %s and it will not "

bmaptool: ERROR: the image file 'core-image-base-imx7d-pico.sdimg' has size 4.0 GiB and it will not fit the block device '/dev/sda' which has 3.6 GiB capacity

Signed-off-by: Pierre-Jean Texier <texier.pj2@gmail.com>