### PR TITLE
chore: kas: fix meta-raspberrypi upstream revision

### DIFF
--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -4,7 +4,7 @@ header:
 repos:
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: 1918a27419dcd5e79954c0dc0edddcde91057a7e
+    commit: 6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins


### PR DESCRIPTION
Changelog: Title
Ticket: None