### PR TITLE
u-boot-fslc_%.bbappend: Fix mender integration patch override priority

### DIFF
--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-fslc_%.bbappend
@@ -1,7 +1,7 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-fslc/patches:"
-
 require recipes-bsp/u-boot/u-boot-mender.inc
 require u-boot-mender-nxp.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-fslc/patches:"
 
 DEPENDS:append = " u-boot-scr"
 


### PR DESCRIPTION
The `FILESEXTRAPATHS:prepend` in `u-boot-fslc_%.bbappend` has to be parsed after the modifications in `recipes-bsp/u-boot/u-boot-mender.inc` to let the u-boot-fslc specific patch have higher priority than the default one.


This fixes a minor mistake in my previous pull request #324