### PR TITLE
chore: meta-mender-tegra-jetpack5: fix README

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-jetpack5/README.md
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack5/README.md
@@ -16,7 +16,7 @@ This layer depends on:
 ```
 URI: https://github.com/madisongh/meta-tegra.git
 layers: meta-tegra
-branch: kirkstone-l4t-r32.7.x
+branch: kirkstone
 revision: HEAD
 ```
 


### PR DESCRIPTION
The README erroneously still refers to the kirkstone-l4t-32.x branch, adjust that to the correct "kirkstone" only.

Changelog: Title
Ticket: None