### PR TITLE
chore: GitHub Actions: add support for assets and site.conf

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,7 @@ jobs:
         - ${{ vars.PERSISTENT_DIR }}/downloads:${{ vars.BUILD_DL_DIR }}
         - ${{ vars.PERSISTENT_DIR }}/sstate-cache:${{ vars.BUILD_SSTATE_DIR }}
         - ${{ vars.PERSISTENT_DIR }}/layers:${{ vars.BUILD_LAYERCACHE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/assets:${{ vars.BUILD_ASSETS_DIR }}
       options: --user ${{ vars.KAS_UID }}:${{ vars.KAS_GID }}
     steps:
       - name: enter build dir and build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,4 +82,7 @@ jobs:
           DL_DIR: ${{ vars.BUILD_DL_DIR}}
           SSTATE_DIR: ${{ vars.BUILD_SSTATE_DIR}}
           KAS_REPO_REF_DIR: ${{ vars.BUILD_LAYERCACHE_DIR}}
-        run: mkdir -p $BUILDDIR/${{ matrix.board }} && cd $BUILDDIR/${{ matrix.board }} && kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml
+        run: >
+          mkdir -p $BUILDDIR/${{ matrix.board }} &&
+          cd $BUILDDIR/${{ matrix.board }} &&
+          kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,4 +87,7 @@ jobs:
           mkdir -p $BUILDDIR/${{ matrix.board }} &&
           cd $BUILDDIR/${{ matrix.board }} &&
           kas checkout ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml &&
+          if [ -f "${{ vars.BUILD_ASSETS_DIR }}/site.conf" ]; then 
+          cp ${{ vars.BUILD_ASSETS_DIR }}/site.conf build/conf/site.conf;
+          fi &&
           kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,4 +85,5 @@ jobs:
         run: >
           mkdir -p $BUILDDIR/${{ matrix.board }} &&
           cd $BUILDDIR/${{ matrix.board }} &&
+          kas checkout ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml &&
           kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml


### PR DESCRIPTION
The recommended way to pass build host specific information or settings into a `bitbake` build is using the `site.conf`. This PR adds support to the GitHub Actions based workflow to mount an `assets` directory which can hold arbitrary data. Using this mechanism, the build command checks if there is a `site.conf` file, and if, then incorporates it into the workflow run.