### PR TITLE
tegra: Detect powerloss during update using boot_attempt flag

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.sh
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-redundant-boot/nv_update_verifier.sh
@@ -1,9 +1,25 @@
 #!/bin/sh
 
+boot_flag="/var/lib/mender/boot_attempted"
+current_slot=$(/usr/sbin/nvbootctrl get-current-slot)
 upgrade_available=$(/sbin/fw_printenv upgrade_available | cut -d "=" -f2)
 
 # Only verify booted slot if we are not in an upgrade process
 # since mender will do that on commit (through fw_setenv)
 if [ "$upgrade_available" = "0" ]; then
 	/usr/sbin/nvbootctrl verify
+	if [ -f $boot_flag ]; then
+		rm $boot_flag
+	fi
+	exit 0
 fi
+
+if [ -f $boot_flag ]; then
+	prev_boot_attempt="$(cat $boot_flag)"
+	rm $boot_flag
+	if [ "$prev_boot_attempt" = "$current_slot" ]; then
+		systemctl reboot -f
+		exit 1
+	fi 
+fi
+echo $current_slot > $boot_flag

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/verify-slot
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/verify-slot
@@ -1,3 +1,6 @@
 #!/bin/sh
 
+boot_flag="/var/lib/mender/boot_attempted"
+
 /usr/sbin/nvbootctrl verify
+rm $boot_flag || true


### PR DESCRIPTION
On tegra devices the update capsule process does not catch powerlosses turing boot of the new rootfs and simply keeps on trying to boot it. Since rerunning several state scripts (e.g. Reboot_Leave -> Reboot_Leave) we could end up in an undefined state.   
To mitigate this `nv_update_verifier` now remembers if we already tried booting the current rootfs in an upgrade process and aborts/reboots if necessary.  
Note that this does not catch power losses that happen before the `nv_update_verifier` service starts and by that extend also does not catch power losses before systemd starts.