### PR TITLE
chore: split the GitHub Actions build workflows

### DIFF
--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -50,7 +50,8 @@ jobs:
           vexpress-qemu,
           vexpress-qemu-flash,
           x86-virtual,
-          beaglebone-uboot
+          beaglebone-uboot,
+          rock-4c-plus,
         ]
         subpath: [.]
 

--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -2,10 +2,9 @@ name: build_boards
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["cache layers"]
-    types: 
-    - completed
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 2 * * 6'
 
 env:
   BUILDDIR: build

--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -1,29 +1,30 @@
-name: build boards
+name: build_boards
 
 on:
   workflow_dispatch:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron:  '5 2 * * 6'
+  workflow_run:
+    workflows: ["cache layers"]
+    types: 
+    - completed
 
 env:
-  BUILDDIR: gh
+  BUILDDIR: build
 
 jobs:
   prepare:
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, builder]
+    outputs:
+      artifact_path: ${{ steps.artifact_path.outputs.artifact_path }}
     steps:
       - name: Clean up
         run: rm -fR $BUILDDIR
       - uses: actions/checkout@v4
-      - name: cache metadata layers
-        run: ./ci/update-repos
-        env:
-          LAYERCACHE: ${{ vars.PERSISTENT_DIR }}/layers
+      - id: artifact_path
+        name: create artifact output directory
+        run: echo "artifact_path=${{ vars.ARTIFACT_OUTPUT_DIR }}/$GITHUB_REPOSITORY/$GITHUB_WORKFLOW/$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" >> $GITHUB_OUTPUT
 
   build:
     needs: [prepare]
-    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
@@ -49,31 +50,11 @@ jobs:
           vexpress-qemu,
           vexpress-qemu-flash,
           x86-virtual,
-          beaglebone-uboot,
-          olimex-imx8mp-evb,
-          jetson-agx-orin-devkit,
-          jetson-agx-xavier-devkit,
-          jetson-orin-nano-devkit
+          beaglebone-uboot
         ]
-        experimental: [false]
         subpath: [.]
-        include:
-          - board: raspberrypi4-64-app-updates
-            subpath: demos
-            experimental: true
-          - board: imx93-var-som
-            experimental: true
-          - board: qemuarm64-client-only
-            subpath: demos
-            experimental: false
-          - board: qemuarm64-bootloader-validation
-            subpath: demos
-            experimental: false
-          - board: raspberrypi4-64-wifi
-            subpath: demos
-            experimental: false
 
-    runs-on: [self-hosted, linux, x64]
+    runs-on: [self-hosted, linux, x64, builder]
     container:
       # the container image needs to be effectively hardcoded, it seems.
       image: ghcr.io/theyoctojester/devcontainer-base-yoep:main
@@ -97,3 +78,12 @@ jobs:
           cp ${{ vars.BUILD_ASSETS_DIR }}/site.conf build/conf/site.conf;
           fi &&
           kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml
+
+  collect:
+    needs: [prepare, build]
+    runs-on: [self-hosted, linux, x64, builder]
+    steps:
+      - name: collect artifacts
+        env:
+          ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
+        run: ./ci/collect_artifacts.sh

--- a/.github/workflows/build_demos.yml
+++ b/.github/workflows/build_demos.yml
@@ -2,10 +2,9 @@ name: build_demos
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["cache layers"]
-    types: 
-    - completed
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 2 * * 6'
 
 env:
   BUILDDIR: demos

--- a/.github/workflows/build_demos.yml
+++ b/.github/workflows/build_demos.yml
@@ -1,0 +1,71 @@
+name: build_demos
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["cache layers"]
+    types: 
+    - completed
+
+env:
+  BUILDDIR: demos
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, linux, x64, builder]
+    outputs:
+      artifact_path: ${{ steps.artifact_path.outputs.artifact_path }}
+    steps:
+      - name: Clean up
+        run: rm -fR $BUILDDIR
+      - uses: actions/checkout@v4
+      - id: artifact_path
+        name: create artifact output directory
+        run: echo "artifact_path=${{ vars.ARTIFACT_OUTPUT_DIR }}/$GITHUB_REPOSITORY/$GITHUB_WORKFLOW/$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [
+          raspberrypi4-64-app-updates,
+          qemuarm64-bootloader-validation,
+          qemuarm64-client-only,
+          raspberrypi4-64-wifi
+        ]
+        subpath: [demos]
+
+    runs-on: [self-hosted, linux, x64, builder]
+    container:
+      # the container image needs to be effectively hardcoded, it seems.
+      image: ghcr.io/theyoctojester/devcontainer-base-yoep:main
+      volumes:
+        - ${{ vars.PERSISTENT_DIR }}/downloads:${{ vars.BUILD_DL_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/sstate-cache:${{ vars.BUILD_SSTATE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/layers:${{ vars.BUILD_LAYERCACHE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/assets:${{ vars.BUILD_ASSETS_DIR }}
+      options: --user ${{ vars.KAS_UID }}:${{ vars.KAS_GID }}
+    steps:
+      - name: enter build dir and build
+        env:
+          DL_DIR: ${{ vars.BUILD_DL_DIR}}
+          SSTATE_DIR: ${{ vars.BUILD_SSTATE_DIR}}
+          KAS_REPO_REF_DIR: ${{ vars.BUILD_LAYERCACHE_DIR}}
+        run: >
+          mkdir -p $BUILDDIR/${{ matrix.board }} &&
+          cd $BUILDDIR/${{ matrix.board }} &&
+          kas checkout ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml &&
+          if [ -f "${{ vars.BUILD_ASSETS_DIR }}/site.conf" ]; then 
+          cp ${{ vars.BUILD_ASSETS_DIR }}/site.conf build/conf/site.conf;
+          fi &&
+          kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml
+
+  collect:
+    needs: [prepare, build]
+    runs-on: [self-hosted, linux, x64, builder]
+    steps:
+      - name: collect artifacts
+        env:
+          ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
+        run: ./ci/collect_artifacts.sh

--- a/.github/workflows/build_experimental.yml
+++ b/.github/workflows/build_experimental.yml
@@ -1,0 +1,58 @@
+name: build_experimental
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["cache layers"]
+    types: 
+    - completed
+
+env:
+  BUILDDIR: experimental
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, linux, x64, builder]
+    steps:
+      - name: Clean up
+        run: rm -fR $BUILDDIR
+      - uses: actions/checkout@v4
+
+  build:
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [
+          olimex-imx8mp-evb,
+          jetson-agx-orin-devkit,
+          jetson-agx-xavier-devkit,
+          jetson-orin-nano-devkit,
+          imx93-var-som
+        ]
+        subpath: [.]
+
+    runs-on: [self-hosted, linux, x64, builder]
+    container:
+      # the container image needs to be effectively hardcoded, it seems.
+      image: ghcr.io/theyoctojester/devcontainer-base-yoep:main
+      volumes:
+        - ${{ vars.PERSISTENT_DIR }}/downloads:${{ vars.BUILD_DL_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/sstate-cache:${{ vars.BUILD_SSTATE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/layers:${{ vars.BUILD_LAYERCACHE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/assets:${{ vars.BUILD_ASSETS_DIR }}
+      options: --user ${{ vars.KAS_UID }}:${{ vars.KAS_GID }}
+    steps:
+      - name: enter build dir and build
+        env:
+          DL_DIR: ${{ vars.BUILD_DL_DIR}}
+          SSTATE_DIR: ${{ vars.BUILD_SSTATE_DIR}}
+          KAS_REPO_REF_DIR: ${{ vars.BUILD_LAYERCACHE_DIR}}
+        run: >
+          mkdir -p $BUILDDIR/${{ matrix.board }} &&
+          cd $BUILDDIR/${{ matrix.board }} &&
+          kas checkout ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml &&
+          if [ -f "${{ vars.BUILD_ASSETS_DIR }}/site.conf" ]; then 
+          cp ${{ vars.BUILD_ASSETS_DIR }}/site.conf build/conf/site.conf;
+          fi &&
+          kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -2,10 +2,10 @@ name: build_validation
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["cache layers"]
-    types: 
-    - completed
+  push:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 2 * * 6'
 
 env:
   BUILDDIR: validation

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -1,0 +1,79 @@
+name: build_validation
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["cache layers"]
+    types: 
+    - completed
+
+env:
+  BUILDDIR: validation
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, linux, x64, builder]
+    outputs:
+      artifact_path: ${{ steps.artifact_path.outputs.artifact_path }}
+      artifact_latest: ${{ steps.artifact_latest.outputs.artifact_latest }}
+    steps:
+      - name: Clean up
+        run: rm -fR $BUILDDIR
+      - uses: actions/checkout@v4
+      - id: artifact_path
+        name: generate artifact output directory name
+        run: echo "artifact_path=${{ vars.ARTIFACT_OUTPUT_DIR }}/$GITHUB_REPOSITORY/$GITHUB_REF_NAME/$GITHUB_WORKFLOW/$GITHUB_RUN_NUMBER-$GITHUB_RUN_ATTEMPT" >> $GITHUB_OUTPUT
+      - id: artifact_latest
+        name: generate latest artifact symlink name
+        run: echo "artifact_latest=${{ vars.ARTIFACT_OUTPUT_DIR }}/$GITHUB_REPOSITORY/$GITHUB_REF_NAME/$GITHUB_WORKFLOW/latest" >> $GITHUB_OUTPUT
+
+  build:
+    needs: [prepare]
+    strategy:
+      fail-fast: false
+      matrix:
+        board: [
+          raspberrypi4,
+          raspberrypi4-64,
+          raspberrypi5,
+        ]
+        subpath: [.]
+
+    runs-on: [self-hosted, linux, x64, builder]
+    container:
+      # the container image needs to be effectively hardcoded, it seems.
+      image: ghcr.io/theyoctojester/devcontainer-base-yoep:main
+      volumes:
+        - ${{ vars.PERSISTENT_DIR }}/downloads:${{ vars.BUILD_DL_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/sstate-cache:${{ vars.BUILD_SSTATE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/layers:${{ vars.BUILD_LAYERCACHE_DIR }}
+        - ${{ vars.PERSISTENT_DIR }}/assets:${{ vars.BUILD_ASSETS_DIR }}
+      options: --user ${{ vars.KAS_UID }}:${{ vars.KAS_GID }}
+    steps:
+      - name: enter build dir and build
+        env:
+          DL_DIR: ${{ vars.BUILD_DL_DIR}}
+          SSTATE_DIR: ${{ vars.BUILD_SSTATE_DIR}}
+          KAS_REPO_REF_DIR: ${{ vars.BUILD_LAYERCACHE_DIR}}
+        run: >
+          mkdir -p $BUILDDIR/${{ matrix.board }} &&
+          cd $BUILDDIR/${{ matrix.board }} &&
+          kas checkout ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml &&
+          if [ -f "${{ vars.BUILD_ASSETS_DIR }}/site.conf" ]; then 
+          cp ${{ vars.BUILD_ASSETS_DIR }}/site.conf build/conf/site.conf;
+          fi &&
+          kas build ../../kas/${{ matrix.subpath }}/${{ matrix.board }}.yml:../../kas/include/validation.yml
+
+  collect:
+    needs: [prepare, build]
+    runs-on: [self-hosted, linux, x64, builder]
+    steps:
+      - name: collect artifacts
+        env:
+          ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
+        run: ./ci/collect_artifacts.sh
+      - name: mark latest
+        run: >
+          rm -fR ${{ needs.prepare.outputs.artifact_latest }};
+          echo "using artifact path ${{ needs.prepare.outputs.artifact_path }}, latest ${{ needs.prepare.outputs.artifact_latest }}" &&
+          ln -s ${{ needs.prepare.outputs.artifact_path }} ${{ needs.prepare.outputs.artifact_latest }}

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -33,6 +33,10 @@ jobs:
       fail-fast: false
       matrix:
         board: [
+          beaglebone,
+          beaglebone-uboot,
+          raspberrypi3,
+          raspberrypi3-64,
           raspberrypi4,
           raspberrypi4-64,
           raspberrypi5,

--- a/.github/workflows/cache_layers.yml
+++ b/.github/workflows/cache_layers.yml
@@ -2,9 +2,10 @@ name: cache_layers
 
 on:
   workflow_dispatch:
+  push:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '5 2 * * 6'
+    - cron:  '5 1 * * *'
 
 jobs:
   prepare:

--- a/.github/workflows/cache_layers.yml
+++ b/.github/workflows/cache_layers.yml
@@ -1,0 +1,16 @@
+name: cache_layers
+
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    - cron:  '5 2 * * 6'
+
+jobs:
+  prepare:
+    runs-on: [self-hosted, linux, x64, builder]
+    steps:
+      - name: cache metadata layers
+        run: ./ci/update-repos
+        env:
+          LAYERCACHE: ${{ vars.PERSISTENT_DIR }}/layers

--- a/ci/collect_artifacts.sh
+++ b/ci/collect_artifacts.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+
+if [ -z ${BUILDDIR+x} ]; then
+	echo "BUILDDIR is unset, exiting";
+	exit 1;
+fi
+if [ -z ${ARTIFACT_PATH+x} ]; then
+	echo "ARTIFACT_PATH is unset, exiting";
+	exit 1;
+fi
+
+echo "using BUILDDIR: $BUILDDIR"
+echo "using ARTIFACT_PATH: $ARTIFACT_PATH"
+
+mkdir -p $ARTIFACT_PATH
+
+IMAGE_SUBPATH="build/tmp/deploy/images"
+
+for build in $(ls $BUILDDIR); do
+	echo "found build: $build"
+
+	if [ ! -d "$BUILDDIR/$build/$IMAGE_SUBPATH" ]; then
+		echo "no artifacts found"
+		continue
+	fi
+
+	for board in $(ls $BUILDDIR/$build/$IMAGE_SUBPATH); do
+		echo ".. found board $board"
+		mkdir -p $ARTIFACT_PATH/$build
+		echo "$board" > $ARTIFACT_PATH/$build/board.txt
+		cp -fR $BUILDDIR/$build/$IMAGE_SUBPATH/$board $ARTIFACT_PATH/$build/images
+		cp -fR $BUILDDIR/$build/build/conf $ARTIFACT_PATH/$build
+
+		if [ -d "$BUILDDIR/$build/build/tmp/buildstats" ]; then
+			cp -fR $BUILDDIR/$build/build/tmp/buildstats $ARTIFACT_PATH/$build
+		fi
+	done
+done

--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -10,3 +10,4 @@ local_conf_header:
   validation: |
     IMAGE_INSTALL:append = " bootloader-validation "
     MENDER_FEATURES_ENABLE:append = " mender-prepopulate-inactive-partition "
+    MENDER_FEATURES_DISABLE:append = " mender-growfs-data "

--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -1,0 +1,11 @@
+header:
+  version: 14
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-validation:
+
+local_conf_header:
+  validation: |
+    IMAGE_INSTALL:append = " bootloader-validation "

--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -9,3 +9,4 @@ repos:
 local_conf_header:
   validation: |
     IMAGE_INSTALL:append = " bootloader-validation "
+    MENDER_FEATURES_ENABLE:append = " mender-prepopulate-inactive-partition "

--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -11,3 +11,4 @@ local_conf_header:
     IMAGE_INSTALL:append = " bootloader-validation "
     MENDER_FEATURES_ENABLE:append = " mender-prepopulate-inactive-partition "
     MENDER_FEATURES_DISABLE:append = " mender-growfs-data "
+    EXTRA_IMAGE_FEATURES:append = " allow-empty-password empty-root-password allow-root-login "

--- a/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_0.1.bb
+++ b/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_0.1.bb
@@ -4,7 +4,7 @@ LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
 SRC_URI = "git://github.com/theyoctojester/mender-validation.git;protocol=https;branch=main"
-SRCREV = "8e9ed9f22b1a7e193dbb0ce93c27ff2b2d9e804b"
+SRCREV = "45033cda680a586d75bb07e0edec81cb92e5e4c9"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"


### PR DESCRIPTION
So far the build workflow was monolithic, which does not scale for a fast turnaround. To improve this, split into
- preparation stage, which caches all required metadata layers
- building the known good boards
- building the experimental boards
- building the boards which are also in automated validation.
The latter upon every push.

Validation build images contain the boot loader integration test script, and are collected to an output directory on NFS for being picked up by the test runners.

Changelog: Title
Ticket: None