### PR TITLE
chore: change GitHub Actions trigger to manual

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: build boards
 
 on:
-  push:
+  workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron:  '5 2 * * 6'


### PR DESCRIPTION
Building all board configurations upon each push is taking too long by now (>2hrs), so change the trigger to manual on-demand.
The weekly build is kept unchanged.

Changelog: Title
Ticket: None

Signed-off-by: TheYoctoJester <jester@theyoctojester.info>
(cherry picked from commit 6e3dfc3d0beb04b97b08791ff0055c62c3563352)