### PR TITLE
chore: kas: add beaglebone-uboot config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,8 @@ jobs:
           qemux86-64,
           vexpress-qemu,
           vexpress-qemu-flash,
-          x86-virtual
+          x86-virtual,
+          beaglebone-uboot
         ]
         experimental: [false]
         subpath: [.]

--- a/kas/beaglebone-uboot.yml
+++ b/kas/beaglebone-uboot.yml
@@ -1,0 +1,9 @@
+header:
+  version: 14
+  includes:
+  - kas/beaglebone.yml
+
+local_conf_header:
+  beaglebone-uboot: |
+    MENDER_FEATURES_ENABLE:append = " mender-uboot"
+    MENDER_FEATURES_DISABLE:append = "mender-grub"


### PR DESCRIPTION
The BeagleBone Black can also use the mender-uboot feature instead of mender-grub. Add a build configuration to reflect that and autobuild it to catch eventual build failures.

Changelog: Title
Ticket: None