### PR TITLE
Add support for Jetson Orin NX

### DIFF
--- a/kas/jetson-orin-16gb-nx-p3786.yml
+++ b/kas/jetson-orin-16gb-nx-p3786.yml
@@ -1,0 +1,17 @@
+header:
+  version: 14
+  includes:
+    - kas/include/mender-full.yml
+    - kas/include/tegra-jetpack6.yml
+
+machine: p3768-0000-p3767-0000
+
+local_conf_header:
+  AB-upgrades: |
+    USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
+  eMMC: |
+    # equivalent: EMMC_SIZE = "32 * 1024 * 1024 * 1024"
+    EMMC_SIZE = "34359738368"
+    # id defined in custom partition layout
+    MENDER_DATA_PART_NUMBER = "17"
+    MENDER_STORAGE_DEVICE = "/dev/nvme0n1"

--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -7,6 +7,7 @@ The supported and tested boards are:
 - AGX Orin
 - AGX Xavier
 - Orin Nano
+- Orin NX
 
 
 ## Dependencies
@@ -27,12 +28,6 @@ branch: scarthgap
 revision: HEAD
 ```
 
-## Quick start
-
-See the mender hub pages and the documentation for the `tegrademo-mender`
-distro on the [tegra-demo-distro](https://github.com/OE4T/tegra-demo-distro) repository
-for the most up to date instructions on starting out with mender and tegra.
-
 ## [`kas`](https://github.com/siemens/kas) configurations
 
 The following configuration files for building using the `kas` tool are provided:
@@ -40,6 +35,15 @@ The following configuration files for building using the `kas` tool are provided
 - [jetson-agx-orin-devkit.yml](../kas/jetson-agx-orin-devkit.yml)
 - [jetson-agx-xavier-devkit.yml](../kas/jetson-agx-xavier-devkit.yml)
 - [jetson-orin-nano-devkit.yml](../kas/jetson-orin-nano-devkit.yml)
+- [jetson-orin-16gb-nx-p3786.yml](../kas/jetson-orin-16gb-nx-p3786.yml)
+
+### Jetson Orin NX
+
+Mender leverages the UDA partition to store the persistent data between updates. But with the 
+Orin NX which uses an NVMe the current process doesn't work. Based on nvidia feedback [UDA is 
+reserved](https://forums.developer.nvidia.com/t/jetson-orin-nx-custom-partition-layout-fails-with-uda-at-the-end/316401/6) by nvidia.
+
+To solve this issue we create a new [custom partition layout](recipes-bsp/tegra-binaries/tegra-storage-layout/flash_l4t_t234_nvme_rootfs_ab.xml) with a dedicated partition `id=17` for persistent data.
 
 ## Acknowlegements
 

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout/flash_l4t_t234_nvme_rootfs_ab.xml
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout/flash_l4t_t234_nvme_rootfs_ab.xml
@@ -1,0 +1,212 @@
+<?xml version="1.0"?>
+
+<!--
+# SPDX-FileCopyrightText: Copyright (c) 2023-2024 NVIDIA CORPORATION & AFFILIATES.
+#                         All rights reserved.
+# SPDX-License-Identifier: LicenseRef-NvidiaProprietary
+#
+# NVIDIA CORPORATION, its affiliates and licensors retain all intellectual
+# property and proprietary rights in and to this material, related
+# documentation and any modifications thereto. Any use, reproduction,
+# disclosure or distribution of this material and related documentation
+# without an express license agreement from NVIDIA CORPORATION or
+# its affiliates is strictly prohibited.
+-->
+
+<!-- Nvidia Tegra Partition Layout Version 1.0.0 -->
+<partition_layout version="01.00.0000">
+    <device type="external" instance="0" sector_size="512" num_sectors="EXT_NUM_SECTORS" >
+        <partition name="master_boot_record" type="protective_master_boot_record">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 512 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="primary_gpt" type="primary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 19968 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="A_kernel" id="3" type="kernel">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 134217728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> LNXFILE </filename>
+        </partition>
+        <partition name="A_kernel-dtb" type="kernel_dtb">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 786432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTB_FILE </filename>
+        </partition>
+        <partition name="A_reserved_on_user" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 33161216 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="B_kernel" type="kernel">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 134217728 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> LNXFILE_b </filename>
+        </partition>
+        <partition name="B_kernel-dtb" type="kernel_dtb">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 786432 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> DTB_FILE </filename>
+        </partition>
+        <partition name="B_reserved_on_user" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 33161216 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="RECNAME" type="kernel">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> RECSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> RECFILE </filename>
+        </partition>
+        <partition name="RECDTB-NAME" type="kernel_dtb">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> RECDTB-FILE </filename>
+        </partition>
+        <partition name="esp" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 67108864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <filename> ESP_FILE </filename>
+            <partition_type_guid> C12A7328-F81F-11D2-BA4B-00A0C93EC93B </partition_type_guid>
+            <description> **Required.** EFI system partition with L4T Launcher. </description>
+        </partition>
+        <partition name="RECNAME_alt" type="kernel">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> RECSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="RECDTB-NAME_alt" type="kernel_dtb">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 524288 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+        <partition name="esp_alt" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 67108864 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** EFI system partition for fail-safe ESP update. </description>
+        </partition>
+        <partition name="UDA" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 419430400 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <align_boundary> 16384 </align_boundary>
+            <description> **Required.** This partition may be mounted and used to store user
+              data. </description>
+        </partition>
+        <partition name="reserved" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 502792192 </size> <!-- Recalculate the size if RECSIZE changed -->
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <description> **Required.** Reserve space in case there is any partition change
+              required in the future, for example, adding new partitions or increasing size
+              of some partitions. </description>
+        </partition>
+        <partition name="APP" id="1" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <align_boundary> 16384 </align_boundary>
+            <percent_reserved> 0 </percent_reserved>
+            <unique_guid> APPUUID </unique_guid>
+            <filename> APPFILE </filename>
+            <description> **Required.** Contains the rootfs. This partition must be assigned
+              the "1" for id as it is physically put to the end of the device, so that it
+              can be accessed as the fixed known special device `/dev/nvme0n1p1`. </description>
+        </partition>
+        <partition name="APP_b" id="2" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> APPSIZE </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x8 </allocation_attribute>
+            <align_boundary> 16384 </align_boundary>
+            <percent_reserved> 0 </percent_reserved>
+            <unique_guid> APPUUID_b </unique_guid>
+            <filename> APPFILE_b </filename>
+            <description> **Required.** Contains the rootfs. This partition must be assigned
+              the "2" for id as it is physically put to the end of the device, so that it
+              can be accessed as the fixed known special device `/dev/nvme0n1p2`. </description>
+        </partition>
+        <partition name="permanet_user_storage" id= "17" type="data">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 419430400 </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 0x808 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+            <align_boundary> 16384 </align_boundary>
+            <filename> DATAFILE </filename>
+            <description> **Required.** This partition is used to store permanent user
+              and device data between A/B updates</description>
+        </partition>
+        <partition name="secondary_gpt" type="secondary_gpt">
+            <allocation_policy> sequential </allocation_policy>
+            <filesystem_type> basic </filesystem_type>
+            <size> 0xFFFFFFFFFFFFFFFF </size>
+            <file_system_attribute> 0 </file_system_attribute>
+            <allocation_attribute> 8 </allocation_attribute>
+            <percent_reserved> 0 </percent_reserved>
+        </partition>
+    </device>
+</partition_layout>

--- a/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append:p3768-0000-p3767-0000 = " \
+    file://flash_l4t_t234_nvme_rootfs_ab.xml \
+"
+
+PARTITION_FILE_EXTERNAL:p3768-0000-p3767-0000 = "${WORKDIR}/flash_l4t_t234_nvme_rootfs_ab.xml"


### PR DESCRIPTION
Enable support for a jetson Orin NX with NVMe

Based on this issue: https://hub.mender.io/t/jetson-orin-nx-and-jetpack-6-mender-intergration-issues/7375

- Create custom partition layout
- Use `<allocation_attribute> 0x808 </allocation_attribute>` to expand the user partition automatically during the flash process
- Add documentation
