### PR TITLE
meta-mender-raspberrypi: extend boot partition to 64MByte

### DIFF
--- a/meta-mender-raspberrypi/templates/local.conf.append
+++ b/meta-mender-raspberrypi/templates/local.conf.append
@@ -4,7 +4,7 @@
 MACHINE ?= "raspberrypi3"
 
 RPI_USE_U_BOOT = "1"
-MENDER_BOOT_PART_SIZE_MB = "40"
+MENDER_BOOT_PART_SIZE_MB = "64"
 IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
 IMAGE_FSTYPES:remove = " rpi-sdimg"
 


### PR DESCRIPTION
Since kirkstone, the olde default boot patition size of 40MByte is not sufficient anymore for the Raspberry Pi 3.

Ticket: None
Changelog: None

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>