### PR TITLE
chore: kas: use main meta-mender repository

### DIFF
--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -19,7 +19,7 @@ repos:
       meta-oe:
 
   meta-mender:
-    url: https://github.com/theyoctojester/meta-mender.git
+    url: https://github.com/mendersoftware/meta-mender.git
     branch: scarthgap
     layers:
       meta-mender-core:

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -10,10 +10,6 @@ repos:
     url: https://git.yoctoproject.org/meta-lts-mixins
     branch: scarthgap/u-boot
 
-  meta-mender:
-    url: https://github.com/TheYoctoJester/meta-mender.git
-    branch: scarthgap
-
   meta-mender-community:
     layers:
       meta-mender-raspberrypi:


### PR DESCRIPTION
The main repository https://github.com/mendersoftware/meta-mender now provides a scarthgap branch. Switch to this one.

Ticket: None
Changelog: Title