### PR TITLE
fix: kas: machine type for raspberrypi4-64

### DIFF
--- a/kas/raspberrypi4-64.yml
+++ b/kas/raspberrypi4-64.yml
@@ -4,4 +4,4 @@ header:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml
 
-machine: raspberrypi4
+machine: raspberrypi4-64


### PR DESCRIPTION
The machine type was a copy error from the
raspberrypi4.yml file.

Changelog: Title
Ticket: None