### PR TITLE
Update tegra-storage-layout-base_%.bbappend to use correct pathing

### DIFF
--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
@@ -29,8 +29,8 @@ do_install:append:tegra194() {
     # prevents the Mender data partition to use remaining space.
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_TEMPLATE}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE}
     sed -i -e 's#<start_location> 0x708400000 </start_location>##g' \
            -e 's#<start_location> 0x710800000 </start_location>##g' \
-		   ${D}${datadir}/tegraflash/${PARTITION_LAYOUT_EXTERNAL}
+		   ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}
 }


### PR DESCRIPTION
The bbappend is looking for the xml in an incorrect location. This file is present at ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_TEMPLATE} and ${D}${datadir}/l4t-storage-layout/${PARTITION_LAYOUT_EXTERNAL}