### PR TITLE
kas: track upstream scarthgap branches

### DIFF
--- a/kas/demos/qemuarm64-bootloader-validation.yml
+++ b/kas/demos/qemuarm64-bootloader-validation.yml
@@ -5,9 +5,7 @@ header:
 
 repos:
   meta-mender:
-    # note: this is the first commit to support the
-    # "mender-prepopulate-inactive-partition"
-    commit: 3d6099368742f1a461fb0aa14eccd2284c98f3b2
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/demos/raspberrypi4-64-app-updates.yml
+++ b/kas/demos/raspberrypi4-64-app-updates.yml
@@ -12,7 +12,7 @@ repos:
 
   meta-virtualization:
     url: git://git.yoctoproject.org/meta-virtualization
-    refspec: scarthgap
+    branch: scarthgap
 
   meta-mender:
     layers:

--- a/kas/imx93-var-som.yml
+++ b/kas/imx93-var-som.yml
@@ -19,30 +19,30 @@ repos:
 
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale
-    refspec: scarthgap
+    branch: scarthgap
 
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty
-    refspec: scarthgap
+    branch: scarthgap
 
   meta-freescale-distro:
     url: https://github.com/Freescale/meta-freescale-distro
-    refspec: scarthgap
+    branch: scarthgap
 
   meta-nxp:
     url: https://github.com/nxp-imx/meta-imx
-    refspec: scarthgap
+    branch: scarthgap
     layers:
       meta-bsp:
       meta-sdk:
 
   meta-variscite-bsp-common:
     url: https://github.com/varigit/meta-variscite-bsp-common
-    refspec: scarthgap
+    branch: scarthgap
 
   meta-variscite-bsp-imx:
     url: https://github.com/varigit/meta-variscite-bsp-imx
-    refspec: scarthgap
+    branch: scarthgap
 
 local_conf_header:
   imx93-var-som: |

--- a/kas/include/arm.yml
+++ b/kas/include/arm.yml
@@ -4,7 +4,7 @@ header:
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
-    commit: 58268ddccbe2780de28513273e15193ee949987b
+    branch: scarthgap
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -6,7 +6,7 @@ distro: poky
 repos:
   poky:
     url: git://git.yoctoproject.org/poky
-    commit: 7117d115eab7351ecf21388ec720a3bb5f4a9b30
+    branch: scarthgap
     layers:
       meta:
       meta-poky:
@@ -14,13 +14,13 @@ repos:
 
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
-    commit: 3c293e14492f01e22a64004e2330fb620c27578a
+    branch: scarthgap
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 4c242af57ff0a00a4d44328896a5cd81c27c8c46
+    branch: scarthgap
 
     layers:
       meta-mender-core:

--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -4,16 +4,13 @@ header:
 repos:
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale.git
-    # branch: scarthgap
-    commit: a7bf57d45cdd908155b4179845aa9d1d78095bc0
+    branch: scarthgap
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty.git
-    # branch: scarthgap
-    commit: 2602df3c730d970b8a4aa685b9f43d7ccd2c5d0f
+    branch: scarthgap
   meta-freescale-distro:
     url: https://github.com/Freescale/meta-freescale-distro.git
-    # branch: scarthgap
-    commit: b9d6a5d9931922558046d230c1f5f4ef6ee72345
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -4,11 +4,11 @@ header:
 repos:
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: 6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17
+    branch: scarthgap
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins
-    commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/include/rockchip.yml
+++ b/kas/include/rockchip.yml
@@ -4,7 +4,7 @@ header:
 repos:
   meta-rockchip:
     url: https://git.yoctoproject.org/meta-rockchip
-    commit: e641dba980efa885df7e992ac5c8783270aa375d
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-base.yml
+++ b/kas/include/tegra-base.yml
@@ -2,9 +2,6 @@ header:
   version: 14
 
 repos:
-  meta-mender:
-    commit: 2f70dbad1441055c299332b7ef33dfe1e4f50c1c # this one fixes the persistent-id for now!
-  
   meta-tegra:
     url: https://github.com/OE4T/meta-tegra.git
   meta-tegra-community:
@@ -24,7 +21,7 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization.git
-    commit: 6a80f140e387621f62964209a2e07d3bcfb125ce
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack5.yml
+++ b/kas/include/tegra-jetpack5.yml
@@ -6,14 +6,11 @@ header:
 
 repos:
   meta-tegra:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: 837aa8a67d2d3caec60e385b719e63387e5a7edc
+    branch: scarthgap-l4t-r35.x
   meta-tegra-community:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: c03675e45fa229a4c067f5bd2e8461b713d789f4
+    branch: scarthgap-l4t-r35.x
   meta-tegrademo:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: a3bdfbe4f67a8b1a172c4a540925a1d18b877109
+    branch: scarthgap-l4t-r35.x
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack6.yml
+++ b/kas/include/tegra-jetpack6.yml
@@ -6,14 +6,11 @@ header:
 
 repos:
   meta-tegra:
-    # refers to the scarthgap branch
-    commit: 8f9748b0178a4d93bceffd86d9d436cd0e685750
+    branch: scarthgap
   meta-tegra-community:
-    # refers to the scarthgap branch
-    commit: 241d1073ba8e610ef8da3fe8470b0a4d0567521f
+    branch: scarthgap
   meta-tegrademo:
-    # refers to the scarthgap branch
-    commit: 3f2641444d6c50c3fa4eea8a4c770bd30db70ee9
+    branch: scarthgap
 
   meta-mender-community:
     layers:

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -4,6 +4,6 @@ header:
 repos:
   meta-ti:
     url: https://git.yoctoproject.org/meta-ti
-    commit: e902a647ec3685009f870d6222336bfb6e7af6c3
+    branch: scarthgap
     layers:
       meta-ti-bsp:

--- a/kas/x86-virtual.yml
+++ b/kas/x86-virtual.yml
@@ -6,7 +6,7 @@ header:
 repos:
   meta-intel:
     url: https://git.yoctoproject.org/meta-intel
-    refspec: scarthgap
+    branch: scarthgap
 
 local_conf_header:
   x86-virtual: |


### PR DESCRIPTION
This branch is meant to test building with the latest upstream state of the scarthgap release branch(es). Adjust the kas files accordingly.