### PR TITLE
meta-mender-ti: add initial support

### DIFF
--- a/meta-mender-ti/README.md
+++ b/meta-mender-ti/README.md
@@ -7,10 +7,12 @@ generic Mender integation.
 Supported targets:
 
 - [BeaglePlay](https://beagleboard.org/play) (default)
+- [BeagleBone AI-64](https://beagleboard.org/ai-64)
 
 Addititional information can be found on the [Mender Hub](https://hub.mender.io):
 
 - [BeaglePlay](https://hub.mender.io/t/beagleplay/5792)
+- [BeagleBone AI-64](https://hub.mender.io/t/beaglebone-ai-64/5793)
 
 ## Dependencies
 

--- a/meta-mender-ti/README.md
+++ b/meta-mender-ti/README.md
@@ -1,0 +1,56 @@
+# meta-mender-ti
+
+Mender integration layer for boards based on machines maintained in [meta-ti](https://git.yoctoproject.org/git/meta-ti).
+Note that this layer currently only contains templates, as the tested targets require no modifications beyond the
+generic Mender integation.
+
+Supported targets:
+
+- [BeaglePlay](https://beagleboard.org/play) (default)
+
+Addititional information can be found on the [Mender Hub](https://hub.mender.io):
+
+- [BeaglePlay](https://hub.mender.io/t/beagleplay/5792)
+
+## Dependencies
+
+This layer depends on:
+
+```
+URI: https://git.yoctoproject.org/poky
+branch: kirkstone
+revision: HEAD
+
+URI: https://git.yoctoproject.org/meta-arm
+layers: meta-arm, meta-arm-toolchain
+branch: kirkstone
+revision: HEAD
+
+URI: https://git.yoctoproject.org/meta-ti
+layers: meta-ti-bsp
+branch: kirkstone
+revision: HEAD
+
+URI: https://github.com/mendersoftware/meta-mender.git
+layers: meta-mender-core
+branch: kirkstone
+revision: HEAD
+```
+
+## Quick start
+
+The following commands will setup the environment and allow you to build images
+that have Mender integrated.
+
+
+```
+mkdir mender-ti && cd mender-ti
+repo init -u https://github.com/mendersoftware/meta-mender-community \
+           -m meta-mender-ti/scripts/manifest-ti.xml \
+           -b kirkstone
+repo sync
+source setup-environment ti
+bitbake core-image-base
+```
+
+Flash the resulting `tmp/deploy/images/beagleplay/core-image-base-xyz.sdimg` file to a SD card and boot up.

--- a/meta-mender-ti/scripts/manifest-ti.xml
+++ b/meta-mender-ti/scripts/manifest-ti.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+  <manifest>
+
+  <remote fetch="git://git.yoctoproject.org" name="yocto"/>
+  <remote fetch="git://git.openembedded.org" name="oe"/>
+
+  <project name="poky" remote="yocto" revision="kirkstone" path="sources/poky"/>
+  <project name="meta-openembedded" remote="oe" revision="kirkstone" path="sources/meta-openembedded"/>
+  <project name="meta-arm" remote="yocto" revision="kirkstone" path="sources/meta-arm"/>
+  <project name="meta-ti" remote="yocto" revision="kirkstone" path="sources/meta-ti"/>
+
+  <include name="scripts/mender.xml"/>
+
+  </manifest>

--- a/meta-mender-ti/templates/bblayers.conf.sample
+++ b/meta-mender-ti/templates/bblayers.conf.sample
@@ -1,0 +1,19 @@
+# POKY_BBLAYERS_CONF_VERSION is increased each time build/conf/bblayers.conf
+# changes incompatibly
+POKY_BBLAYERS_CONF_VERSION = "2"
+
+BBPATH = "${TOPDIR}"
+BBFILES ?= ""
+
+BBLAYERS ?= " \
+  ${TOPDIR}/../sources/poky/meta \
+  ${TOPDIR}/../sources/poky/meta-poky \
+  ${TOPDIR}/../sources/poky/meta-yocto-bsp \
+  ${TOPDIR}/../sources/meta-openembedded/meta-oe \
+  ${TOPDIR}/../sources/meta-arm/meta-arm \
+  ${TOPDIR}/../sources/meta-arm/meta-arm-toolchain \
+  ${TOPDIR}/../sources/meta-ti/meta-ti-bsp \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-core \
+  ${TOPDIR}/../sources/meta-mender/meta-mender-demo \
+"
+

--- a/meta-mender-ti/templates/local.conf.append
+++ b/meta-mender-ti/templates/local.conf.append
@@ -14,3 +14,15 @@ MENDER_PARTITION_ALIGNMENT:beagleplay = "1048576"
 # attention: sdimg.bmap seems to not work correctly.
 # in order to avoid accidential usage, not building it
 IMAGE_FSTYPES:remove:beagleplay = "wic wic.bmap mender.bmap sdimg.bmap"
+
+# Integration for BeagleBone-AI64 board
+MENDER_FEATURES_ENABLE:append:beaglebone-ai64 = " mender-image-sd"
+MENDER_FEATURES_DISABLE:append:beaglebone-ai64 = "mender-image-uefi"
+MENDER_STORAGE_DEVICE:beaglebone-ai64 = "/dev/mmcblk1"
+# these two settings replicate the wks set up from meta-ti
+MENDER_BOOT_PART_SIZE_MB:beaglebone-ai64 = "128"
+MENDER_PARTITION_ALIGNMENT:beaglebone-ai64 = "1048576"
+# remove image types that we do not need
+# attention: sdimg.bmap seems to not work correctly.
+# in order to avoid accidential usage, not building it
+IMAGE_FSTYPES:remove:beaglebone-ai64 = "wic wic.bmap mender.bmap sdimg.bmap"

--- a/meta-mender-ti/templates/local.conf.append
+++ b/meta-mender-ti/templates/local.conf.append
@@ -1,0 +1,16 @@
+
+# Appended fragment from meta-mender-community/meta-mender-ti/templates
+
+MACHINE ?= "beagleplay"
+
+# Integration for BeaglePlay board
+MENDER_FEATURES_ENABLE:append:beagleplay = " mender-image-sd"
+MENDER_FEATURES_DISABLE:append:beagleplay = "mender-image-uefi"
+MENDER_STORAGE_DEVICE:beagleplay = "/dev/mmcblk1"
+# these two settings replicate the wks set up from meta-ti
+MENDER_BOOT_PART_SIZE_MB:beagleplay = "128"
+MENDER_PARTITION_ALIGNMENT:beagleplay = "1048576"
+# remove image types that we do not need
+# attention: sdimg.bmap seems to not work correctly.
+# in order to avoid accidential usage, not building it
+IMAGE_FSTYPES:remove:beagleplay = "wic wic.bmap mender.bmap sdimg.bmap"

--- a/scripts/setup-environment
+++ b/scripts/setup-environment
@@ -43,6 +43,7 @@ targets=(
     "rockchip"
     "sunxi"
     "tegra"
+    "ti"
     "up"
     "variscite")
 


### PR DESCRIPTION
This adds initial support for boards maintained in meta-ti. The first board integration is the BeaglePlay platform.