### PR TITLE
u-boot-boundary: update nitrogen8m Mender support

### DIFF
--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-boundary/0003-nitrogen8m-add-Mender-support.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-boundary/0003-nitrogen8m-add-Mender-support.patch
@@ -1,23 +1,22 @@
-From fb8b30263fd76fbd29a8a7e3fd0cd97c5f44dc96 Mon Sep 17 00:00:00 2001
+From 851284ae3cfd8f5a23dcb96e07314650e676824e Mon Sep 17 00:00:00 2001
 From: Chris Dimich <chris.dimich@boundarydevices.com>
-Date: Tue, 1 Nov 2022 10:54:40 -0700
-Subject: [PATCH 3/4] nitrogen8m*: add Mender support
+Date: Thu, 1 Feb 2024 12:03:01 -0800
+Subject: [PATCH 1/1] nitrogen8m*: add Mender support
 
 Signed-off-by: Chris Dimich <chris.dimich@boundarydevices.com>
 ---
  configs/nitrogen8m_2g_defconfig        | 6 +++++-
  configs/nitrogen8m_2gr0_defconfig      | 6 +++++-
- configs/nitrogen8m_3g_defconfig        | 6 +++++-
  configs/nitrogen8m_4g_defconfig        | 6 +++++-
  configs/nitrogen8m_som_2g_defconfig    | 6 +++++-
  configs/nitrogen8m_som_2gr0_defconfig  | 6 +++++-
  configs/nitrogen8m_som_4g_defconfig    | 6 +++++-
  configs/nitrogen8m_som_sd_2g_defconfig | 6 +++++-
  configs/nitrogen8m_som_sd_4g_defconfig | 6 +++++-
- 9 files changed, 45 insertions(+), 9 deletions(-)
+ 8 files changed, 40 insertions(+), 8 deletions(-)
 
 diff --git a/configs/nitrogen8m_2g_defconfig b/configs/nitrogen8m_2g_defconfig
-index f43c3756f4..0d57af2520 100644
+index 5da1ff014cf..0e231871d4c 100644
 --- a/configs/nitrogen8m_2g_defconfig
 +++ b/configs/nitrogen8m_2g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -29,7 +28,7 @@ index f43c3756f4..0d57af2520 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=2048
-@@ -87,6 +87,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -38,14 +37,14 @@ index f43c3756f4..0d57af2520 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -164,3 +166,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -170,3 +172,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_2gr0_defconfig b/configs/nitrogen8m_2gr0_defconfig
-index fa617044fe..bbb7e0119d 100644
+index 40b1d133f73..e2595acd143 100644
 --- a/configs/nitrogen8m_2gr0_defconfig
 +++ b/configs/nitrogen8m_2gr0_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -57,7 +56,7 @@ index fa617044fe..bbb7e0119d 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_RANK_BITS=0
-@@ -88,6 +88,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -90,6 +90,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -66,42 +65,14 @@ index fa617044fe..bbb7e0119d 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -165,3 +167,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
- CONFIG_VIDEO_BMP_GZIP=y
- CONFIG_IMX_WATCHDOG=y
- CONFIG_LIBAVB=y
-+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-+CONFIG_ENV_OFFSET_REDUND=0x3fc000
-diff --git a/configs/nitrogen8m_3g_defconfig b/configs/nitrogen8m_3g_defconfig
-index b11e192224..53368aa50e 100644
---- a/configs/nitrogen8m_3g_defconfig
-+++ b/configs/nitrogen8m_3g_defconfig
-@@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
- CONFIG_SYS_MEMTEST_START=0x40000000
- CONFIG_SYS_MEMTEST_END=0x40010000
- CONFIG_ENV_SIZE=0x2000
--CONFIG_ENV_OFFSET=0xffffe000
-+CONFIG_ENV_OFFSET=0x3fe000
- CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
- # CONFIG_SPLASH_SCREEN_PREPARE is not set
- CONFIG_DDR_MB=3072
-@@ -87,6 +87,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
- CONFIG_SYS_MMC_ENV_PART=1
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_NET_RANDOM_ETHADDR=y
-+CONFIG_BOOTCOUNT_LIMIT=y
-+CONFIG_BOOTCOUNT_ENV=y
- CONFIG_REGMAP=y
- CONFIG_SYSCON=y
- CONFIG_CLK_IMX8MQ=y
-@@ -164,3 +166,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -171,3 +173,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_4g_defconfig b/configs/nitrogen8m_4g_defconfig
-index f10c125b02..a2dc90599c 100644
+index c23a3f7c731..17e2c3a1f49 100644
 --- a/configs/nitrogen8m_4g_defconfig
 +++ b/configs/nitrogen8m_4g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -113,7 +84,7 @@ index f10c125b02..a2dc90599c 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=4096
-@@ -87,6 +87,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -122,14 +93,14 @@ index f10c125b02..a2dc90599c 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -164,3 +166,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -170,3 +172,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_som_2g_defconfig b/configs/nitrogen8m_som_2g_defconfig
-index b8311eac38..54d12790a1 100644
+index 5b49132d17e..674bf45a0c5 100644
 --- a/configs/nitrogen8m_som_2g_defconfig
 +++ b/configs/nitrogen8m_som_2g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -141,7 +112,7 @@ index b8311eac38..54d12790a1 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=2048
-@@ -87,6 +87,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -150,14 +121,14 @@ index b8311eac38..54d12790a1 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -164,3 +166,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -169,3 +171,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_som_2gr0_defconfig b/configs/nitrogen8m_som_2gr0_defconfig
-index a443e7ea51..5b11cfd0b1 100644
+index d89d66989db..46349ff71d9 100644
 --- a/configs/nitrogen8m_som_2gr0_defconfig
 +++ b/configs/nitrogen8m_som_2gr0_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -169,7 +140,7 @@ index a443e7ea51..5b11cfd0b1 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_RANK_BITS=0
-@@ -88,6 +88,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -90,6 +90,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -178,14 +149,14 @@ index a443e7ea51..5b11cfd0b1 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -165,3 +167,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -170,3 +172,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_som_4g_defconfig b/configs/nitrogen8m_som_4g_defconfig
-index e1e3ee067e..9f2e01b3dd 100644
+index a404bf626f2..1aef16f424f 100644
 --- a/configs/nitrogen8m_som_4g_defconfig
 +++ b/configs/nitrogen8m_som_4g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -197,7 +168,7 @@ index e1e3ee067e..9f2e01b3dd 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=4096
-@@ -87,6 +87,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -206,14 +177,14 @@ index e1e3ee067e..9f2e01b3dd 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -164,3 +166,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -169,3 +171,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_som_sd_2g_defconfig b/configs/nitrogen8m_som_sd_2g_defconfig
-index dae31f9da0..9aef100c77 100644
+index 6fa7650bda9..37f92fda438 100644
 --- a/configs/nitrogen8m_som_sd_2g_defconfig
 +++ b/configs/nitrogen8m_som_sd_2g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -225,7 +196,7 @@ index dae31f9da0..9aef100c77 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=2048
-@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -91,6 +91,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -234,14 +205,14 @@ index dae31f9da0..9aef100c77 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -166,3 +168,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -171,3 +173,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 diff --git a/configs/nitrogen8m_som_sd_4g_defconfig b/configs/nitrogen8m_som_sd_4g_defconfig
-index 4a81dd0d80..00741f314a 100644
+index 227c40e6305..046fcf4aecb 100644
 --- a/configs/nitrogen8m_som_sd_4g_defconfig
 +++ b/configs/nitrogen8m_som_sd_4g_defconfig
 @@ -12,7 +12,7 @@ CONFIG_NR_DRAM_BANKS=2
@@ -253,7 +224,7 @@ index 4a81dd0d80..00741f314a 100644
  CONFIG_IMX_CONFIG="arch/arm/mach-imx/imx8m/imximage.cfg"
  # CONFIG_SPLASH_SCREEN_PREPARE is not set
  CONFIG_DDR_MB=4096
-@@ -89,6 +89,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+@@ -91,6 +91,8 @@ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_SYS_MMC_ENV_PART=1
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_NET_RANDOM_ETHADDR=y
@@ -262,12 +233,12 @@ index 4a81dd0d80..00741f314a 100644
  CONFIG_REGMAP=y
  CONFIG_SYSCON=y
  CONFIG_CLK_IMX8MQ=y
-@@ -166,3 +168,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
+@@ -171,3 +173,5 @@ CONFIG_SPLASH_SCREEN_ALIGN=y
  CONFIG_VIDEO_BMP_GZIP=y
  CONFIG_IMX_WATCHDOG=y
  CONFIG_LIBAVB=y
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 +CONFIG_ENV_OFFSET_REDUND=0x3fc000
 -- 
-2.34.1
+2.43.0
 


### PR DESCRIPTION
Remove 3g_defconfig patch as defconfig no longer exists.