### PR TITLE
u-boot-fslc_%.bbappend: Overriding mender boot code integration patch

### DIFF
--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/patches/0003-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc/patches/0003-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,0 +1,51 @@
+From 6802750fbe50f8c75a6678493464347958df761b Mon Sep 17 00:00:00 2001
+From: Marcin Pasinski <marcin.pasinski@northern.tech>
+Date: Wed, 31 Jan 2018 18:10:04 +0100
+Subject: [PATCH 3/4] Integration of Mender boot code into U-Boot.
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>
+---
+ include/env_default.h     | 3 +++
+ scripts/Makefile.autoconf | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index 23430dc70d..a8c782c725 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -10,6 +10,8 @@
+ #include <env_callback.h>
+ #include <linux/stringify.h>
+ 
++#include <env_mender.h>
++
+ #ifndef USE_HOSTCC
+ #include <generated/environment.h>
+ #endif
+@@ -31,6 +33,7 @@ char default_environment[] = {
+ #else
+ const char default_environment[] = {
+ #endif
++	MENDER_ENV_SETTINGS
+ #ifndef CONFIG_USE_DEFAULT_ENV_FILE
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
+index 8a3efdb2db..5f09f52b24 100644
+--- a/scripts/Makefile.autoconf
++++ b/scripts/Makefile.autoconf
+@@ -108,7 +108,8 @@ define filechk_config_h
+ 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	echo \#include \<asm/config.h\>;				\
+ 	echo \#include \<linux/kconfig.h\>;				\
+-	echo \#include \<config_fallbacks.h\>;)
++	echo \#include \<config_fallbacks.h\>;				\
++	echo \#include \<config_mender.h\>;)
+ endef
+ 
+ include/config.h: scripts/Makefile.autoconf create_symlink FORCE
+-- 
+2.17.1
+

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-fslc/patches:"
+
 require recipes-bsp/u-boot/u-boot-mender.inc
 require u-boot-mender-nxp.inc
 


### PR DESCRIPTION
When using u-boot-fslc 0003-Integration-of-Mender-boot-code-into-U-Boot.patch from meta-mender-core does not apply cleanly and throws a warning [patch-fuzz].

This is u-boot-fslc specific issue because u-boot-fslc does not use the kirkstone version of u-boot.
u-boot-fslc uses v2022.10 while kirkstone uses u-boot v2022.01.