### PR TITLE
Remove stm32mp merge artifacts

### DIFF
--- a/meta-mender-st-stm32mp/classes/stm32mp-gptimg.bbclass
+++ b/meta-mender-st-stm32mp/classes/stm32mp-gptimg.bbclass
@@ -46,7 +46,3 @@ EOF
     BUILDDIR="${TOPDIR}" wic create "$wks" --vars "${STAGING_DIR}/${MACHINE}/imgdata/" -e "${IMAGE_BASENAME}" -o "$wicout/" ${WIC_CREATE_EXTRA_ARGS}
     mv "$wicout/$(basename "${wks%.wks}")"*.direct "$outimgname"
 }
-<<<<<<< HEAD
-=======
-
->>>>>>> 9a09902 (commit for sign-off)


### PR DESCRIPTION
This change removes git merge artifacts that are incompatible with bitbake