### PR TITLE
beaglebone: Use rootwait when running with mender-uboot.

### DIFF
--- a/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,2 @@
 MENDER_UBOOT_PRE_SETUP_COMMANDS:beaglebone-yocto = "run findfdt; setenv mender_dtb_name \${fdtfile}"
+MENDER_UBOOT_PRE_SETUP_COMMANDS:append:beaglebone-yocto:mender-uboot = "; setenv bootargs \${bootargs} rootwait"


### PR DESCRIPTION
For mender-uboot based integrations on the Beaglebone, we need to specify rootwait for the kirkstone branch. Timeouts were seen where the root filesystem was not available.

Changelog: Title
Signed-off-by: Drew Moseley <drew@moseleynet.net>