### PR TITLE
kas: demos: fix qemuarm64-clientonly

### DIFF
--- a/kas/demos/qemuarm64-client-only.yml
+++ b/kas/demos/qemuarm64-client-only.yml
@@ -25,5 +25,7 @@ local_conf_header:
     MENDER_INVENTORY_POLL_INTERVAL_SECONDS = "5"
     MENDER_RETRY_POLL_INTERVAL_SECONDS = "30"
     IMAGE_INSTALL:append = "mender-auth mender-update mender-connect"
+    # quickfix: adding mender-systemd to fix packaging of mender-connect
+    DISTROOVERRIDES:append = ":mender-systemd"
 
 machine: qemuarm64


### PR DESCRIPTION
Packaging mender-connect depends on the mender-systemd overrride being set. Without mender-full being inherited in the build, this is not populated into DISTROOVERRIDES.

As a quick fix, add it via local.conf.