### PR TITLE
fix: kas: adjust qemuboot settings for qemuarm64

### DIFF
--- a/kas/qemuarm64.yml
+++ b/kas/qemuarm64.yml
@@ -17,4 +17,13 @@ local_conf_header:
     MENDER_EFI_LOADER = "edk2-firmware"
     MENDER_STORAGE_DEVICE = "/dev/vda"
 
+  qemu: |
+    QB_MACHINE = "-machine virt,secure=on"
+    QB_OPT_APPEND += "-no-acpi"
+    QB_MEM = "-m 2048"
+    QB_DEFAULT_FSTYPE = "uefiimg"
+    QB_DEFAULT_BIOS = "QEMU_EFI.fd"
+    QB_ROOTFS_OPT = ""
+    QB_KERNEL_ROOT = "/dev/vda2"
+
 machine: qemuarm64

--- a/meta-mender-qemu-community/README
+++ b/meta-mender-qemu-community/README
@@ -46,17 +46,3 @@ MENDER_EFI_LOADER = "edk2-firmware"
 MENDER_STORAGE_DEVICE = "/dev/vda"
 ```
 
-Running the `qemuarm64` machine:
-
-```
-cd tmp/deploy/qemuarm64
-qemu-system-aarch64 \
-  -machine virt \
-  -name "Virtual ARM64" \
-  -m 4G \
-  -smp 6 \
-  -cpu cortex-a57 \
-  -drive file=./core-image-minimal-qemuarm64.uefiimg,if=virtio,format=raw \
-  -bios ./QEMU_EFI.fd \
-  -nographic
-```


### PR DESCRIPTION
This adjusts the runqemu related variables such that a canonical runqemu invocation uses the correct bios and image for the full boot flow.

Changelog: Title
Ticket: None