### PR TITLE
fix: kas: adjust qemuboot settings for qemux86

### DIFF
--- a/kas/qemux86-64.yml
+++ b/kas/qemux86-64.yml
@@ -5,3 +5,9 @@ header:
   - kas/include/qemu.yml
 
 machine: qemux86-64
+
+local_conf_header:
+  qemu: |
+    MENDER_STORAGE_DEVICE = "/dev/vda"
+    QB_DEFAULT_FSTYPE = "uefiimg"
+    QB_KERNEL_ROOT = "/dev/vda2"


### PR DESCRIPTION
This adjusts the runqemu related variables such that a canonical runqemu invocation uses the correct bios and image for the full boot flow.

Changelog: Title
Ticket: None