### PR TITLE
Scarthgap tegra jetpack5 v3

### DIFF
--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/abort-blupdate
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/abort-blupdate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CAPTARGET="/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap"
+CAPTARGET="/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"
 
 if [ -f "$CAPTARGET" ]; then
     rm "$CAPTARGET"

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -37,9 +37,9 @@ fi
 tmp_mount=`mktemp -d`
 
 reset_unbootable_status $next_slot
-mkdir -p /opt/nvidia/esp/EFI/UpdateCapsule
+mkdir -p /boot/efi/EFI/UpdateCapsule
 mount -o ro $next_rootfs_dev $tmp_mount
-cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap
+cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap
 umount $tmp_mount
 oe4t-set-uefi-OSIndications
 

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-echo "$(mender show-artifact): $(basename "$0") was called!" >&2
+echo "$(mender-update show-artifact): $(basename "$0") was called!" >&2
 
 get_bootpart() {
 	local current_slot=`nvbootctrl get-current-slot 2>/dev/null`


### PR DESCRIPTION
Starting with Mender Client 4.0, the binary is split into mender-auth and mender-update, so we should use `mender-update`.
Also includes a first step towards compatibility with JP 6.