### PR TITLE
feat: kas: add x86-virtual machine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,7 +83,8 @@ jobs:
           cubox-i,
           rock-pi-e,
           apalis-imx8, 
-          apalis-imx8-boot2qt
+          apalis-imx8-boot2qt,
+          x86-virtual
         ]
         experimental: [false]
         include:

--- a/kas/x86-virtual.yml
+++ b/kas/x86-virtual.yml
@@ -1,0 +1,23 @@
+header:
+  version: 11
+  includes:
+  - kas/include/mender-full.yml
+
+repos:
+  meta-intel:
+    url: https://git.yoctoproject.org/meta-intel
+    refspec: 1aacdb4ed1e639cc6e19c541b058264eb17eb093
+
+local_conf_header:
+  x86-virtual: |
+    # The size of core-image-base is 936 MB, meaning that if one tries to build
+    # that specific image you get an build error saying that it does not fit in the
+    # allocated part. This is because the default *total size* is set to 1024MB in
+    # mender-setup.bbclass, this value is used to calculate IMAGE_ROOTFS_MAXSIZE
+    #
+    # Lets increase the total storage as the core-image-base target is quite
+    # common and is the only image type that fully supports target device hardware.
+    MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT = "4096"
+    IMAGE_FSTYPES += "uefiimg.vmdk"
+
+machine: intel-corei7-64


### PR DESCRIPTION
The x86-virtual machine shows how to build a vmdk image which can be booted on desktop virtualizations such as VirtualBox.

Changelog: Title
Ticket: None