### PR TITLE
scarthgap-l4t-r35.x kas build errors

### DIFF
--- a/kas/include/tegra-jetpack5.yml
+++ b/kas/include/tegra-jetpack5.yml
@@ -6,7 +6,8 @@ header:
 repos:
   meta-tegra:
     # refers to the scarthgap-l4t-r35.x branch
-    commit: 972488415a80afebbd652a983a46c2641eed99ad
+    # commit: 972488415a80afebbd652a983a46c2641eed99ad # this lacks classes/l4t_version.bbclass
+    commit: 32d86844d857321e1ed137abbdd5a045c6f5cb3f
   meta-tegra-community:
     # refers to the scarthgap-l4t-r35.x branch
     commit: 865561b6d3ba6607a814354c122c91422df720d5

--- a/meta-mender-tegra/classes-global/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes-global/tegra-mender-setup.bbclass
@@ -49,7 +49,7 @@ IMAGE_BOOT_FILES = "u-boot-dtb.bin"
 # boot into an emergency shell and examine the /dev/mmcblk* devices,
 # or use the uboot console to look at mtdparts
 MENDER_DATA_PART_NUMBER_DEFAULT:tegra186 = "34"
-MENDER_DATA_PART_NUMBER_DEFAULT:tegra194 = "42"
+MENDER_DATA_PART_NUMBER_DEFAULT:tegra194 = "45"
 MENDER_DATA_PART_NUMBER_DEFAULT:xavier-nx = "23"
 MENDER_DATA_PART_NUMBER_DEFAULT:tegra210 = "${@'16' if (d.getVar('TEGRA_SPIFLASH_BOOT') or '') == '1' else '23'}"
 MENDER_DATA_PART_NUMBER_DEFAULT:jetson-nano-emmc = "19"

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
@@ -29,8 +29,8 @@ do_install:append:tegra194() {
     # prevents the Mender data partition to use remaining space.
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_TEMPLATE}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE}
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_EXTERNAL}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}
 }


### PR DESCRIPTION
# Describe the bug
**BUG Nr1**
l4t_version.bbclass not found

**BUG Nr2**
| install: cannot create regular file '/home/yocto/git/ext/meta-mender-community/build/tmp/work/jetson_agx_xavier_devkit-oe4t-linux/tegra-storage-layout-base/35.5.0/image/usr/share/tegraflash/flash_l4t_nvme_rootfs_ab.xml': No such file or directory
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/yocto/git/ext/meta-mender-community/build/../meta-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_35.5.0.bb:do_install) failed with exit code '1'

**BUG Nr3**
| Error: Return value 4
| Command tegrabct_v2 --chip 0x19 --mb1bct mb1_cold_boot_bct_MB1.bct --updatefwinfo flash.xml.bin
| WARNING: exit code 1 from a shell command.
ERROR: Task (/home/yocto/git/ext/meta-mender-community/build/../meta-tegra/recipes-bsp/uefi/tegra-uefi-capsules_35.5.0.bb:do_compile) failed with exit code '1'

# To Reproduce
```
git clone https://github.com/mendersoftware/meta-mender-community.git
git checkout scarthgap
kas build kas/jetson-agx-xavier-devkit.yml
```

# Additional context

In order to fix the above bugs I think these changes need to be made:

**Bug Nr1**
in `kas/include/tegra-jetpack5.yml`
```
repos:
  meta-tegra:
    # refers to the scarthgap-l4t-r35.x branch
    # commit: 972488415a80afebbd652a983a46c2641eed99ad
    commit: 32d86844d857321e1ed137abbdd5a045c6f5cb3f # NOTE !!! (this commit has the global l4t_version)
```
This pull request.

and **Bug Nr2**
`meta-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_35.5.0.bb`

```
do_install() {
    install -d ${D}${datadir}/l4t-storage-layout
    install -d ${D}${datadir}/tegraflash # NOTE
    install -m 0644 ${PARTITION_FILE} ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE}
    install -m 0644 ${PARTITION_FILE} ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_TEMPLATE} # NOTE
    [ -z "${PARTITION_LAYOUT_EXTERNAL}" ] || install -m 0644 ${PARTITION_FILE_EXTERNAL} ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_EXTERNAL} # NOTE
    [ -z "${PARTITION_LAYOUT_EXTERNAL}" ] || install -m 0644 ${PARTITION_FILE_EXTERNAL} ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}
}
```
Additionally there is a typo in the last `PARTITION_LAYOUT_EXTERNAL` used in the original code. It is missing a `T`.

I was referred here to create a pull request , even though the bug seems to be in `meta-tegra` :( . See [here](https://github.com/OE4T/meta-tegra/issues/1682).

No idea how to fix **Bug Nr3**. It seems to be an issue with the partition layout. I have a 32GB Nvidia Jetson AGX Xavier.

#### Many many thanks for making the meta-mender version L4T 35.5 available to owners of an NVIDIA AGX Xavier !!!!!