### PR TITLE
remove zstd support on tegra platform to allow building of mender-cli 3.5

### DIFF
--- a/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
+++ b/meta-mender-tegra/recipes-mender/mender-client/mender-client_%.bbappend
@@ -2,3 +2,7 @@ EXTRADEPS = ""
 EXTRADEPS_tegra = "tegra-bup-payload tegra-boot-tools tegra-boot-tools-nvbootctrl tegra-boot-tools-lateboot${@' libubootenv-fake' if d.getVar('PREFERRED_PROVIDER_virtual/bootloader').startswith('cboot') else ''}"
 EXTRADEPS_tegra210 = "tegra-bup-payload tegra-boot-tools"
 RDEPENDS_${PN} += "${EXTRADEPS}"
+
+# zstd prevent the build on tegra platforms with the oe4t toolchain for any version > 3.4
+EXTRA_OEMAKE:append = " TAGS='nozstd'"
+PTEST_ENABLED = "0"


### PR DESCRIPTION
`zstd` prevent the build of mender client `3.5.0` and upper on tegra platforms.