### PR TITLE
Remove the need to copy ownership for FAT partition

### DIFF
--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/files/ArtifactInstall_Leave_50.in
@@ -15,7 +15,7 @@ safe_copy() {
     echo "safe_copy can only handle one file copy at a time" >&2
     exit 2
   fi
-  cp -a "$1" "$2".tmp || return $?
+  cp  "$1" "$2".tmp || return $?
   sync "$2".tmp || return $?
   mv "$2".tmp "$2" || return $?
   sync "$(dirname "$2")" || return $?


### PR DESCRIPTION
Error on our system:
cp: failed to preserve ownership for '/uboot/start_cd.elf.tmp': Operation not permitted

* uboot parition is FAT on our system and rasbbery  PI OS. 
 Has this change in newer releases? 
 i.e. /dev/mmcblk0p1 on /uboot type vfat