### PR TITLE
fix: tegra: replace outdated reference to mender binary

### DIFF
--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-echo "$(mender show-artifact): $(basename "$0") was called!" >&2
+echo "$(mender-update show-artifact): $(basename "$0") was called!" >&2
 
 get_bootpart() {
 	local current_slot=`nvbootctrl get-current-slot 2>/dev/null`


### PR DESCRIPTION
scarthgap defaults to mender 4.0 which has split up the monolith mender binary into several ones. The show-artifact function is now available through mender-update instead.