### PR TITLE
fix: tegra: use correct ESP mount path

### DIFF
--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/abort-blupdate
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/abort-blupdate
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CAPTARGET="/opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap"
+CAPTARGET="/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"
 
 if [ -f "$CAPTARGET" ]; then
     rm "$CAPTARGET"

--- a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -37,9 +37,9 @@ fi
 tmp_mount=`mktemp -d`
 
 reset_unbootable_status $next_slot
-mkdir -p /opt/nvidia/esp/EFI/UpdateCapsule
+mkdir -p /boot/efi/EFI/UpdateCapsule
 mount -o ro $next_rootfs_dev $tmp_mount
-cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /opt/nvidia/esp/EFI/UpdateCapsule/TEGRA_BL.Cap
+cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap
 umount $tmp_mount
 oe4t-set-uefi-OSIndications
 


### PR DESCRIPTION
Upstream meta-tegra dropped the extra link in /opt/nvidia/esp and now only mounts the ESP at /boot/efi.

See also: https://github.com/OE4T/meta-tegra/commit/3b763e9a41d

(Not entirely sure if we need something cleverer here)