### PR TITLE
feat: kas configurations for known boards

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,100 @@
+name: build boards
+
+on:
+  [push]
+
+env:
+  BUILDDIR: gh
+  DL_DIR: ${{ vars.BUILD_DL_DIR }}
+  SSTATE_DIR: ${{ vars.BUILD_SSTATE_DIR }}
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - name: Clean up
+        run: rm -fR $BUILDDIR
+
+  build:
+    needs: [prepare]
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [
+          beaglebone,
+          beaglebone-ai64,
+          beagleplay,
+          hardkernel-odroidc2,
+          hardkernel-odroidc4,
+          hardkernel-odroidhc4,
+          hardkernel-odroidn2,
+          hardkernel-odroidn2plus,
+          imx7d-pico,
+          imx7s-warp,
+          jetson-agx-xavier-devkit,
+          jetson-nano-2gb-devkit,
+          jetson-nano-devkit-emmc,
+          jetson-nano-devkit,
+          jetson-tx2-devkit-4gb,
+          jetson-tx2-devkit-tx2i,
+          jetson-tx2-devkit,
+          jetson-xavier-nx-devkit-emmc,
+          jetson-xavier-nx-devkit-tx2-nx,
+          jetson-xavier-nx-devkit,
+          libretech-ac,
+          libretech-cc,
+          nitrogen8m,
+          nitrogen8mm,
+          nitrogen8mn,
+          nitrogen8mp,
+          osd32mp1-emmc-mender,
+          raspberrypi,
+          raspberrypi-cm,
+          raspberrypi0,
+          raspberrypi0-wifi,
+          raspberrypi2,
+          raspberrypi0-2w,
+          raspberrypi0-2w-64,
+          raspberrypi3,
+          raspberrypi3-64,
+          raspberrypi-cm3,
+          raspberrypi4,
+          raspberrypi4-64,
+          qemuarm64,
+          qemux86-64,
+          vexpress-qemu,
+          vexpress-qemu-flash,
+          colibri-imx6ull,
+          colibri-imx8x,
+          verdin-imx8mm,
+          verdin-imx8mp,
+          imx8mm-var-dart,
+          sama5d27-som1-ek-sd,
+          sama5d3-xplained
+        ]
+        experimental: [false]
+        include:
+          - board: cubox-i
+            experimental: true
+          - board: apalis-imx6
+            experimental: true
+          - board: apalis-imx8
+            experimental: true
+          - board: stm32mp15-disco
+            experimental: true
+          - board: rock-pi-e
+            experimental: true
+
+    runs-on: [self-hosted, linux, x64]
+    container:
+      # the container image needs to be effectively hardcoded, it seems.
+      image: ghcr.io/theyoctojester/devcontainer-base-yoep:main
+      volumes:
+        - ${{ vars.KAS_DL_DIR }}:${{ vars.BUILD_DL_DIR }}
+        - ${{ vars.KAS_SSTATE_DIR }}:${{ vars.BUILD_SSTATE_DIR }}
+      options: --user ${{ vars.KAS_UID }}:${{ vars.KAS_GID }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: enter build dir and build
+        run: mkdir -p $BUILDDIR/${{ matrix.board }} && cd $BUILDDIR/${{ matrix.board }} && kas build ../../kas/${{ matrix.board }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
             experimental: true
           - board: apalis-imx8
             experimental: true
+          - board: apalis-imx8-boot2qt
+            experimental: true
           - board: stm32mp15-disco
             experimental: true
           - board: rock-pi-e

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,10 @@
 name: build boards
 
 on:
-  [push]
+  push:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 2 * * 6'
 
 env:
   BUILDDIR: gh

--- a/kas/apalis-imx6.yml
+++ b/kas/apalis-imx6.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: apalis-imx6
+
+local_conf_header:
+  apalis-imx6: |
+    TEZI_STORAGE_DEVICE = "mmcblk0"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk2"
+    MENDER_UBOOT_STORAGE_DEVICE = "0"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    KERNEL_DEVICETREE = "imx6q-apalis-ixora-v1.1.dtb"

--- a/kas/apalis-imx6.yml
+++ b/kas/apalis-imx6.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 

--- a/kas/apalis-imx8-boot2qt.yml
+++ b/kas/apalis-imx8-boot2qt.yml
@@ -1,0 +1,70 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+
+repos:
+  openembedded-core:
+    refspec: f7766da462905ec67bf549d46b8017be36cd5b2a
+  meta-yocto:
+    url: https://git.yoctoproject.org/git/meta-yocto
+    refspec: ca9c465e37b693ab768ee8e21a929d1c18956e98
+    layers:
+      meta-poky:
+  meta-openembedded:
+    refspec: a8055484f2829e8dfd03d5c8520b2c611aa7ebd2
+    layers:
+      meta-python:
+      meta-multimedia:
+      meta-networking:
+      meta-initramfs:
+  meta-qt6:
+    url: git://code.qt.io/yocto/meta-qt6
+    refspec: c06b8b3e34f0dccfebb795a279010db1ab68ed2e
+  meta-boot2qt:
+    url: git://code.qt.io/yocto/meta-boot2qt
+    refspec: 7ec529584af7375e1a460b5093ccc42d406c6541
+    layers:
+      meta-boot2qt:
+      meta-boot2qt-distro:
+  meta-toradex-bsp-common:
+    url: https://git.toradex.com/meta-toradex-bsp-common.git
+    refspec: 1a14c2724ab0cbcf3d01042fed7b60b48c8ab836
+  meta-toradex-nxp:
+    url: https://git.toradex.com/meta-toradex-nxp.git
+    refspec: 364341c23ea49fb875e84f980b208699311aaf9c
+  meta-mender-community:
+    layers:
+      meta-mender-toradex-nxp:
+
+machine: apalis-imx8
+
+distro: b2qt
+
+local_conf_header:
+  qt: |
+    LICENSE_FLAGS_ACCEPTED = "commercial"
+    QT_SDK_PATH = ""
+
+  toradex: |
+    INHERIT += "mender-toradex"
+    INHERIT += "mender-full"
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv tdxargs \${tdxargs} \${bootargs}; "
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv overlays_file /boot/overlays.txt ; setenv overlays_prefix boot/overlays/ "
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    IMAGE_CLASSES += "image_type_mender_tezi"
+    IMAGE_FSTYPES:append = " mender_tezi"
+    IMAGE_FSTYPES:remove = " teziimg"
+    KERNEL_IMAGETYPE:aarch64_mender-grub = "Image"
+    IMAGE_BOOT_FILES:remove:mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
+    IMAGE_BOOT_FILES:remove:mender-uboot = "zImage ${KERNEL_DEVICETREE} overlays.txt overlays/*;overlays/"
+
+  apalis-imx8: |
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "0"
+    MENDER_BOOT_PART_SIZE_MB = "32"
+    OFFSET_SPL_PAYLOAD = ""
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    KERNEL_DEVICETREE = "freescale/imx8qm-apalis-v1.1-ixora-v1.2.dtb"

--- a/kas/apalis-imx8-boot2qt.yml
+++ b/kas/apalis-imx8-boot2qt.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
 
 repos:

--- a/kas/apalis-imx8.yml
+++ b/kas/apalis-imx8.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 

--- a/kas/apalis-imx8.yml
+++ b/kas/apalis-imx8.yml
@@ -1,0 +1,17 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: apalis-imx8
+
+local_conf_header:
+  apalis-imx8: |
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "0"
+    MENDER_BOOT_PART_SIZE_MB = "32"
+    OFFSET_SPL_PAYLOAD = ""
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    KERNEL_DEVICETREE = "freescale/imx8qm-apalis-v1.1-ixora-v1.2.dtb"

--- a/kas/beaglebone-ai64.yml
+++ b/kas/beaglebone-ai64.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/ti.yml
+
+machine: beaglebone-ai64
+
+local_conf_header:
+  beagleplay: |
+    MENDER_FEATURES_ENABLE:append = " mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = "mender-image-uefi"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
+    MENDER_BOOT_PART_SIZE_MB = "128"
+    MENDER_PARTITION_ALIGNMENT = "1048576"
+    IMAGE_FSTYPES:remove = "wic wic.bmap mender.bmap sdimg.bmap"

--- a/kas/beaglebone-ai64.yml
+++ b/kas/beaglebone-ai64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/ti.yml
 
 machine: beaglebone-ai64

--- a/kas/beaglebone.yml
+++ b/kas/beaglebone.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
 
 repos:
   meta-yocto:

--- a/kas/beaglebone.yml
+++ b/kas/beaglebone.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+
+repos:
+  meta-yocto:
+    url: git://git.yoctoproject.org/meta-yocto
+    refspec: 15fd5faf510329a8022b60c53576eb76451d4358
+    layers:
+      meta-yocto-bsp:
+  meta-mender-community:
+    layers:
+      meta-mender-beaglebone:
+
+machine: beaglebone-yocto

--- a/kas/beagleplay.yml
+++ b/kas/beagleplay.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/ti.yml
+
+machine: beagleplay
+
+local_conf_header:
+  beagleplay: |
+    MENDER_FEATURES_ENABLE:append = " mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = "mender-image-uefi"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
+    MENDER_BOOT_PART_SIZE_MB = "128"
+    MENDER_PARTITION_ALIGNMENT = "1048576"
+    IMAGE_FSTYPES:remove = "wic wic.bmap mender.bmap sdimg.bmap"

--- a/kas/beagleplay.yml
+++ b/kas/beagleplay.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/ti.yml
 
 machine: beagleplay

--- a/kas/colibri-imx6ull.yml
+++ b/kas/colibri-imx6ull.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full-ubi.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 
@@ -9,8 +9,6 @@ machine: colibri-imx6ull
 
 local_conf_header:
   colibri-imx8x: |
-    INHERIT:remove = " mender-full "
-    INHERIT:append = " mender-full-ubi "
     IMAGE_FSTYPES:remove = " mtdimg teziimg"
     MENDER_MTDIDS = "nand0=gpmi-nand"
     MENDER_MTDPARTS = "gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,-(ubi)"

--- a/kas/colibri-imx6ull.yml
+++ b/kas/colibri-imx6ull.yml
@@ -1,0 +1,22 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: colibri-imx6ull
+
+local_conf_header:
+  colibri-imx8x: |
+    INHERIT:remove = " mender-full "
+    INHERIT:append = " mender-full-ubi "
+    IMAGE_FSTYPES:remove = " mtdimg teziimg"
+    MENDER_MTDIDS = "nand0=gpmi-nand"
+    MENDER_MTDPARTS = "gpmi-nand:512k(mx6ull-bcb),1536k(u-boot1)ro,1536k(u-boot2)ro,-(ubi)"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "512"
+    MENDER_STORAGE_PEB_SIZE = "131072"
+    MKUBIFS_ARGS = "-m ${MENDER_FLASH_MINIMUM_IO_UNIT} -e ${MENDER_UBI_LEB_SIZE} -c ${MENDER_MAXIMUM_LEB_COUNT} --space-fixup"
+    MENDER_FEATURES_ENABLE:remove = " mender-image-sd mender-image-grub mender-image-uefi"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi mender-image-sd"
+    KERNEL_DEVICETREE = "imx6ull-colibri-wifi-eval-v3.dtb"

--- a/kas/colibri-imx8x.yml
+++ b/kas/colibri-imx8x.yml
@@ -1,0 +1,17 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: colibri-imx8x
+
+local_conf_header:
+  colibri-imx8x: |
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "0"
+    MENDER_BOOT_PART_SIZE_MB = "32"
+    OFFSET_SPL_PAYLOAD = ""
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    KERNEL_DEVICETREE = "freescale/imx8qxp-colibri-iris-v2.dtb"

--- a/kas/colibri-imx8x.yml
+++ b/kas/colibri-imx8x.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 

--- a/kas/cubox-i.yml
+++ b/kas/cubox-i.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
 
 machine: cubox-i

--- a/kas/cubox-i.yml
+++ b/kas/cubox-i.yml
@@ -1,0 +1,18 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+
+machine: cubox-i
+
+local_conf_header:
+  cubox-i: |
+    MENDER_IMAGE_BOOTLOADER_FILE = "SPL_UBOOT"
+    IMAGE_BOOT_FILES = "boot.scr"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "1"
+    # Use a single dtb and fix the warning:
+    # Found more than one dtb specified
+    KERNEL_DEVICETREE = "imx6q-hummingboard.dtb"

--- a/kas/cubox-i.yml
+++ b/kas/cubox-i.yml
@@ -2,6 +2,7 @@ header:
   version: 11
   includes:
   - kas/include/mender-full.yml
+  - kas/include/poky.yml
   - kas/include/nxp.yml
 
 machine: cubox-i

--- a/kas/hardkernel-odroidc2.yml
+++ b/kas/hardkernel-odroidc2.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: hardkernel-odroidc2
+
+local_conf_header:
+  hardkernel-odroidc2: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/hardkernel-odroidc2.yml
+++ b/kas/hardkernel-odroidc2.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: hardkernel-odroidc2

--- a/kas/hardkernel-odroidc4.yml
+++ b/kas/hardkernel-odroidc4.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: hardkernel-odroidc4

--- a/kas/hardkernel-odroidc4.yml
+++ b/kas/hardkernel-odroidc4.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: hardkernel-odroidc4
+
+local_conf_header:
+  hardkernel-odroidc4: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/hardkernel-odroidhc4.yml
+++ b/kas/hardkernel-odroidhc4.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: hardkernel-odroidhc4
+
+local_conf_header:
+  hardkernel-odroidhc4: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/hardkernel-odroidhc4.yml
+++ b/kas/hardkernel-odroidhc4.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: hardkernel-odroidhc4

--- a/kas/hardkernel-odroidn2.yml
+++ b/kas/hardkernel-odroidn2.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: hardkernel-odroidn2
+
+local_conf_header:
+  hardkernel-odroidn2: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/hardkernel-odroidn2.yml
+++ b/kas/hardkernel-odroidn2.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: hardkernel-odroidn2

--- a/kas/hardkernel-odroidn2plus.yml
+++ b/kas/hardkernel-odroidn2plus.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: hardkernel-odroidn2plus
+
+local_conf_header:
+  hardkernel-odroidn2plus: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/hardkernel-odroidn2plus.yml
+++ b/kas/hardkernel-odroidn2plus.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: hardkernel-odroidn2plus

--- a/kas/imx7d-pico.yml
+++ b/kas/imx7d-pico.yml
@@ -1,0 +1,20 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+
+machine: imx7d-pico
+
+local_conf_header:
+  imx7d-pico: |
+    IMAGE_BOOT_FILES = "boot.scr"
+    KERNEL_DEVICETREE:remove = "imx7d-pico-hobbit.dtb imx7d-pico-dwarf.dtb"
+    UBOOT_CONFIG:remove = "dwarf hobbit generic nymph"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "0"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk2"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 = "0xC0000"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 = "0xE0000"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"

--- a/kas/imx7d-pico.yml
+++ b/kas/imx7d-pico.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
 

--- a/kas/imx7dsabresd.yml
+++ b/kas/imx7dsabresd.yml
@@ -1,0 +1,13 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+
+machine: imx7dsabresd
+
+local_conf_header:
+  imx7dsabresd: |
+    IMAGE_BOOT_FILES = "boot.scr"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 = "0xC0000"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 = "0xE0000"

--- a/kas/imx7dsabresd.yml
+++ b/kas/imx7dsabresd.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
 
 machine: imx7dsabresd

--- a/kas/imx7s-warp.yml
+++ b/kas/imx7s-warp.yml
@@ -1,0 +1,17 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+
+machine: imx7s-warp
+
+local_conf_header:
+  imx7s-warp: |
+    IMAGE_BOOT_FILES = "boot.scr"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "0"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk2"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 = "0xC0000"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 = "0xE0000"

--- a/kas/imx7s-warp.yml
+++ b/kas/imx7s-warp.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
 

--- a/kas/imx8mm-var-dart.yml
+++ b/kas/imx8mm-var-dart.yml
@@ -1,0 +1,29 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+  - kas/include/variscite.yml
+
+local_conf_header:
+  fsl: |
+    ACCEPT_FSL_EULA = "1"
+
+  imx8mm-var-dart: |
+    MENDER_IMAGE_BOOTLOADER_FILE = "u-boot-spl.img"
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "2"
+    IMAGE_BOOT_FILES = ""
+    MENDER_BOOT_PART_SIZE_MB = "0"
+    MENDER_PARTITION_ALIGNMENT = "4194304"
+    IMAGE_FSTYPES:remove = "tar.gz ext4 wic.gz wic.bmap multiubi mender.bmap"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    MENDER_IMAGE_BOOTLOADER_FILE = "imx-boot"
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "66"
+    MENDER_STORAGE_DEVICE_BASE = "/dev/mmcblk1p"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
+    UBOOT_CONFIG = "sd"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "8192"
+
+machine: imx8mm-var-dart

--- a/kas/imx8mm-var-dart.yml
+++ b/kas/imx8mm-var-dart.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
   - kas/include/variscite.yml

--- a/kas/include/amlogic.yml
+++ b/kas/include/amlogic.yml
@@ -1,0 +1,28 @@
+header:
+  version: 11
+
+repos:
+  meta-meson:
+    url: https://github.com/superna9999/meta-meson
+    refspec: 2255f691bef0fd23228b777c2043548581917382
+
+  meta-mender-community:
+    layers:
+      meta-mender-amlogic:
+
+local_conf_header:
+  amlogic: |
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    IMAGE_FSTYPES:remove = "wic"
+    IMAGE_CLASSES = "sdimg-meson"
+    KERNEL_IMAGETYPE = "fitImage"
+    MACHINE_EXTRA_RRECOMMENDS += " kernel-devicetree"
+    IMAGE_BOOT_FILES:remove = "Image"
+    IMAGE_BOOT_FILES:remove = "fitImage"
+    MENDER_BOOT_PART_SIZE_MB = "0"
+    MENDER_PARTITION_ALIGNMENT = "4194304"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET = "4194304"
+    MENDER_RESERVED_SPACE_BOOTLOADER_DATA = "8388608"

--- a/kas/include/atmel.yml
+++ b/kas/include/atmel.yml
@@ -4,11 +4,11 @@ header:
 repos:
   meta-atmel:
     url: https://github.com/linux4sam/meta-atmel
-    refspec: kirkstone
+    refspec: 7d0f089e6c924b2cbb1a67a98cf49e6412efbd41
 
   meta-arm:
     url: git://git.yoctoproject.org/meta-arm.git
-    refspec: kirkstone
+    refspec: 96aad3b29aa7a5ee4df5cf617a6336e5218fa9bd
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/include/boundarydevices.yml
+++ b/kas/include/boundarydevices.yml
@@ -1,0 +1,7 @@
+header:
+  version: 11
+
+repos:
+  meta-boundary:
+    url: https://github.com/boundarydevices/meta-boundary.git
+    refspec: a923c43ec40bd406e719df7bd645f7da0728ec7a

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -35,8 +35,7 @@ local_conf_header:
     PACKAGE_CLASSES = "package_ipk"
     INIT_MANAGER = "systemd"
   
-  mender: |
-    INHERIT += "mender-full"
+  mender-artifact: |
     MENDER_ARTIFACT_NAME = "gha_autobuild"
 
 target:

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -1,0 +1,43 @@
+header:
+  version: 11
+
+distro: ""
+
+repos:
+  openembedded-core:
+    url: http://git.openembedded.org/openembedded-core
+    refspec: b67e714b367a08fdeeeff68c2d9495ec9bc07304
+    layers:
+      meta:
+
+  bitbake:
+    url: http://git.openembedded.org/bitbake
+    refspec: 2802adb572eb73a3eb2725a74a9bbdaafc543fa7
+    path: "openembedded-core/bitbake"
+    layers:
+      bitbake: excluded
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: 571e36e20e9d1f27af0eb4545291beeb64f280e2
+    layers:
+      meta-oe:
+
+  meta-mender:
+    url: https://github.com/mendersoftware/meta-mender.git
+    refspec: 73a5d1098282d968901ee581c85f28cfbe928242
+    layers:
+      meta-mender-core:
+
+local_conf_header:
+  base: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    INIT_MANAGER = "systemd"
+  
+  mender: |
+    INHERIT += "mender-full"
+    MENDER_ARTIFACT_NAME = "gha_autobuild"
+
+target:
+  - core-image-minimal

--- a/kas/include/mender-full-ubi.yml
+++ b/kas/include/mender-full-ubi.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+
+local_conf_header:
+  mender-full: |
+    INHERIT += "mender-full-ubi"

--- a/kas/include/mender-full.yml
+++ b/kas/include/mender-full.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+
+local_conf_header:
+  mender-full: |
+    INHERIT += "mender-full"

--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -1,0 +1,29 @@
+header:
+  version: 11
+
+repos:
+  meta-freescale:
+    url: https://github.com/Freescale/meta-freescale.git
+    refspec: 82cbf4e5adac1017adc1e4a2ce056c57b3148ba0
+  meta-freescale-3rdparty:
+    url: https://github.com/Freescale/meta-freescale-3rdparty.git
+    refspec: bf12dc09d88a53d7345377de277fbcc20ed87235
+  meta-freescale-distro:
+    url: https://github.com/Freescale/meta-freescale-distro.git
+    refspec: d5bbb487b2816dfc74984a78b67f7361ce404253
+
+  meta-mender-community:
+    layers:
+      meta-mender-nxp:
+
+distro: fslc-framebuffer
+
+local_conf_header:
+  nxp: |
+    ACCEPT_FSL_EULA = "1"
+    MENDER_BOOT_PART_SIZE_MB = "64"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "4096"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_FSTYPES:remove = " rpi-sdimg"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"

--- a/kas/include/poky.yml
+++ b/kas/include/poky.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+
+repos:
+  meta-yocto:
+    url: https://git.yoctoproject.org/git/meta-yocto
+    refspec: 15fd5faf510329a8022b60c53576eb76451d4358
+    layers:
+      meta-poky:
+
+distro: poky

--- a/kas/include/qemu.yml
+++ b/kas/include/qemu.yml
@@ -1,0 +1,7 @@
+header:
+  version: 11
+
+repos:
+  meta-mender:
+    layers:
+      meta-mender-qemu:

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -1,0 +1,19 @@
+header:
+  version: 11
+
+repos:
+  meta-raspberrypi:
+    url: https://github.com/agherzan/meta-raspberrypi.git
+    refspec: kirkstone
+
+  meta-mender:
+    layers:
+      meta-mender-raspberrypi:
+
+local_conf_header:
+  raspberrypi: |
+    RPI_USE_U_BOOT = "1"
+    ENABLE_UART = "1"
+    MENDER_BOOT_PART_SIZE_MB = "100"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_FSTYPES:remove = " rpi-sdimg"

--- a/kas/include/rockchip.yml
+++ b/kas/include/rockchip.yml
@@ -1,0 +1,29 @@
+header:
+  version: 11
+
+repos:
+  meta-arm:
+    url: git://git.yoctoproject.org/meta-arm.git
+    refspec: kirkstone
+    layers:
+      meta-arm:
+      meta-arm-toolchain:
+  meta-rockchip:
+    url: git://git.yoctoproject.org/meta-rockchip.git
+    refspec: 1f5e7b10eef4e4906daee7e7f03211823f832ce7
+
+  meta-mender-community:
+    layers:
+      meta-mender-rockchip:
+
+local_conf_header:
+  rockchip: |
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "1"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image mender-client-install mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    IMAGE_BOOT_FILES:remove = "fitImage"
+    IMAGE_BOOT_FILES:append = "boot.scr"
+    IMAGE_FSTYPES:remove = "wic wic.bmap mender.bmap"
+    IMAGE_CLASSES += "rockchip-sdimg"
+    MENDER_PARTITION_ALIGNMENT = "10485760"

--- a/kas/include/st.yml
+++ b/kas/include/st.yml
@@ -1,0 +1,51 @@
+header:
+  version: 11
+
+repos:
+  # needs a specific version due to versioned overrides, like gstreamer
+  openembedded-core:
+    url: http://git.openembedded.org/openembedded-core
+    refspec: f7766da462905ec67bf549d46b8017be36cd5b2a
+  meta-openembedded:
+    layers:
+      meta-python:
+      meta-gnome:
+      meta-initramfs:
+      meta-multimedia:
+      meta-networking:
+      meta-webserver:
+      meta-filesystems:
+      meta-perl:
+  meta-qt5:
+    url: https://github.com/meta-qt5/meta-qt5
+    refspec: 5b71df60e523423b9df6793de9387f87a149ac42
+  meta-st-openstlinux:
+    url: https://github.com/STMicroelectronics/meta-st-openstlinux
+    refspec: cb736b403d0fef2a02390695613b6b4bb13ca1b7
+  meta-st-stm32mp:
+    url: https://github.com/STMicroelectronics/meta-st-stm32mp
+    refspec: ca501bd7dbe023682903ceedddaacd940b0898f4
+  meta-st-stm32mp-addons:
+    url: https://github.com/STMicroelectronics/meta-st-stm32mp-addons
+    refspec: f1a18b73343afd8dd5f9aa7f5b605d139fb9e4a8
+  meta-st-scripts:
+    url: https://github.com/STMicroelectronics/meta-st-scripts
+    refspec: bc063e7af04d04aff66401eb73610381bebc49a0
+    layers:
+      bitbake: excluded
+
+distro: openstlinux-weston
+
+local_conf_header:
+  st: |
+    MENDER_FEATURES_ENABLE:append = " \
+      mender-client-install \
+      mender-systemd \
+      mender-uboot \
+      mender-growfs-data \
+      mender-image \
+    "
+    MENDER_FEATURES_DISABLE:append = " \
+      mender-grub \
+      mender-image-uefi \
+    "

--- a/kas/include/tegra.yml
+++ b/kas/include/tegra.yml
@@ -1,0 +1,25 @@
+header:
+  version: 11
+
+repos:
+  meta-tegra:
+    url: https://github.com/OE4T/meta-tegra.git
+    refspec: kirkstone-l4t-r32.7.x
+  meta-tegra-community:
+    url: https://github.com/OE4T/meta-tegra-community.git
+    refspec: kirkstone-l4t-r32.7.x
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: kirkstone
+    layers:
+      meta-python:
+
+  meta-mender-community:
+    layers:
+      meta-mender-tegra:
+
+local_conf_header:
+  tegra: |
+    INHERIT += "tegra-mender-setup"
+    MENDER_FEATURES_ENABLE:append = " mender-growfs-data"

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -1,0 +1,15 @@
+header:
+  version: 11
+
+repos:
+  meta-arm:
+    url: https://git.yoctoproject.org/meta-arm
+    refspec: kirkstone
+    layers:
+      meta-arm:
+      meta-arm-toolchain:
+  meta-ti:
+    url: https://git.yoctoproject.org/meta-ti
+    refspec: kirkstone
+    layers:
+      meta-ti-bsp:

--- a/kas/include/toradex.yml
+++ b/kas/include/toradex.yml
@@ -5,9 +5,9 @@ repos:
   openembedded-core:
     refspec: f7766da462905ec67bf549d46b8017be36cd5b2a
   meta-freescale:
-    refspec: 3068a16ff6fde4d025f234332b953456e93cc8f6
+    refspec: ded147b76123365f2700fd8cab402869eca3219a
   meta-freescale-3rdparty:
-    refspec: 6d8213fc5ec192c33f963b8095d1f01af1574eea
+    refspec: 5977197340c7a7db17fe3e02a4e014ad997565ae
   meta-freescale-distro:
     refspec: ecd571288e41a8b6195f226b61be330072e42f81
   meta-yocto:
@@ -16,7 +16,7 @@ repos:
     layers:
       meta-poky:
   meta-openembedded:
-    refspec: 8f96c05f6d82fde052f2cb1652c13922814accb0
+    refspec: a8055484f2829e8dfd03d5c8520b2c611aa7ebd2
     layers:
       meta-python:
       meta-gnome:
@@ -32,10 +32,10 @@ repos:
     refspec: 095032507d6560ff6bb916982732a2190019b97f
   meta-toradex-bsp-common:
     url: https://git.toradex.com/meta-toradex-bsp-common.git
-    refspec: 0a52bbb4b3759d21848330bac72f1b23ac9d6c7d
+    refspec: 1a14c2724ab0cbcf3d01042fed7b60b48c8ab836
   meta-toradex-nxp:
     url: https://git.toradex.com/meta-toradex-nxp.git
-    refspec: a80de26deaaf94fd735bf00ce724ed568f965b04
+    refspec: 364341c23ea49fb875e84f980b208699311aaf9c
   meta-toradex-demos:
     url: https://git.toradex.com/meta-toradex-demos.git
     refspec: 6cbe18653ab705592671001daab88a7c58c81a69

--- a/kas/include/toradex.yml
+++ b/kas/include/toradex.yml
@@ -1,0 +1,62 @@
+header:
+  version: 11
+
+repos:
+  openembedded-core:
+    refspec: f7766da462905ec67bf549d46b8017be36cd5b2a
+  meta-freescale:
+    refspec: 3068a16ff6fde4d025f234332b953456e93cc8f6
+  meta-freescale-3rdparty:
+    refspec: 6d8213fc5ec192c33f963b8095d1f01af1574eea
+  meta-freescale-distro:
+    refspec: ecd571288e41a8b6195f226b61be330072e42f81
+  meta-yocto:
+    url: https://git.yoctoproject.org/git/meta-yocto
+    refspec: ca9c465e37b693ab768ee8e21a929d1c18956e98
+    layers:
+      meta-poky:
+  meta-openembedded:
+    refspec: 8f96c05f6d82fde052f2cb1652c13922814accb0
+    layers:
+      meta-python:
+      meta-gnome:
+      meta-xfce:
+      meta-multimedia:
+      meta-networking:
+      meta-filesystems:
+  meta-qt5:
+    url: https://github.com/meta-qt5/meta-qt5
+    refspec: 5b71df60e523423b9df6793de9387f87a149ac42
+  meta-toradex-distro:
+    url: https://git.toradex.com/meta-toradex-distro.git
+    refspec: 095032507d6560ff6bb916982732a2190019b97f
+  meta-toradex-bsp-common:
+    url: https://git.toradex.com/meta-toradex-bsp-common.git
+    refspec: 0a52bbb4b3759d21848330bac72f1b23ac9d6c7d
+  meta-toradex-nxp:
+    url: https://git.toradex.com/meta-toradex-nxp.git
+    refspec: a80de26deaaf94fd735bf00ce724ed568f965b04
+  meta-toradex-demos:
+    url: https://git.toradex.com/meta-toradex-demos.git
+    refspec: 6cbe18653ab705592671001daab88a7c58c81a69
+  meta-mender-community:
+    layers:
+      meta-mender-toradex-nxp:
+
+distro: tdx-xwayland
+
+local_conf_header:
+  toradex: |
+    INHERIT += "toradex-mirrors toradex-sanity"
+    INHERIT += "mender-toradex"
+    INHERIT += "mender-full"
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv tdxargs \${tdxargs} \${bootargs}; "
+    MENDER_UBOOT_POST_SETUP_COMMANDS:append = " ; setenv overlays_file /boot/overlays.txt ; setenv overlays_prefix boot/overlays/ "
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"
+    IMAGE_CLASSES += "image_type_mender_tezi"
+    IMAGE_FSTYPES:append = " mender_tezi"
+    IMAGE_FSTYPES:remove = " teziimg"
+    KERNEL_IMAGETYPE:aarch64_mender-grub = "Image"
+    IMAGE_BOOT_FILES:remove:mender-grub = "boot.scr-verdin-imx8mm;boot.scr"
+    IMAGE_BOOT_FILES:remove:mender-uboot = "zImage ${KERNEL_DEVICETREE} overlays.txt overlays/*;overlays/"

--- a/kas/include/variscite.yml
+++ b/kas/include/variscite.yml
@@ -1,0 +1,18 @@
+header:
+  version: 11
+
+repos:
+  meta-openembedded:
+    layers:
+      meta-python:
+      meta-multimedia:
+      meta-networking:
+      meta-filesystems:
+  meta-variscite-bsp:
+    url: https://github.com/varigit/meta-variscite-bsp
+    refspec: 9bd972eece1e17cfb928863de8b2ae399a073c54
+  meta-mender-community:
+    layers:
+      meta-mender-variscite:
+
+distro: fslc-x11

--- a/kas/jetson-agx-xavier-devkit.yml
+++ b/kas/jetson-agx-xavier-devkit.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-agx-xavier-devkit.yml
+++ b/kas/jetson-agx-xavier-devkit.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-agx-xavier-devkit

--- a/kas/jetson-nano-2gb-devkit.yml
+++ b/kas/jetson-nano-2gb-devkit.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-nano-2gb-devkit.yml
+++ b/kas/jetson-nano-2gb-devkit.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-nano-2gb-devkit

--- a/kas/jetson-nano-devkit-emmc.yml
+++ b/kas/jetson-nano-devkit-emmc.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-nano-devkit-emmc.yml
+++ b/kas/jetson-nano-devkit-emmc.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-nano-devkit-emmc

--- a/kas/jetson-nano-devkit.yml
+++ b/kas/jetson-nano-devkit.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-nano-devkit.yml
+++ b/kas/jetson-nano-devkit.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-nano-devkit

--- a/kas/jetson-tx2-devkit-4gb.yml
+++ b/kas/jetson-tx2-devkit-4gb.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-tx2-devkit-4gb

--- a/kas/jetson-tx2-devkit-4gb.yml
+++ b/kas/jetson-tx2-devkit-4gb.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-tx2-devkit-tx2i.yml
+++ b/kas/jetson-tx2-devkit-tx2i.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-tx2-devkit-tx2i.yml
+++ b/kas/jetson-tx2-devkit-tx2i.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-tx2-devkit-tx2i

--- a/kas/jetson-tx2-devkit.yml
+++ b/kas/jetson-tx2-devkit.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-tx2-devkit

--- a/kas/jetson-tx2-devkit.yml
+++ b/kas/jetson-tx2-devkit.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-xavier-nx-devkit-emmc.yml
+++ b/kas/jetson-xavier-nx-devkit-emmc.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-xavier-nx-devkit-emmc.yml
+++ b/kas/jetson-xavier-nx-devkit-emmc.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-xavier-nx-devkit-emmc

--- a/kas/jetson-xavier-nx-devkit-tx2-nx.yml
+++ b/kas/jetson-xavier-nx-devkit-tx2-nx.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-xavier-nx-devkit-tx2-nx

--- a/kas/jetson-xavier-nx-devkit-tx2-nx.yml
+++ b/kas/jetson-xavier-nx-devkit-tx2-nx.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/jetson-xavier-nx-devkit.yml
+++ b/kas/jetson-xavier-nx-devkit.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/tegra.yml
+
+machine: jetson-xavier-nx-devkit

--- a/kas/jetson-xavier-nx-devkit.yml
+++ b/kas/jetson-xavier-nx-devkit.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/tegra.yml
 

--- a/kas/libretech-ac.yml
+++ b/kas/libretech-ac.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: libretech-ac

--- a/kas/libretech-ac.yml
+++ b/kas/libretech-ac.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: libretech-ac
+
+local_conf_header:
+  libretech-ac: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/libretech-cc.yml
+++ b/kas/libretech-cc.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/amlogic.yml
 
 machine: libretech-cc

--- a/kas/libretech-cc.yml
+++ b/kas/libretech-cc.yml
@@ -1,0 +1,11 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/amlogic.yml
+
+machine: libretech-cc
+
+local_conf_header:
+  libretech-cc: |
+    MENDER_UBOOT_STORAGE_DEVICE = "0"

--- a/kas/nitrogen8m.yml
+++ b/kas/nitrogen8m.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
   - kas/include/boundarydevices.yml

--- a/kas/nitrogen8m.yml
+++ b/kas/nitrogen8m.yml
@@ -1,0 +1,9 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+  - kas/include/boundarydevices.yml
+
+machine: nitrogen8m

--- a/kas/nitrogen8mm.yml
+++ b/kas/nitrogen8mm.yml
@@ -1,0 +1,9 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+  - kas/include/boundarydevices.yml
+
+machine: nitrogen8mm

--- a/kas/nitrogen8mm.yml
+++ b/kas/nitrogen8mm.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
   - kas/include/boundarydevices.yml

--- a/kas/nitrogen8mn.yml
+++ b/kas/nitrogen8mn.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
   - kas/include/boundarydevices.yml

--- a/kas/nitrogen8mn.yml
+++ b/kas/nitrogen8mn.yml
@@ -1,0 +1,9 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+  - kas/include/boundarydevices.yml
+
+machine: nitrogen8m

--- a/kas/nitrogen8mp.yml
+++ b/kas/nitrogen8mp.yml
@@ -1,0 +1,13 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/nxp.yml
+  - kas/include/boundarydevices.yml
+
+machine: nitrogen8mp
+
+local_conf_header:
+  nitrogen8mp: |
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk2"

--- a/kas/nitrogen8mp.yml
+++ b/kas/nitrogen8mp.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/nxp.yml
   - kas/include/boundarydevices.yml

--- a/kas/osd32mp1-emmc-mender.yml
+++ b/kas/osd32mp1-emmc-mender.yml
@@ -1,0 +1,12 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/st.yml
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-octavo-osd32mp:
+
+machine: osd32mp1-emmc-mender

--- a/kas/osd32mp1-emmc-mender.yml
+++ b/kas/osd32mp1-emmc-mender.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/st.yml
 
 repos:

--- a/kas/qemuarm64.yml
+++ b/kas/qemuarm64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/qemu.yml
 
 repos:

--- a/kas/qemuarm64.yml
+++ b/kas/qemuarm64.yml
@@ -1,0 +1,32 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/qemu.yml
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-qemu-community:
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: kirkstone
+    layers:
+      meta-oe:
+
+  meta-arm:
+    url: https://git.yoctoproject.org/meta-arm
+    refspec: kirkstone
+    layers:
+      meta-arm:
+      meta-arm-toolchain:
+
+local_conf_header:
+  efi: |
+    EFI_PROVIDER = "grub-efi"
+    MACHINE_FEATURES += "efi"
+    MENDER_EFI_LOADER = "edk2-firmware"
+    MENDER_STORAGE_DEVICE = "/dev/vda"
+
+machine: qemuarm64

--- a/kas/qemux86-64.yml
+++ b/kas/qemux86-64.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/qemu.yml
 
-machine: sama5d27-som1-ek-sd
+machine: qemux86-64

--- a/kas/qemux86-64.yml
+++ b/kas/qemux86-64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/qemu.yml
 
 machine: qemux86-64

--- a/kas/raspberrypi-cm.yml
+++ b/kas/raspberrypi-cm.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi-cm

--- a/kas/raspberrypi-cm.yml
+++ b/kas/raspberrypi-cm.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi-cm

--- a/kas/raspberrypi-cm3.yml
+++ b/kas/raspberrypi-cm3.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi-cm3

--- a/kas/raspberrypi-cm3.yml
+++ b/kas/raspberrypi-cm3.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi-cm3

--- a/kas/raspberrypi.yml
+++ b/kas/raspberrypi.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi

--- a/kas/raspberrypi.yml
+++ b/kas/raspberrypi.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi

--- a/kas/raspberrypi0-2w-64.yml
+++ b/kas/raspberrypi0-2w-64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi0-2w-64

--- a/kas/raspberrypi0-2w-64.yml
+++ b/kas/raspberrypi0-2w-64.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi0-2w-64

--- a/kas/raspberrypi0-2w.yml
+++ b/kas/raspberrypi0-2w.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi0-2w

--- a/kas/raspberrypi0-2w.yml
+++ b/kas/raspberrypi0-2w.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi0-2w

--- a/kas/raspberrypi0-wifi.yml
+++ b/kas/raspberrypi0-wifi.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi0-wifi

--- a/kas/raspberrypi0-wifi.yml
+++ b/kas/raspberrypi0-wifi.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi0-wifi

--- a/kas/raspberrypi0.yml
+++ b/kas/raspberrypi0.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi0

--- a/kas/raspberrypi0.yml
+++ b/kas/raspberrypi0.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi0

--- a/kas/raspberrypi2.yml
+++ b/kas/raspberrypi2.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi2

--- a/kas/raspberrypi2.yml
+++ b/kas/raspberrypi2.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi2

--- a/kas/raspberrypi3-64.yml
+++ b/kas/raspberrypi3-64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi3-64

--- a/kas/raspberrypi3-64.yml
+++ b/kas/raspberrypi3-64.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi3-64

--- a/kas/raspberrypi3.yml
+++ b/kas/raspberrypi3.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi3

--- a/kas/raspberrypi3.yml
+++ b/kas/raspberrypi3.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi3

--- a/kas/raspberrypi4-64.yml
+++ b/kas/raspberrypi4-64.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi4

--- a/kas/raspberrypi4-64.yml
+++ b/kas/raspberrypi4-64.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi4

--- a/kas/raspberrypi4.yml
+++ b/kas/raspberrypi4.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 machine: raspberrypi4

--- a/kas/raspberrypi4.yml
+++ b/kas/raspberrypi4.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/raspberrypi.yml
 
-machine: sama5d27-som1-ek-sd
+machine: raspberrypi4

--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -1,0 +1,16 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/raspberrypi.yml
+
+repos:
+  meta-seeed-cm4:
+    url: https://github.com/theyoctojester/meta-seeed-cm4.git
+    refspec: kirkstone
+
+  meta-openembedded:
+    layers:
+      meta-python:
+
+machine: seeed-reterminal

--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
 repos:

--- a/kas/rock-pi-e.yml
+++ b/kas/rock-pi-e.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/poky.yml
   - kas/include/rockchip.yml
 

--- a/kas/rock-pi-e.yml
+++ b/kas/rock-pi-e.yml
@@ -1,0 +1,8 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/poky.yml
+  - kas/include/rockchip.yml
+
+machine: rock-pi-e

--- a/kas/sama5d27-som1-ek-sd.yml
+++ b/kas/sama5d27-som1-ek-sd.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/atmel.yml
 
 machine: sama5d27-som1-ek-sd

--- a/kas/sama5d3-xplained.yml
+++ b/kas/sama5d3-xplained.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - mender-base.yml
-  - includes/atmel.yml
+  - kas/include/mender-base.yml
+  - kas/include/atmel.yml
 
 machine: sama5d3-xplained

--- a/kas/sama5d3-xplained.yml
+++ b/kas/sama5d3-xplained.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/atmel.yml
 
 machine: sama5d3-xplained

--- a/kas/stm32mp15-disco.yml
+++ b/kas/stm32mp15-disco.yml
@@ -1,0 +1,35 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/st.yml
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-st-stm32mp:
+
+local_conf_header:
+  stm32mp15-disco: |
+    EXTRA_IMAGECMD:ext4:remove = "-L"
+    IMAGE_CLASSES:remove = "st-partitions-image"
+    WKS_FILE_DEPENDS:remove = "st-image-bootfs st-image-vendorfs st-image-userfs"
+    ENABLE_FLASHLAYOUT_CONFIG = "0"
+    MACHINE_ESSENTIAL_EXTRA_RDEPENDS:remove:mender-image:arm = "kernel-devicetree"
+    MACHINE_ESSENTIAL_EXTRA_RDEPENDS:append:mender-image:arm = " kernel-imagebootfs"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    PREFERRED_PROVIDER_u-boot="u-boot-stm32mp"
+    PREFERRED_PROVIDER_virtual/bootloader="u-boot-stm32mp"
+    IMAGE_CLASSES += "stm32mp-gptimg"
+    MENDER_BOOT_PART = "${MENDER_STORAGE_DEVICE_BASE}6"
+    MENDER_ROOTFS_PART_A = "${MENDER_STORAGE_DEVICE_BASE}7"
+    MENDER_ROOTFS_PART_B = "${MENDER_STORAGE_DEVICE_BASE}8"
+    MENDER_DATA_PART_NUMBER = "9"
+    MENDER_DATA_PART_SIZE_MB = "10"
+    IMAGE_FSTYPES:append = " gptimg.gz"
+    IMAGE_BOOT_FILES = "stm32mp1-boot.scr;boot.scr"
+    KERNEL_DEVICETREE="stm32mp157d-dk1.dtb"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_1 = "9437184"
+    MENDER_UBOOT_ENV_STORAGE_DEVICE_OFFSET_2 = "9699328"
+
+machine: stm32mp15-disco

--- a/kas/stm32mp15-disco.yml
+++ b/kas/stm32mp15-disco.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/st.yml
 
 repos:

--- a/kas/verdin-imx8mm.yml
+++ b/kas/verdin-imx8mm.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 

--- a/kas/verdin-imx8mm.yml
+++ b/kas/verdin-imx8mm.yml
@@ -1,0 +1,14 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: verdin-imx8mm
+
+local_conf_header:
+  verdin-imx8mm: |
+    MENDER_BOOT_PART_SIZE_MB = "32"
+    OFFSET_SPL_PAYLOAD = ""
+    KERNEL_DEVICETREE = "freescale/imx8mm-verdin-wifi-dahlia.dtb"

--- a/kas/verdin-imx8mp.yml
+++ b/kas/verdin-imx8mp.yml
@@ -1,0 +1,19 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/nxp.yml
+  - kas/include/toradex.yml
+
+machine: verdin-imx8mp
+
+local_conf_header:
+  verdin-imx8mp: |
+    MENDER_BOOT_PART_SIZE_MB = "32"
+    OFFSET_SPL_PAYLOAD = ""
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "0"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "2"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk2"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2048"
+    KERNEL_DEVICETREE = "freescale/imx8mp-verdin-wifi-dahlia.dtb"

--- a/kas/verdin-imx8mp.yml
+++ b/kas/verdin-imx8mp.yml
@@ -1,7 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full.yml
   - kas/include/nxp.yml
   - kas/include/toradex.yml
 

--- a/kas/vexpress-qemu-flash.yml
+++ b/kas/vexpress-qemu-flash.yml
@@ -1,0 +1,13 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-base.yml
+  - kas/include/qemu.yml
+
+machine: vexpress-qemu-flash
+
+local_conf_header:
+# this deliberately overrides the fragment from mender-base.yml!
+  mender: |
+    INHERIT += "mender-full-ubi"
+    MENDER_ARTIFACT_NAME = "gha_autobuild"

--- a/kas/vexpress-qemu-flash.yml
+++ b/kas/vexpress-qemu-flash.yml
@@ -1,13 +1,7 @@
 header:
   version: 11
   includes:
-  - kas/include/mender-base.yml
+  - kas/include/mender-full-ubi.yml
   - kas/include/qemu.yml
 
 machine: vexpress-qemu-flash
-
-local_conf_header:
-# this deliberately overrides the fragment from mender-base.yml!
-  mender: |
-    INHERIT += "mender-full-ubi"
-    MENDER_ARTIFACT_NAME = "gha_autobuild"

--- a/kas/vexpress-qemu.yml
+++ b/kas/vexpress-qemu.yml
@@ -5,3 +5,7 @@ header:
   - kas/include/qemu.yml
 
 machine: vexpress-qemu
+
+local_conf_header:
+  mender-efi: |
+    MENDER_EFI_LOADER = ""

--- a/kas/vexpress-qemu.yml
+++ b/kas/vexpress-qemu.yml
@@ -2,6 +2,6 @@ header:
   version: 11
   includes:
   - kas/include/mender-base.yml
-  - kas/include/atmel.yml
+  - kas/include/qemu.yml
 
-machine: sama5d27-som1-ek-sd
+machine: vexpress-qemu


### PR DESCRIPTION
Add kas configurations for boards that are known to build respectively under maintenance to have a
reproducible way of building them.

The kas files do not follow branch names, but provide verified commit hashes to ensure a known-good state is kept available.