### PR TITLE
u-boot: Remove bbappend after RPi 5 was re-enabled upstream

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_2024.04.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_2024.04.bbappend
@@ -1,1 +1,0 @@
-COMPATIBLE_MACHINE:raspberrypi5 = "(.*)"


### PR DESCRIPTION
## Description

RPi 5 was re-enabled upstream in the following commit:

  * https://github.com/agherzan/meta-raspberrypi/commit/6d593646babb5efbcf79ba8e012fb76bd594c5a8

So we don't need the bbappend to disable it anymore.

## How has this been tested?

Tested with U-boot v2024.04 from the meta-lts-mixins layer.

Before, when building my OS for the RPi 5, I get the error:

```
ERROR: No recipes in default available for:
  layers/meta-mender-community/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_2024.04.bbappend
```

After:

Bitbake recipes parse correctly.

Runtime tested the resulting image on the RPi 5 (at least I got as far as getting stuck in the bootloader).