### PR TITLE
Add meta-mender-nxp for Yocto release Scrathgap and Olimex i.MX8MP iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND

### DIFF
--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -1,0 +1,26 @@
+header:
+  version: 14
+
+repos:
+  meta-freescale:
+    url: https://github.com/Freescale/meta-freescale.git
+    branch: scarthgap
+  meta-freescale-3rdparty:
+    url: https://github.com/Freescale/meta-freescale-3rdparty.git
+    branch: scarthgap
+  meta-freescale-distro:
+    url: https://github.com/Freescale/meta-freescale-distro.git
+    branch: scarthgap
+
+  meta-mender-community:
+    layers:
+      meta-mender-nxp:
+
+distro: poky
+
+local_conf_header:
+  nxp: |
+    ACCEPT_FSL_EULA = "1"
+    MENDER_BOOT_PART_SIZE_MB = "64"
+    MENDER_FEATURES_ENABLE:append = " mender-uboot mender-image-sd"
+    MENDER_FEATURES_DISABLE:append = " mender-grub mender-image-uefi"

--- a/kas/olimex-imx8mp-evb.yml
+++ b/kas/olimex-imx8mp-evb.yml
@@ -1,0 +1,19 @@
+header:
+  version: 14
+  includes:
+  - kas/include/mender-full.yml
+  - kas/include/nxp.yml
+
+machine: olimex-imx8mp-evb
+
+target:
+  - core-image-base
+
+local_conf_header:
+  olimex-imx8mp-evb: |
+    MENDER_IMAGE_BOOTLOADER_FILE = "imx-boot"
+    MENDER_IMAGE_BOOTLOADER_BOOTSECTOR_OFFSET = "64"
+    MENDER_UBOOT_STORAGE_INTERFACE = "mmc"
+    MENDER_UBOOT_STORAGE_DEVICE = "1"
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk1"
+    IMAGE_BOOT_FILES:append = "boot.scr"

--- a/meta-mender-nxp/README.md
+++ b/meta-mender-nxp/README.md
@@ -1,0 +1,47 @@
+# meta-mender-nxp
+
+Mender integration for nxp based boards
+
+The supported and tested boards are:
+
+ - [Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND](https://www.olimex.com/Products/SOM/NXP-iMX8/)
+
+
+Visit the individual board links above for more information on status of the
+integration and more detailed instructions on how to build and use images
+together with Mender for the mentioned boards.
+
+## Dependencies
+
+This layer depends on:
+
+```
+URI: https://github.com/Freescale/meta-freescale
+branch: scarthgap
+revision: HEAD
+```
+
+```
+URI: https://github.com/Freescale/meta-freescale-3rdparty
+branch: scarthgap
+revision: HEAD
+```
+
+```
+URI: https://github.com/Freescale/meta-freescale-distro
+branch: scarthgap
+revision: HEAD
+```
+
+## Quick start
+
+The following commands will setup the environment and allow you to build images
+that have Mender integrated.
+
+
+```
+mkdir -p meta-mender-community/mender-nxp && cd meta-mender-community/mender-nxp
+kas build ../kas/olimex-imx8mp-evb.yml
+```
+
+

--- a/meta-mender-nxp/conf/layer.conf
+++ b/meta-mender-nxp/conf/layer.conf
@@ -1,0 +1,14 @@
+# Copyright 2024, Leon Anavi
+
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+	${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-nxp"
+BBFILE_PATTERN_mender-nxp = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-nxp = "10"
+
+LAYERSERIES_COMPAT_mender-nxp = "scarthgap"

--- a/meta-mender-nxp/recipes-bsp/u-boot-scr/files/olimex-imx8mp-evb/boot.cmd
+++ b/meta-mender-nxp/recipes-bsp/u-boot-scr/files/olimex-imx8mp-evb/boot.cmd
@@ -1,0 +1,12 @@
+run sr_ir_v2_cmd
+mmc dev 1
+setenv devtype mmc
+setenv devnum 1
+setenv distro_bootpart 1
+run scan_dev_for_efi
+setenv bootargs '${jh_clk} ${mcore_clk} console=${console},${baudrate} root=${mender_kernel_root} rootwait rw'
+run mender_setup
+mmc dev ${mender_uboot_dev}
+fatload mmc ${mmcdev}:${mmcpart} ${loadaddr} ${image}
+booti ${loadaddr} - ${fdt_addr_r}
+run mender_try_to_recover

--- a/meta-mender-nxp/recipes-bsp/u-boot-scr/u-boot-scr.bb
+++ b/meta-mender-nxp/recipes-bsp/u-boot-scr/u-boot-scr.bb
@@ -1,0 +1,23 @@
+SUMMARY = "U-Boot boot script generator"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+DEPENDS = "u-boot-mkimage-native"
+
+SRC_URI = "file://boot.cmd"
+
+do_compile() {
+	mkimage -C none -A arm -T script -d "${WORKDIR}/boot.cmd" boot.scr
+}
+
+inherit deploy
+
+do_deploy() {
+	install -d ${DEPLOYDIR}
+	install -m 0644 boot.scr ${DEPLOYDIR}
+}
+
+addtask do_deploy after do_compile before do_build
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(olimex-imx8mp-evb)"

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx/olimex-imx8mp-evb/0001-configs-olimex-imx8mp-evb-mender-integration.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx/olimex-imx8mp-evb/0001-configs-olimex-imx8mp-evb-mender-integration.patch
@@ -1,0 +1,56 @@
+From 6f0ac7836f92efe24aeb7e2c3640f1b870d561ea Mon Sep 17 00:00:00 2001
+From: Leon Anavi <leon.anavi@konsulko.com>
+Date: Mon, 15 Jul 2024 13:14:34 +0000
+Subject: [PATCH] configs: olimex-imx8mp-evb: mender integration
+
+Apply configuration changes for Mender.
+
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ configs/imx8mp_olimex_defconfig | 7 ++++---
+ include/configs/imx8mp_olimex.h | 3 +++
+ 2 files changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/configs/imx8mp_olimex_defconfig b/configs/imx8mp_olimex_defconfig
+index 8f763537537..990cb70bebd 100644
+--- a/configs/imx8mp_olimex_defconfig
++++ b/configs/imx8mp_olimex_defconfig
+@@ -10,7 +10,9 @@ CONFIG_NR_DRAM_BANKS=3
+ CONFIG_SYS_MEMTEST_START=0x60000000
+ CONFIG_SYS_MEMTEST_END=0xC0000000
+ CONFIG_ENV_SIZE=0x4000
+-CONFIG_ENV_OFFSET=0x700000
++CONFIG_ENV_OFFSET=0x800000
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+ CONFIG_ENV_SECT_SIZE=0x10000
+ CONFIG_SYS_I2C_MXC_I2C1=y
+ CONFIG_SYS_I2C_MXC_I2C2=y
+@@ -92,11 +94,10 @@ CONFIG_CMD_LED=y
+ CONFIG_OF_CONTROL=y
+ CONFIG_SPL_OF_CONTROL=y
+ CONFIG_ENV_OVERWRITE=y
+-CONFIG_ENV_IS_NOWHERE=y
+ CONFIG_ENV_IS_IN_MMC=y
+-CONFIG_ENV_IS_IN_SPI_FLASH=y
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_SYS_MMC_ENV_DEV=1
++CONFIG_SYS_MMC_ENV_PART=0
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_USE_ETHPRIME=y
+ CONFIG_ETHPRIME="eth1"
+diff --git a/include/configs/imx8mp_olimex.h b/include/configs/imx8mp_olimex.h
+index 6941d3ede4c..be0624da558 100644
+--- a/include/configs/imx8mp_olimex.h
++++ b/include/configs/imx8mp_olimex.h
+@@ -181,4 +181,7 @@
+ #include "imx8mp_evk_android.h"
+ #endif
+ 
++#define CONFIG_BOOTCOUNT_ENV
++#define CONFIG_BOOTCOUNT_LIMIT
++
+ #endif
+-- 
+2.44.1
+

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx/olimex-imx8mp-evb/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx/olimex-imx8mp-evb/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -1,0 +1,51 @@
+From ca210db3a1b480f438eecf6ad6fcd911fefdbb2c Mon Sep 17 00:00:00 2001
+From: Marcin Pasinski <marcin.pasinski@northern.tech>
+Date: Wed, 31 Jan 2018 18:10:04 +0100
+Subject: [PATCH] Integration of Mender boot code into U-Boot.
+
+Upstream-Status: Inappropriate [Mender specific]
+
+Signed-off-by: Kristian Amlie <kristian.amlie@mender.io>
+Signed-off-by: Maciej Borzecki <maciej.borzecki@rndity.com>
+Signed-off-by: Marcin Pasinski <marcin.pasinski@northern.tech>
+Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
+---
+ include/env_default.h     | 3 +++
+ scripts/Makefile.autoconf | 3 ++-
+ 2 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/include/env_default.h b/include/env_default.h
+index c0df39d62f9..e180612c0d2 100644
+--- a/include/env_default.h
++++ b/include/env_default.h
+@@ -14,6 +14,8 @@
+ #include <generated/environment.h>
+ #endif
+ 
++#include <env_mender.h>
++
+ #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
+ env_t embedded_environment __UBOOT_ENV_SECTION__(environment) = {
+ 	ENV_CRC,	/* CRC Sum */
+@@ -28,6 +30,7 @@ char default_environment[] = {
+ #else
+ const char default_environment[] = {
+ #endif
++	MENDER_ENV_SETTINGS
+ #ifndef CONFIG_USE_DEFAULT_ENV_FILE
+ #ifdef	CONFIG_ENV_CALLBACK_LIST_DEFAULT
+ 	ENV_CALLBACK_VAR "=" CONFIG_ENV_CALLBACK_LIST_DEFAULT "\0"
+diff --git a/scripts/Makefile.autoconf b/scripts/Makefile.autoconf
+index 0ade91642ae..c653f1afaa1 100644
+--- a/scripts/Makefile.autoconf
++++ b/scripts/Makefile.autoconf
+@@ -116,7 +116,8 @@ define filechk_config_h
+ 	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
+ 	echo \#include \<asm/config.h\>;				\
+ 	echo \#include \<linux/kconfig.h\>;				\
+-	echo \#include \<config_fallbacks.h\>;)
++	echo \#include \<config_fallbacks.h\>;				\
++	echo \#include \<config_mender.h\>;)
+ endef
+ 
+ include/config.h: scripts/Makefile.autoconf create_symlink FORCE

--- a/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/meta-mender-nxp/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -1,0 +1,13 @@
+require recipes-bsp/u-boot/u-boot-mender.inc
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/u-boot-imx:"
+
+DEPENDS:append = " u-boot-scr"
+
+SRC_URI:append:olimex-imx8mp-evb = " \
+	file://0001-configs-olimex-imx8mp-evb-mender-integration.patch \
+"
+
+BOOTENV_SIZE:olimex-imx8mp-evb = "0x4000"
+
+MENDER_UBOOT_AUTO_CONFIGURE = "0"


### PR DESCRIPTION
Hi,

This GitHub pull request adds meta-mender-nxp for Yocto release Scrathgap and [Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND](https://www.olimex.com/Products/SOM/NXP-iMX8/). It contains the following modifications:

* meta-mender-nxp: Mender support for Olimex i.MX8MP SoM and evaluation board: iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND. This is the first NXP board with Mender support for Yocto release Scarthgap and this commit reintroduces layer meta-mender-nxp.

* kas: Adds include/nxp.yml and olimex-imx8mp-evb.yml to build image with Mender for [Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND](https://www.olimex.com/Products/SOM/NXP-iMX8/). For this machine the kas configuration targets `core-image-base`, because it provides all required dependencies for enabling Ethernet networking.

Tested with `core-image-base` and a Mender update to extend the systemd with `nano` on [Olimex iMX8MP-SOM-4GB-IND and iMX8MP-SOM-EVB-IND](https://www.olimex.com/Products/SOM/NXP-iMX8/). 

Best regards, Leon