### PR TITLE
mender-uboot: Reduce SPL size for beaglebone-yocto (scarthgap)

### DIFF
--- a/meta-mender-beaglebone/recipes-bsp/u-boot/files/reduce-spl-size.cfg
+++ b/meta-mender-beaglebone/recipes-bsp/u-boot/files/reduce-spl-size.cfg
@@ -1,0 +1,4 @@
+# CONFIG_SPL_USB_GADGET is not set
+# CONFIG_SPL_USB_ETHER is not set
+# CONFIG_SPL_USB_ETH_RNDIS is not set
+# CONFIG_SPL_MUSB_NEW is not set

--- a/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-beaglebone/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,2 +1,6 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:mender-uboot:beaglebone-yocto = " file://reduce-spl-size.cfg "
+
 MENDER_UBOOT_PRE_SETUP_COMMANDS:beaglebone-yocto = "run findfdt; setenv mender_dtb_name \${fdtfile}"
 MENDER_UBOOT_PRE_SETUP_COMMANDS:append:beaglebone-yocto:mender-uboot = "; setenv bootargs \${bootargs} rootwait"


### PR DESCRIPTION
It seems the uboot image in Scarthgap has grown such that the default autoconfig setup for at least Beaglebone no longer fits in sram:

   cp u-boot-dtb.bin u-boot.bin
|    rm -f spl/drivers/mtd/nand/built-in.o; arm-poky-linux-gnueabi-ar cDPrsT spl/drivers/mtd/nand/built-in.o spl/drivers/mtd/nand/raw/built-in.o
|    rm -f spl/drivers/mtd/built-in.o; arm-poky-linux-gnueabi-ar cDPrsT spl/drivers/mtd/built-in.o spl/drivers/mtd/mtd.o spl/drivers/mtd/nand/built-in.o
|    rm -f spl/drivers/built-in.o; arm-poky-linux-gnueabi-ar cDPrsT spl/drivers/built-in.o spl/drivers/block/built-in.o spl/drivers/core/built-in.o spl/drivers/gpio/built-in.o spl/drivers/i2c/built-in.o spl/drivers/mmc/built-in.o spl/drivers/mtd/built-in.o spl/drivers/net/built-in.o spl/drivers/power/built-in.o spl/drivers/serial/built-in.o spl/drivers/bus/built-in.o spl/drivers/usb/musb-new/built-in.o spl/drivers/usb/gadget/built-in.o spl/drivers/usb/common/built-in.o spl/drivers/usb/gadget/udc/built-in.o spl/drivers/watchdog/built-in.o spl/drivers/soc/built-in.o
|   ( cd spl && arm-poky-linux-gnueabi-ld.bfd -z noexecstack --no-warn-rwx-segments -T u-boot-spl.lds --gc-sections -Bstatic --gc-sections  --no-dynamic-linker --build-id=none -Ttext 0x402F0400 arch/arm/cpu/armv7/start.o --whole-archive arch/arm/mach-omap2/built-in.o arch/arm/cpu/armv7/built-in.o arch/arm/cpu/built-in.o arch/arm/lib/built-in.o board/ti/am335x/built-in.o board/ti/common/built-in.o common/spl/built-in.o common/init/built-in.o boot/built-in.o common/built-in.o cmd/built-in.o env/built-in.o lib/built-in.o disk/built-in.o drivers/built-in.o drivers/usb/dwc3/built-in.o drivers/usb/cdns3/built-in.o dts/built-in.o fs/built-in.o net/built-in.o  --no-whole-archive arch/arm/lib/eabi_compat.o arch/arm/lib/lib.a -Map u-boot-spl.map -o u-boot-spl )
| arm-poky-linux-gnueabi-ld.bfd: u-boot-spl section `__u_boot_list' will not fit in region `.sram'
| arm-poky-linux-gnueabi-ld.bfd: region `.sram' overflowed by 824 bytes
| make[2]: *** [/work/dmoseley/scratch/mender-beaglebone/build/tmp/work/beaglebone_yocto-poky-linux-gnueabi/u-boot/2024.01/git/scripts/Makefile.spl:527: spl/u-boot-spl] Error 1
| make[1]: *** [/work/dmoseley/scratch/mender-beaglebone/build/tmp/work/beaglebone_yocto-poky-linux-gnueabi/u-boot/2024.01/git/Makefile:2054: spl/u-boot-spl] Error 2

This patch removes a few USB config options from SPL which should not be needed in a Mender config since it is just going to load the main uboot image from SDCard.


Changelog: Title
Ticket: None