### PR TITLE
kas: track upstream kirkstone branches

### DIFF
--- a/kas/apalis-imx8-boot2qt.yml
+++ b/kas/apalis-imx8-boot2qt.yml
@@ -13,19 +13,19 @@ repos:
       meta-initramfs:
   meta-qt6:
     url: git://code.qt.io/yocto/meta-qt6
-    commit: c06b8b3e34f0dccfebb795a279010db1ab68ed2e
+    branch: kirkstone
   meta-boot2qt:
     url: git://code.qt.io/yocto/meta-boot2qt
-    commit: 7ec529584af7375e1a460b5093ccc42d406c6541
+    branch: kirkstone
     layers:
       meta-boot2qt:
       meta-boot2qt-distro:
   meta-toradex-bsp-common:
     url: https://git.toradex.com/meta-toradex-bsp-common.git
-    commit: 1a14c2724ab0cbcf3d01042fed7b60b48c8ab836
+    branch: kirkstone
   meta-toradex-nxp:
     url: https://git.toradex.com/meta-toradex-nxp.git
-    commit: 364341c23ea49fb875e84f980b208699311aaf9c
+    branch: kirkstone
   meta-mender-community:
     layers:
       meta-mender-toradex-nxp:

--- a/kas/demos/qemuarm64-swupdate.yml
+++ b/kas/demos/qemuarm64-swupdate.yml
@@ -12,7 +12,7 @@ repos:
 
   meta-swupdate:
     url: https://github.com/sbabic/meta-swupdate
-    commit: 6918be849ddf1fed5b7a0173e51c7a136e8d4101
+    branch: kirkstone
 
   meta-mender:
     layers:

--- a/kas/include/amlogic.yml
+++ b/kas/include/amlogic.yml
@@ -4,7 +4,7 @@ header:
 repos:
   meta-meson:
     url: https://github.com/superna9999/meta-meson
-    commit: 4a83d41dda9fcad026253046b677a1c20582391e
+    branch: kirkstone
 
   meta-mender-community:
     layers:

--- a/kas/include/atmel.yml
+++ b/kas/include/atmel.yml
@@ -4,11 +4,11 @@ header:
 repos:
   meta-atmel:
     url: https://github.com/linux4sam/meta-atmel
-    commit: 8c0d39c31ca47a677e8bcfe88045ab81fb7f20da
+    branch: kirkstone
 
   meta-arm:
     url: git://git.yoctoproject.org/meta-arm.git
-    commit: bf98ef902e6e7042e46a69fb2df6c68d00de2764
+    branch: kirkstone
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/include/boundarydevices.yml
+++ b/kas/include/boundarydevices.yml
@@ -4,4 +4,4 @@ header:
 repos:
   meta-boundary:
     url: https://github.com/boundarydevices/meta-boundary.git
-    commit: 0c405be0b905b239b96dc6f65a2eebc27a7e21c7
+    branch: kirkstone

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -6,7 +6,7 @@ distro: "poky"
 repos:
   poky:
     url: http://git.yoctoproject.org/poky
-    commit: 7e87dc422d972e0dc98372318fcdc63a76347d16
+    branch: kirkstone
     layers:
       meta:
       meta-poky:
@@ -14,13 +14,13 @@ repos:
 
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
-    commit: dd3d2293ffdf2559f8a433f241765a8ab50cd085
+    branch: kirkstone
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: a52f158b033c709df824c7e66a577c41f432ae7f
+    branch: kirkstone
     layers:
       meta-mender-core:
 

--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -4,13 +4,13 @@ header:
 repos:
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale.git
-    commit: c525e0c19bdc46d45f71873b5f286f49abb69418
+    branch: kirkstone
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty.git
-    commit: 9e94b64bdfebcf7bfdf2af6447cec866a4efa814
+    branch: kirkstone
   meta-freescale-distro:
     url: https://github.com/Freescale/meta-freescale-distro.git
-    commit: d5bbb487b2816dfc74984a78b67f7361ce404253
+    branch: kirkstone
 
   meta-mender-community:
     layers:

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -4,11 +4,11 @@ header:
 repos:
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: d7544f35756d87834e8b4bf3e3e733c771d380ae
+    branch: kirkstone
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins
-    commit: 66ceeebd047d7fdfc8668b300319a76da8ae257d
+    branch: kirkstone
     patches:
       0001-uboot-lts-kirkstone:
         repo: meta-mender-community

--- a/kas/include/rockchip.yml
+++ b/kas/include/rockchip.yml
@@ -4,13 +4,13 @@ header:
 repos:
   meta-arm:
     url: git://git.yoctoproject.org/meta-arm.git
-    commit: bf98ef902e6e7042e46a69fb2df6c68d00de2764
+    branch: kirkstone
     layers:
       meta-arm:
       meta-arm-toolchain:
   meta-rockchip:
     url: git://git.yoctoproject.org/meta-rockchip.git
-    commit: 1f5e7b10eef4e4906daee7e7f03211823f832ce7
+    branch: kirkstone
 
   meta-mender-community:
     layers:

--- a/kas/include/st.yml
+++ b/kas/include/st.yml
@@ -5,7 +5,7 @@ repos:
   # needs a specific version due to versioned overrides, like gstreamer
   openembedded-core:
     url: http://git.openembedded.org/openembedded-core
-    commit: f09fca692f96c9c428e89c5ef53fbcb92ac0c9bf
+    branch: kirkstone
   meta-openembedded:
     layers:
       meta-python:
@@ -18,19 +18,19 @@ repos:
       meta-perl:
   meta-qt5:
     url: https://github.com/meta-qt5/meta-qt5
-    commit: 644ebf220245bdc06e7696ccc90acc97a0dd2566
+    branch: kirkstone
   meta-st-openstlinux:
     url: https://github.com/STMicroelectronics/meta-st-openstlinux
-    commit: 644ebf220245bdc06e7696ccc90acc97a0dd2566
+    branch: kirkstone
   meta-st-stm32mp:
     url: https://github.com/STMicroelectronics/meta-st-stm32mp
-    commit: 2abadb39d040b3c1c452664e33b7b365516b372d
+    branch: kirkstone
   meta-st-stm32mp-addons:
     url: https://github.com/STMicroelectronics/meta-st-stm32mp-addons
-    commit: f1a18b73343afd8dd5f9aa7f5b605d139fb9e4a8
+    branch: kirkstone
   meta-st-scripts:
     url: https://github.com/STMicroelectronics/meta-st-scripts
-    commit: 69e10d187debb1d4136af1c454b3dffd994c3de7
+    branch: kirkstone
     layers:
       bitbake: excluded
 

--- a/kas/include/tegra-jetpack4.yml
+++ b/kas/include/tegra-jetpack4.yml
@@ -5,19 +5,16 @@ header:
 
 repos:
   meta-tegra:
-    #branch: kirkstone-l4t-r32.7.x
-    commit: 928ba1b5fd3a49c511a29fe2e00de971675e42d5
+    branch: kirkstone-l4t-r32.7.x
     layers:
       .:
       contrib:
   meta-tegra-community:
-    #branch: kirkstone-l4t-r32.7.x
-    commit: 8f2e68383378f8a57437e4832f6b6de5be139b2b
+    branch: kirkstone-l4t-r32.7.x
   meta-tegrademo:
-    #branch: kirkstone-l4t-r32.7.x
-    commit: f7618854c9fc23e1c8f4150c8c36dbe5d5b56531
+    branch: kirkstone-l4t-r32.7.x
   meta-virtualization:
-    commit: 02a6c00d9370992a54296633de26a13a9a08ca2a
+    branch: kirkstone
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack5.yml
+++ b/kas/include/tegra-jetpack5.yml
@@ -5,17 +5,14 @@ header:
 
 repos:
   meta-tegra:
-    #branch: kirkstone
-    commit: 67ec5c4c1924eb34745c00ee1b9c48335d3b6964
+    branch: kirkstone
   meta-tegra-community:
-    #branch: kirkstone
-    commit: 298939d20c30ba76f1db6357e47d2b64abdbc9e2
+    branch: kirkstone
   meta-tegrademo:
-    #branch: kirkstone
-    commit: 98181a0a4e24b961c586a0ed81005543ce9e13fe
+    branch: kirkstone
 
   meta-virtualization:
-    commit: 02a6c00d9370992a54296633de26a13a9a08ca2a
+    branch: kirkstone
 
   meta-mender-community:
     layers:

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -4,12 +4,12 @@ header:
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
-    commit: bf98ef902e6e7042e46a69fb2df6c68d00de2764
+    branch: kirkstone
     layers:
       meta-arm:
       meta-arm-toolchain:
   meta-ti:
     url: https://git.yoctoproject.org/meta-ti
-    commit: 1a4575bf209e420a477e095bf2a5113f39229906
+    branch: kirkstone
     layers:
       meta-ti-bsp:

--- a/kas/include/toradex.yml
+++ b/kas/include/toradex.yml
@@ -12,23 +12,19 @@ repos:
       meta-filesystems:
   meta-qt5:
     url: https://github.com/meta-qt5/meta-qt5
-    commit: 644ebf220245bdc06e7696ccc90acc97a0dd2566
+    branch: kirkstone
   meta-toradex-distro:
     url: https://git.toradex.com/meta-toradex-distro.git
-    #branch: kirkstone-6.x.y
-    commit: b63547f3772ea9d0f8f83bc24238005d621966f5
+    branch: kirkstone-6.x.y
   meta-toradex-bsp-common:
     url: https://git.toradex.com/meta-toradex-bsp-common.git
-    #branch: kirkstone-6.x.y
-    commit: 95d58eee6e1ba025c3ab84285bd11222889a41a4
+    branch: kirkstone-6.x.y
   meta-toradex-nxp:
     url: https://git.toradex.com/meta-toradex-nxp.git
-    #branch: kirkstone-6.x.y
-    commit: 163c71393949f241ce60e3e0e0b474fa3eee1ddc
+    branch: kirkstone-6.x.y
   meta-toradex-demos:
     url: https://git.toradex.com/meta-toradex-demos.git
-    #branch: kirkstone-6.x.y
-    commit: ad72d14becf6b54c1c76864eb691a369307672fa
+    branch: kirkstone-6.x.y
 
   meta-mender-community:
     layers:

--- a/kas/include/variscite.yml
+++ b/kas/include/variscite.yml
@@ -10,7 +10,7 @@ repos:
       meta-filesystems:
   meta-variscite-bsp:
     url: https://github.com/varigit/meta-variscite-bsp
-    commit: 4a0f976941c575fe10241380b3e84e6dc6665dd4
+    branch: kirkstone
   meta-mender-community:
     layers:
       meta-mender-variscite:

--- a/kas/intel-corei7-64.yml
+++ b/kas/intel-corei7-64.yml
@@ -6,7 +6,7 @@ header:
 repos:
   meta-intel:
     url: https://git.yoctoproject.org/meta-intel
-    commit: 1aacdb4ed1e639cc6e19c541b058264eb17eb093
+    branch: kirkstone
 
 local_conf_header:
   intel-corei7-64: |

--- a/kas/jetson-agx-orin-devkit.yml
+++ b/kas/jetson-agx-orin-devkit.yml
@@ -8,7 +8,7 @@ machine: jetson-agx-orin-devkit
 
 repos:
   meta-tegra:
-    commit: eb2bcfbfca44d100205c2d865a1ab5add1c4f264
+    branch: kirkstone
 
 local_conf_header:
   AB-upgrades: |

--- a/kas/jetson-agx-xavier-devkit.yml
+++ b/kas/jetson-agx-xavier-devkit.yml
@@ -8,7 +8,7 @@ machine: jetson-agx-xavier-devkit
 
 repos:
   meta-tegra:
-    commit: eb2bcfbfca44d100205c2d865a1ab5add1c4f264
+    branch: kirkstone
 
 local_conf_header:
   AB-upgrades: |

--- a/kas/jetson-orin-nano-devkit.yml
+++ b/kas/jetson-orin-nano-devkit.yml
@@ -7,7 +7,7 @@ header:
 machine: jetson-orin-nano-devkit
 repos:
   meta-tegra:
-    commit: b7a0792b996b47305c7ec1713621b0e07d314700
+    branch: kirkstone
 
 local_conf_header:
   AB-upgrades: |

--- a/kas/qemuarm64.yml
+++ b/kas/qemuarm64.yml
@@ -16,7 +16,7 @@ repos:
 
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
-    commit: bf98ef902e6e7042e46a69fb2df6c68d00de2764
+    branch: kirkstone
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/reterminal.yml
+++ b/kas/reterminal.yml
@@ -7,7 +7,7 @@ header:
 repos:
   meta-seeed-cm4:
     url: https://github.com/theyoctojester/meta-seeed-cm4.git
-    commit: kirkstone
+    branch: kirkstone
 
   meta-openembedded:
     layers:

--- a/kas/x86-virtual.yml
+++ b/kas/x86-virtual.yml
@@ -6,7 +6,7 @@ header:
 repos:
   meta-intel:
     url: https://git.yoctoproject.org/meta-intel
-    commit: 1abc8ef0fc11041e2ff18989dce5b99214ee89ed
+    branch: kirkstone
 
 local_conf_header:
   x86-virtual: |


### PR DESCRIPTION
This branch is meant to test building with the latest upstream state of the kirkstone release branch(es). Adjust the kas files accordingly.