### PR TITLE
meta-mender-nxp: add imx8mq-voipac to README

### DIFF
--- a/meta-mender-nxp/README.md
+++ b/meta-mender-nxp/README.md
@@ -9,6 +9,7 @@ The supported and tested boards are:
  - [Nitrogen8M](https://hub.mender.io/t/boundary-devices-nitrogen8m/409)
  - [Nitrogen8MM](https://hub.mender.io/t/boundary-devices-nitrogen8m/409)
  - [i.MX7D SABRE](https://hub.mender.io/t/nxp-i-mx7d-sabre/1279)
+ - [iMX8M Dev Kit by Voipac](https://hub.mender.io/t/voipac-imx8mq-industrial-development-kit/5865)
 
 
 Visit the individual board links above for more information on status of the


### PR DESCRIPTION
The board integration has already been merged, add the missing entry and link to Mender Hub post.

Changelog: Title
Ticket: None