### PR TITLE
RFC toradex: Move dtb and dtbo files to root partition.

### DIFF
--- a/meta-mender-toradex-nxp/classes/mender-toradex.bbclass
+++ b/meta-mender-toradex-nxp/classes/mender-toradex.bbclass
@@ -9,6 +9,16 @@ toradex_mender_update_fstab_file() {
     mv ${IMAGE_ROOTFS}${sysconfdir}/fstab.toradex ${IMAGE_ROOTFS}${sysconfdir}/fstab
 }
 
+ROOTFS_POSTPROCESS_COMMAND:append = " toradex_mender_update_devicetree_overlays;"
+toradex_mender_update_devicetree_overlays() {
+    # the Toradex BSP uses Device Tree overlays which are normally populated to the boot
+    # partition using WIC and bootimg-partition types. Since Mender does not use that partition
+    # type we have to account for that here. We want it in a POSTPROCESS_COMMAND so that it
+    # applies to all images
+    cp ${DEPLOY_DIR_IMAGE}/overlays.txt ${IMAGE_ROOTFS}/boot/overlays.txt
+    cp -R ${DEPLOY_DIR_IMAGE}/overlays/ ${IMAGE_ROOTFS}/boot/overlays
+}
+
 addhandler mender_tezi_sanity_handler
 mender_tezi_sanity_handler[eventmask] = "bb.event.ParseCompleted"
 python mender_tezi_sanity_handler() {

--- a/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.6.0/0001-Adapt-boot.cmd.in-to-Mender.patch
+++ b/meta-mender-toradex-nxp/recipes-bsp/u-boot-distro-boot/files/toradex-bsp-5.6.0/0001-Adapt-boot.cmd.in-to-Mender.patch
@@ -1,5 +1,5 @@
---- boot.cmd.in.orig	2022-05-04 17:11:45.617164243 -0400
-+++ boot.cmd.in	2022-05-04 17:17:32.098033569 -0400
+--- boot.cmd.in.orig	2022-11-14 13:05:03.731252900 -0500
++++ boot.cmd.in	2022-11-14 13:05:55.301297974 -0500
 @@ -3,33 +3,9 @@
  # Copyright 2020 Toradex
  #
@@ -71,7 +71,7 @@
 +# Set dynamic commands
 +env set load_prefix 'boot/'
 +env set load_cmd 'load ${mender_uboot_root}'
-+env set load_cmd_boot 'load ${mender_uboot_boot}'
++env set load_cmd_boot 'load ${mender_uboot_root}'
 +env set set_bootcmd_kernel 'env set bootcmd_kernel "${load_cmd} \\${kernel_addr_load} \\${load_prefix}\\${kernel_image}"'
 +env set set_load_overlays_file 'env set load_overlays_file "${load_cmd_boot} \\${loadaddr} \\${overlays_file}; env import -t \\${loadaddr} \\${filesize}"'
 +env set fdt_resize 'fdt addr ${fdt_addr_r} && fdt resize 0x20000'

--- a/meta-mender-toradex-nxp/templates/local.conf.append
+++ b/meta-mender-toradex-nxp/templates/local.conf.append
@@ -17,6 +17,10 @@ KERNEL_IMAGETYPE_aarch64_mender-grub = "Image"
 # boot.scr conflicts when using GRUB
 IMAGE_BOOT_FILES_remove_mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
 
+# Remove files from boot partition that are loaded by Mender
+# from the root partitions; this allows the files to be updated OTA
+IMAGE_BOOT_FILES_remove_mender-uboot = "zImage ${KERNEL_DEVICETREE} overlays.txt overlays/*;overlays/"
+
 #
 # Settings for verdin-imx8mm
 #
@@ -84,3 +88,7 @@ KERNEL_DEVICETREE_apalis-imx6 = "imx6q-apalis-ixora-v1.1.dtb"
 # Append the Mender provided bootargs to tdxargs
 # the Toradex boot.scr will overwrite bootargs so we stash the context in tdxargs
 MENDER_UBOOT_POST_SETUP_COMMANDS_append = " ; setenv tdxargs \${tdxargs} \${bootargs}; "
+
+# Make sure the Toradex boot script finds the overlays and overlays.txt file in
+# the /boot directory of the rootfs partition
+MENDER_UBOOT_POST_SETUP_COMMANDS_append = " ; setenv overlays_file /boot/overlays.txt ; setenv overlays_prefix boot/overlays/ "


### PR DESCRIPTION
These files should be loaded from the rootfs partition so we can update them OTA.

Changelog: Title
Signed-off-by: Drew Moseley <drew@moseleynet.net>