### PR TITLE
tegra: fix conflict with tegra-boot-tools for TX2 u-boot bootloader configurations

### DIFF
--- a/meta-mender-tegra/classes/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/classes/tegra-mender-setup.bbclass
@@ -141,3 +141,8 @@ MENDER_DEVICE_TYPES_COMPATIBLE_append_jetson-tx2-devkit-4gb = " jetson-tx2-4gb"
 MENDER_DEVICE_TYPES_COMPATIBLE_append_jetson-agx-xavier-devkit = " jetson-xavier"
 MENDER_DEVICE_TYPES_COMPATIBLE_append_jetson-agx-xavier-devkit-8gb = " jetson-xavier-8gb"
 MENDER_DEVICE_TYPES_COMPATIBLE_append_jetson-nano-devkit-emmc = " jetson-nano-emmc"
+
+# Handle uboot storage location conflicts on t186 platforms
+TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE_DEFAULT = "0"
+TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE_DEFAULT_tegra186 = "${@'0' if (d.getVar('PREFERRED_PROVIDER_virtual/bootloader') or '').startswith('cboot') else '1'}"
+TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE ?= "${TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE_DEFAULT}"

--- a/meta-mender-tegra/recipes-bsp/tools/tegra-boot-tools_%.bbappend
+++ b/meta-mender-tegra/recipes-bsp/tools/tegra-boot-tools_%.bbappend
@@ -1,0 +1,1 @@
+EXTRA_OECONF:append = "${@' --with-extended-sector-count=1' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE')) else ''}"


### PR DESCRIPTION
Proposing this PR to at least get some visibility on the issue but it won't hurt my feelings if you don't want to merge it.... I know these branches are old and there is something to be said for if it isn't broke don't fix it.  That said I think this change is unlikely to make anything worse than it is for the current user base and would definitely help anyone who ended up in this case through an update scenario.

The PR targets `dunfell` since this is where the problem was discovered in the OE4T element thread [here](https://matrix.to/#/!mKaltPMAHUgQwPUKcH:gitter.im/$xvPfnhEYNz4OWlgpOsM4v_3ySpLkJ6xRFocjj0G_7eI?via=gitter.im&via=matrix.org&via=3dvisionlabs.com) but I think we have the same problem in kirkstone-l4t-r32.x so a similar change needs to go there.


Since the `PREFERRED_PROVIDER_virtual/bootloader` is `cboot` on the reference example for TX2 on tegra-demo-distro as of https://github.com/OE4T/tegra-demo-distro/commit/9a9fee5bf5e4945b77351bb38914bbf41a6df399 most likely the only people ending up in this scenario are people who changed their `PREFERERED_PROVIDER_virtual/bootloader` to `u-boot-tegra`, or who started with an early implementation before we switched the default tegra-demo-distro implementation to `cboot` and are now attempting to upgrade to the latest on the dunfell branch (which was the case for the element thread referenced above).

# Commit Message with Detail

Tegra 186 (TX2 and TX2-NX platforms) have a conflict with tegra-boot-tools in the usage of /dev/mmcblk0boot1 partition which can cause corrupt uboot redundant environment when u-boot-tegra is used as the PREFERRED_PROVIDER The uboot redundant partition is stored from region 0x3db000 to 0x3fb000, however the default extension sector count for tegra-bootinfo at [1] and [2] places extension sectors starting at 0x3f7800 within this range.

This means that during the first boot, the --initialize from bootcountcheck script at [3] which runs during early boot will corrupt the bootloader vars initially setup by u-boot.

The mender-client, as long as it's enabled, will fix the corruption shortly after when started and normally you would not notice this corruption.

As long as the mender-client is initialized during the first boot, tegra-bootinfo would only further corrupt the uboot environment if used to write extended vars using the set-variable option, if re-initialized using the force-initialize option, or a re-initialzation occured because the copy A version of devinfo was corrupt, for instance due to a power cycle during write.

Extended variables are used in tegra-bootinfo to write machine-id in the cboot mender implementation but not used on the u-boot example, so unless the implementation layer has used tegra-bootinfo to store extended variables with the set-variable option the only way this bug would be noticed would be if mender-client is not run on the first startup OR if a write failure happened and corrupted copy A of tegra-bootinfo occured during boot.  In this scenario, uboot environment would presumably be restored from the redundant copy and only variables changed in the non-redundant copy would be lost.

To avoid this possibility, resize the tegra-bootinfo extended sectors to 1 when using tegra186 targets and tegra-bootinfo.  This limits storage space to a single sector but ensures the extended variable store starts at 0x3fb000 outside the u-boot redundant environment variable storage space.

If desired, this workaround can be disabled and the default extended sector size (and resulting u-boot storage conflict) may be used by setting
```
TEGRA_MENDER_BOOTINFO_STORAGE_REDUCE = "0"
```
in the implementation layer

1: https://github.com/OE4T/tegra-boot-tools/blob/059ddc8187ae0e9f7ba0acdb672bdabaa7559434/bootinfo.c#L139-L149
2: https://github.com/OE4T/tegra-boot-tools/blob/master/doc/bootinfo.md#tegra186-tx2
3: https://github.com/OE4T/tegra-boot-tools/blob/6914656e5d662be23e94cad920c33d1245beb4d1/scripts/bootcountcheck#L2

# Upgrade Path

One consideration is the upgrade path, where the size of tegra-bootinfo extension storage space was reduced from 15 sectors to 1 with this commit.  Based on code review I believe the [initialize here](https://github.com/OE4T/tegra-boot-tools/blob/059ddc8187ae0e9f7ba0acdb672bdabaa7559434/tegra-bootinfo.c#L217-L228) will re-initialize tegra-bootinfo content due to extension sector mismatch detected [here](https://github.com/OE4T/tegra-boot-tools/blob/059ddc8187ae0e9f7ba0acdb672bdabaa7559434/bootinfo.c#L631-L633), and any variables written by tegra-bootinfo will be lost.  I don’t believe anything related to subsequent slot checking [here](https://github.com/OE4T/tegra-boot-tools/blob/master/bootinfo.c#L781-L804) will be impacted since the default context boot flags [will be initialized to zero](https://github.com/OE4T/tegra-boot-tools/blob/059ddc8187ae0e9f7ba0acdb672bdabaa7559434/bootinfo.c#L464).  I believe this means the only noticeable impact would be if the application stored their own content in with the set-variable command of tegra-bootinfo.  In this case the content of the variable would be lost on upgrade.  I believe we don’t use tegra-bootinfo to store any variables in the mender example implementation on the u-boot integration where this conflict occurs, only on the [cboot implementation](https://github.com/mendersoftware/meta-mender-community/blob/dd4621ca3304cf536105416baff7be529b9f543a/meta-mender-tegra/recipes-mender/tegra-state-scripts/files/redundant-boot-install-script#L65) for machine-id.

## Upgrade Path Testing

I ran these commands on a system booted with the current dunfell content with `PREFERRED_PROVIDER_virtual/bootloader_tegra186 = "u-boot-tegra"`

```
root@jetson-tx2-devkit:~# tegra-bootinfo --show
devinfo version:        3
Boot in progress:       NO
Failed boots:           0
Extension space:        15 sectors
root@jetson-tx2-devkit:~# tegra-bootinfo -v test
not found: test
root@jetson-tx2-devkit:~# tegra-bootinfo -V test="test var"
root@jetson-tx2-devkit:~# fw_printenv -n mender_boot_part
1
root@jetson-tx2-devkit:~# nvbootctrl get-current-slot
0
root@jetson-tx2-devkit:~# tegra-boot-control --current-slot
0
```
So initially the extension space is 15 sectors and I can add a `test` variable using the extension space

I then `mender install`ed a .mender file built with this commit
```
root@jetson-tx2-devkit:~# mender install /tmp/core-image-minimal-jetson-tx2-devkit.mender
INFO[0000] Loaded configuration file: /var/lib/mender/mender.conf
INFO[0000] Loaded configuration file: /etc/mender/mender.conf
INFO[0000] Mender running on partition: /dev/mmcblk0p1
INFO[0000] Start updating from local image file: [/tmp/core-image-minimal-jetson-tx2-devkit.mender]
Installing Artifact of size 67409920...
INFO[0000] No public key was provided for authenticating the artifact
INFO[0000] Update Module path "/usr/share/mender/modules/v3" could not be opened (open /usr/share/mender/modules/v3: no such file or directory). Update modules will not be available
INFO[0000] Opening device "/dev/mmcblk0p33" for writing
INFO[0000] Native sector size of block device /dev/mmcblk0p33 is 512 bytes. Mender will write in chunks of 1048576 bytes
.............................................................. - 100 %
INFO[0100] All bytes were successfully written to the new partition
INFO[0100] The optimized block-device writer wrote a total of 11772 frames, where 44 frames did need to be rewritten (i.e., skipped)
INFO[0102] Wrote 12343259136/12343259136 bytes to the inactive partition
INFO[0102] Enabling partition with new image installed to be a boot candidate: 33
INFO[0102] Executing script: ArtifactInstall_Leave_80_bl-update
Use -commit to update, or -rollback to roll back the update.
At least one payload requested a reboot of the device it updated.
```

I then rebooted and re-ran the same commands:
```
root@jetson-tx2-devkit:~# tegra-bootinfo --show
devinfo version:        3
Boot in progress:       NO
Failed boots:           0
Extension space:        1 sector
root@jetson-tx2-devkit:~# tegra-bootinfo -v test
not found: test
root@jetson-tx2-devkit:~# tegra-bootinfo -V test="test var"
root@jetson-tx2-devkit:~# fw_printenv -n mender_boot_part
33
root@jetson-tx2-devkit:~# nvbootctrl get-current-slot
1
root@jetson-tx2-devkit:~# tegra-boot-control --current-slot
1
root@jetson-tx2-devkit:~# mender commit
INFO[0000] Loaded configuration file: /var/lib/mender/mender.conf
INFO[0000] Loaded configuration file: /etc/mender/mender.conf
INFO[0000] Mender running on partition: /dev/mmcblk0p33
INFO[0000] Update Module path "/usr/share/mender/modules/v3" could not be opened (open /usr/share/mender/modules/v3: no such file or directory). Update modules will not be available
Committing Artifact...
INFO[0000] Executing script: ArtifactCommit_Enter_80_bl-check-update
INFO[0000] Committing update
root@jetson-tx2-devkit:~#reboot
```
Here we see that our `test` variable disappeared from tegra-bootinfo as we've resized the extension space to 1 sector.  However, the rest of the content is as expected, and boot slots have changed and are synchronized.

Then rebooted again and verified the test var still was found after reboot

```
root@jetson-tx2-devkit:~# tegra-bootinfo -v test
test=test var
```