### PR TITLE
kas: replace beagleplay by beagleplay-ti

### DIFF
--- a/kas/beagleplay-ti.yml
+++ b/kas/beagleplay-ti.yml
@@ -5,7 +5,7 @@ header:
   - kas/include/arm.yml
   - kas/include/ti.yml
 
-machine: beagleplay
+machine: beagleplay-ti
 
 local_conf_header:
   beagleplay: |


### PR DESCRIPTION
The "beagleplay" machine has been replaced by "beagleplay-ti" in meta-ti.
kas/beagleplay.yml fails to build anyway.