### PR TITLE
fix: kas: add dtbo for Raspberry Pi 5, D0 variant

### DIFF
--- a/kas/raspberrypi5.yml
+++ b/kas/raspberrypi5.yml
@@ -11,3 +11,7 @@ local_conf_header:
     KERNEL_IMAGETYPE_UBOOT ?= "Image"
     KERNEL_BOOTCMD ?= "booti"
     UBOOT_MACHINE = "rpi_arm64_config"
+
+  raspberrypi5_BCM2712D0: |
+    # at least the 2GB RAM version uses the D0 chip variant, which requires this
+    RPI_KERNEL_DEVICETREE_OVERLAYS:append = " overlays/bcm2712d0.dtbo"


### PR DESCRIPTION
The Raspberry Pi 5 uses two different SoCs as of right now (see documentation: https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#flagship-series)
- BCM2712
- BCM2712D0 (2GB variant) For the latter, an additional device tree overlay is required to work, otherwise the kernel fails to boot with
[    1.386466] SError Interrupt on CPU0, code 0x00000000be000011 ...

As this does not negatively affect other variants, it can be unconditionally added.

Changelog: Title
Ticket: None