### PR TITLE
rpi-update-firmware: Fix paths

### DIFF
--- a/meta-mender-raspberrypi/classes/rpi-update-firmware.bbclass
+++ b/meta-mender-raspberrypi/classes/rpi-update-firmware.bbclass
@@ -5,11 +5,11 @@ rpi_install_firmware_to_rootfs() {
 
     # To exclude files such as bcm2710-rpi-3-b-1-4.19.88+git0+988cc7beac-r0-raspberrypi3-20200323173633.dtb
     # as only the link names are actually valid and searched for on the device.
-    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtb" \) -exec cp {} ${IMAGE_ROOTFS}/boot/firmware/ \;
-    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtbo" \) -exec cp {} ${IMAGE_ROOTFS}/boot/firmware/overlays/ \;
+    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtb" \) -exec cp {} ${IMAGE_ROOTFS}/boot/ \;
+    find ${DEPLOY_DIR_IMAGE}/ -type l \( -iname "*.dtbo" \) -exec cp {} ${IMAGE_ROOTFS}/boot/overlays/ \;
 
-    cp ${DEPLOY_DIR_IMAGE}/u-boot.bin ${IMAGE_ROOTFS}/boot/firmware/${SDIMG_KERNELIMAGE}
-    cp ${DEPLOY_DIR_IMAGE}/boot.scr ${IMAGE_ROOTFS}/boot/firmware/
+    cp ${DEPLOY_DIR_IMAGE}/u-boot.bin ${IMAGE_ROOTFS}/boot/${SDIMG_KERNELIMAGE}
+    cp ${DEPLOY_DIR_IMAGE}/boot.scr ${IMAGE_ROOTFS}/boot/
 }
 ROOTFS_POSTPROCESS_COMMAND += "rpi_install_firmware_to_rootfs; "
 

--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
@@ -34,12 +34,12 @@ mount -o ro ${inactive_part} /tmp/inactive_part
 # render the device unusable.
 
 # Copy 'core' firmware files first
-for f in $(find /tmp/inactive_part/boot/firmware/ -maxdepth 1 -type f); do
+for f in $(find /tmp/inactive_part/boot -maxdepth 1 -type f ! -name "*.dtbo"); do
   safe_copy $f /uboot/$(basename $f)
 done
 
 # Copy overlays
-for f in $(find /tmp/inactive_part/boot/firmware/overlays/ -maxdepth 1 -type f); do
+for f in $(find /tmp/inactive_part/boot/*.dtbo -maxdepth 1 -type f); do
   safe_copy $f /uboot/overlays/$(basename $f)
 done
 


### PR DESCRIPTION
Fix paths and file names in rpi-update-firmware.bbclass and ArtifactInstall_Leave_50.in from update-firmware-state-script following the migration of the layer to release Scarthgap.