### PR TITLE
meta-mender-nxp: Support cubox-i and HummingBoard

### DIFF
--- a/meta-mender-nxp/recipes-bsp/u-boot-scr/files/cubox-i/boot.cmd
+++ b/meta-mender-nxp/recipes-bsp/u-boot-scr/files/cubox-i/boot.cmd
@@ -1,0 +1,9 @@
+setenv bootargs 'console=${console},${baudrate} root=${mender_kernel_root} rootwait rw'
+run mender_setup
+setenv image @@KERNEL_IMAGETYPE@@
+setenv fdt_file @@KERNEL_DEVICETREE@@
+mmc dev ${mender_uboot_dev}
+load ${mender_uboot_root} ${loadaddr} /boot/${image}
+load ${mender_uboot_root} ${fdt_addr} /boot/${fdt_file}
+bootz ${loadaddr} - ${fdt_addr}
+run mender_try_to_recover

--- a/meta-mender-nxp/recipes-bsp/u-boot-scr/u-boot-scr.bb
+++ b/meta-mender-nxp/recipes-bsp/u-boot-scr/u-boot-scr.bb
@@ -10,6 +10,13 @@ do_compile() {
 	mkimage -C none -A arm -T script -d "${WORKDIR}/boot.cmd" boot.scr
 }
 
+do_compile:cubox-i() {
+	sed -e 's/@@KERNEL_IMAGETYPE@@/${KERNEL_IMAGETYPE}/' \
+	    -e 's/@@KERNEL_DEVICETREE@@/${KERNEL_DEVICETREE}/' \
+	    "${WORKDIR}/boot.cmd" > "${WORKDIR}/boot.cmd.out"
+	mkimage -C none -A arm -T script -d "${WORKDIR}/boot.cmd.out" boot.scr
+}
+
 inherit deploy
 
 do_deploy() {
@@ -20,4 +27,4 @@ do_deploy() {
 addtask do_deploy after do_compile before do_build
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-COMPATIBLE_MACHINE = "(imx7s-warp|imx7d-pico|imx7dsabresd)"
+COMPATIBLE_MACHINE = "(imx7s-warp|imx7d-pico|imx7dsabresd|cubox-i)"

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/cubox-i/0001-configs-mx6cuboxi_defconfig-Enable-Mender.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/cubox-i/0001-configs-mx6cuboxi_defconfig-Enable-Mender.patch
@@ -1,0 +1,35 @@
+From 552b961abba72b55e5fc79b4767cce9d6eb424d7 Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Tue, 21 Feb 2023 14:02:24 +0000
+Subject: [PATCH] configs/mx6cuboxi_defconfig: Enable Mender
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ configs/mx6cuboxi_defconfig | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/configs/mx6cuboxi_defconfig b/configs/mx6cuboxi_defconfig
+index 46d0e8c990..17999cc99a 100644
+--- a/configs/mx6cuboxi_defconfig
++++ b/configs/mx6cuboxi_defconfig
+@@ -7,7 +7,7 @@ CONFIG_SPL_LIBCOMMON_SUPPORT=y
+ CONFIG_SPL_LIBGENERIC_SUPPORT=y
+ CONFIG_NR_DRAM_BANKS=1
+ CONFIG_ENV_SIZE=0x2000
+-CONFIG_ENV_OFFSET=0xFE000
++CONFIG_ENV_OFFSET=0x800000
+ CONFIG_MX6QDL=y
+ CONFIG_TARGET_MX6CUBOXI=y
+ CONFIG_DM_GPIO=y
+@@ -87,3 +87,8 @@ CONFIG_VIDEO_IPUV3=y
+ CONFIG_SPLASH_SCREEN=y
+ CONFIG_SPLASH_SCREEN_ALIGN=y
+ CONFIG_BMP_16BPP=y
++CONFIG_BOOTCOUNT_LIMIT=y
++CONFIG_BOOTCOUNT_ENV=y
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_MMC_ENV_DEV=1
+-- 
+2.30.2
+

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -2,3 +2,11 @@ require recipes-bsp/u-boot/u-boot-mender.inc
 require u-boot-mender-nxp.inc
 
 DEPENDS:append = " u-boot-scr"
+
+do_deploy:append:cubox-i(){
+	# Machine cubox-i requires SPL and u-boot.img to boot so
+	# these two file are concatinated together into a single file
+	rm -f ${D}/boot/${MENDER_IMAGE_BOOTLOADER_FILE}
+	install -m 644 ${D}/boot/${SPL_BINARY} ${DEPLOYDIR}/${MENDER_IMAGE_BOOTLOADER_FILE}
+	dd if=${D}/boot/${UBOOT_BINARY} of=${DEPLOYDIR}/${MENDER_IMAGE_BOOTLOADER_FILE} bs=1k seek=68
+}

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-mender-nxp.inc
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-mender-nxp.inc
@@ -15,4 +15,9 @@ SRC_URI:append:imx7dsabresd = " \
 "
 BOOTENV_SIZE:imx7dsabresd = "0x2000"
 
+SRC_URI:append:cubox-i = " \
+	file://0001-configs-mx6cuboxi_defconfig-Enable-Mender.patch \
+"
+BOOTENV_SIZE:cubox-i = "0x2000"
+
 MENDER_UBOOT_AUTO_CONFIGURE = "0"

--- a/meta-mender-nxp/templates/local.conf.append
+++ b/meta-mender-nxp/templates/local.conf.append
@@ -8,6 +8,7 @@
 #    - nitrogen8mn
 #    - nitrogen8mp
 #    - imx7dsabresd
+#    - cubox-i
 #
 MACHINE ?= "imx7s-warp"
 
@@ -48,3 +49,13 @@ MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2:imx7dsabresd = "0xE0000"
 
 # Specific Congifuration for nitrogen8mp
 MENDER_STORAGE_DEVICE:nitrogen8mp = "/dev/mmcblk2"
+
+# Specific Congifuration for cubox-i (HummingBoard)
+MENDER_IMAGE_BOOTLOADER_FILE:cubox-i = "SPL_UBOOT"
+IMAGE_BOOT_FILES:cubox-i = "boot.scr"
+MENDER_STORAGE_DEVICE:cubox-i = "/dev/mmcblk1"
+MENDER_UBOOT_STORAGE_INTERFACE:cubox-i = "mmc"
+MENDER_UBOOT_STORAGE_DEVICE:cubox-i = "1"
+# Use a single dtb and fix the warning:
+# Found more than one dtb specified
+KERNEL_DEVICETREE:cubox-i="imx6q-hummingboard.dtb"


### PR DESCRIPTION
These patches add Mender support for SolidRun HummingBoard and Cubox-i (Yocto/OE BSP machine name is `cubox-i`. To build an image follow the generic steps for nxp and add the following extra configuration, for example in `local.conf` to accept EULA:

```
# Accept end user agreement required by the BSP layer.
ACCEPT_FSL_EULA = "1"
```

I will add details about cubox-i to hub.mender.io.

Best regards,
Leon
