### PR TITLE
chore: kas: remove leftover debug-tweaks in raspberrypi.yml

### DIFF
--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -21,4 +21,3 @@ local_conf_header:
     MENDER_BOOT_PART_SIZE_MB = "100"
     IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
     IMAGE_FSTYPES:remove = " rpi-sdimg"
-    EXTRA_IMAGE_FEATURES = "debug-tweaks"


### PR DESCRIPTION
The debug-tweaks IMAGE_FEATURE allows a passwordless root login by default and this must not be showcased as a good default practise

Changelog: Title
Ticket: None