### PR TITLE
meta-mender-raspberrypi: fix :remove operator syntax in local.conf

### DIFF
--- a/meta-mender-raspberrypi/templates/local.conf.append
+++ b/meta-mender-raspberrypi/templates/local.conf.append
@@ -6,7 +6,7 @@ MACHINE ?= "raspberrypi3"
 RPI_USE_U_BOOT = "1"
 MENDER_BOOT_PART_SIZE_MB = "40"
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
-IMAGE_FSTYPES:remove += " rpi-sdimg"
+IMAGE_FSTYPES:remove = " rpi-sdimg"
 
 MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
 MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"


### PR DESCRIPTION
Ticket: None
Changelog: None

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>