### PR TITLE
validation: use dedicated image

### DIFF
--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -8,7 +8,8 @@ repos:
 
 local_conf_header:
   validation: |
-    IMAGE_INSTALL:append = " bootloader-validation "
     MENDER_FEATURES_ENABLE:append = " mender-prepopulate-inactive-partition "
     MENDER_FEATURES_DISABLE:append = " mender-growfs-data "
-    EXTRA_IMAGE_FEATURES:append = " allow-empty-password empty-root-password allow-root-login "
+
+target:
+  - mender-validation-image

--- a/meta-mender-validation/recipes-mender/images/mender-validation-image.bb
+++ b/meta-mender-validation/recipes-mender/images/mender-validation-image.bb
@@ -1,0 +1,6 @@
+require recipes-core/images/core-image-minimal.bb
+
+DESCRIPTION = "Small image capable of running the Mender validation suite"
+
+IMAGE_INSTALL:append = " bootloader-validation "
+IMAGE_FEATURES:append = " allow-empty-password empty-root-password allow-root-login "


### PR DESCRIPTION
Instead of adding packages and image features through local.conf for validation builds, create a specialized image
"mender-validation-image" and refer to it from the validation.yml kas file.

Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
(cherry picked from commit 71d5112dd3ac25890fa6b3c0aceba18a6a596a67)