### PR TITLE
meta-mender-nxp/README.md: Add HummingBoard

### DIFF
--- a/meta-mender-nxp/README.md
+++ b/meta-mender-nxp/README.md
@@ -11,6 +11,7 @@ The supported and tested boards are:
  - [Nitrogen8MN](https://hub.mender.io/t/boundary-devices-nitrogen8m/409)
  - [Nitrogen8MP](https://hub.mender.io/t/boundary-devices-nitrogen8m/409)
  - [i.MX7D SABRE](https://hub.mender.io/t/nxp-i-mx7d-sabre/1279)
+ - [HummingBoard i.MX6 SBC](https://hub.mender.io/t/solidrun-hummingboard-and-cubox-i/5671)
 
 
 Visit the individual board links above for more information on status of the


### PR DESCRIPTION
Add SolidRun HummingBoard i.MX6 SBC which is similar to SolidRun Cubox-i and both share the same machine name from Yocto/OE BSP layer meta-freescale-3rdparty.

Changelog: None