### PR TITLE
tegra: add bbappend for mender 4

### DIFF
--- a/meta-mender-tegra/recipes-mender/mender-client/mender_%.bbappend
+++ b/meta-mender-tegra/recipes-mender/mender-client/mender_%.bbappend
@@ -1,0 +1,4 @@
+EXTRADEPS = ""
+EXTRADEPS:tegra = "tegra-bup-payload tegra-boot-tools tegra-boot-tools-nvbootctrl tegra-boot-tools-lateboot${@' libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
+EXTRADEPS:tegra210 = "tegra-bup-payload tegra-boot-tools"
+RDEPENDS:mender-update += "${EXTRADEPS}"


### PR DESCRIPTION
With Mender 4, the recipe name changed from `mender-client` to `mender` so a corresponding `mender_%.bbappend` is required.