### PR TITLE
Tegra fw scripts fix up

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -3,15 +3,15 @@ set -e
 LABELCHARS="AB"
 
 get_bootpart() {
-    local current_slot=$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)
-    if [ -z "${current_slot}" ]; then
+    _current_slot=$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)
+    if [ -z "${_current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"
         return
     fi
-    local cfglbl="\"RootfsPart${LABELCHARS:${current_slot}:1}\""
-    local devnam=$(grep -h "${cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')
-    echo "${devnam}"
+    _cfglbl="\"RootfsPart${LABELCHARS:${_current_slot}:1}\""
+    _devnam=$(grep -h "${_cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')
+    echo "${_devnam}"
 }
 
 quiet=

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -3,14 +3,14 @@ set -e
 LABELCHARS="AB"
 
 get_bootpart() {
-    local current_slot=`nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null`
+    local current_slot=$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)
     if [ -z "${current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"
         return
     fi
     local cfglbl="\"RootfsPart${LABELCHARS:${current_slot}:1}\""
-    local devnam=`grep -h "${cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$'`
+    local devnam=$(grep -h "${cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')
     echo "${devnam}"
 }
 
@@ -25,7 +25,7 @@ if [ "${1}" = "-n" ]; then
 fi
 
 if [ -z "$1" ]; then
-    bootpart=`get_bootpart`
+    bootpart=$(get_bootpart)
     echo "mender_boot_part=${bootpart}"
     exit 0
 fi
@@ -33,13 +33,13 @@ fi
 while [ -n "${1}" ]; do
     case "${1}" in
         mender_boot_part)
-            bootpart=`get_bootpart`
+            bootpart=$(get_bootpart)
             [ -n "${quiet}" ] || echo -n "$1="
             echo "${bootpart}"
             ;;
         mender_boot_part_hex)
-            bootpart=`get_bootpart`
-            bootpart_hex=`echo 16o${bootpart}p | dc`
+            bootpart=$(get_bootpart)
+            bootpart_hex=$(echo 16o${bootpart}p | dc)
             [ -n "${quiet}" ] || echo -n "${1}="
             echo "${bootpart_hex}"
             ;;

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -3,7 +3,18 @@ set -e
 
 get_bootpart() {
     _cfglbl='"RootfsPartA"'
-    _current_slot="$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)"
+    _current_slot_cmd="nvbootctrl get-current-slot 2>/dev/null"
+    _check=$(command -v nvbootctrl 2>/dev/null || true)
+    if [ -z "${_check}" ]; then
+        _check=$(command -v tegra-boot-control 2>/dev/null || true)
+        if [ -z "${_check}" ]; then
+            echo "ERR: Neither nvbootctrl nor tegra-boot-control were found!"
+            exit 1
+        fi
+        _current_slot_cmd="tegra-boot-control --current-slot 2>/dev/null"
+    fi
+
+    _current_slot="$(${_current_slot_cmd})"
     if [ -z "${_current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -34,21 +34,21 @@ while [ -n "${1}" ]; do
     case "${1}" in
         mender_boot_part)
             bootpart=$(get_bootpart)
-            [ -n "${quiet}" ] || echo -n "$1="
+            [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "${bootpart}"
             ;;
         mender_boot_part_hex)
             bootpart=$(get_bootpart)
             bootpart_hex=$(echo 16o${bootpart}p | dc)
-            [ -n "${quiet}" ] || echo -n "${1}="
+            [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "${bootpart_hex}"
             ;;
         mender_uboot_separator)
-            [ -n "${quiet}" ] || echo -n "${1}="
+            [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "something other than just 1"
             ;;
         upgrade_available)
-            [ -n "${quiet}" ] || echo -n "${1}="
+            [ -n "${quiet}" ] || printf "%s=" "${1}"
             if [ -e "/var/lib/mender/upgrade_available" ]; then
                 echo "1"
             else
@@ -56,7 +56,7 @@ while [ -n "${1}" ]; do
             fi
             ;;
         mender_check_saveenv_canary)
-            [ -n "${quiet}" ] || echo -n "${1}="
+            [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "0"
             ;;
         *)

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -4,9 +4,9 @@ LABELCHARS="AB"
 get_bootpart() {
     local current_slot=`nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null`
     if [ -z "$current_slot" ]; then
-	echo "ERR: could not identify current boot slot" >&2
-	echo "UNKNOWN"
-	return
+        echo "ERR: could not identify current boot slot" >&2
+        echo "UNKNOWN"
+        return
     fi
     local cfglbl="\"RootfsPart${LABELCHARS:$current_slot:1}\""
     local devnam=`grep -h "$cfglbl:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$'`
@@ -22,11 +22,13 @@ if [ "$1" = "-n" ]; then
         exit 1
     fi
 fi
+
 if [ -z "$1" ]; then
     bootpart=`get_bootpart`
     echo "mender_boot_part=$bootpart"
     exit 0
 fi
+
 while [ -n "$1" ]; do
     case "$1" in
         mender_boot_part)

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -1,15 +1,19 @@
 #!/bin/sh
 set -e
-LABELCHARS="AB"
 
 get_bootpart() {
+    _cfglbl='"RootfsPartA"'
     _current_slot="$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)"
     if [ -z "${_current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"
         return
     fi
-    _cfglbl="\"RootfsPart${LABELCHARS:${_current_slot}:1}\""
+
+    if [ "${_current_slot}" = "1" ]; then
+        _cfglbl='"RootfsPartB"'
+    fi
+
     _devnam="$(grep -h "${_cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')"
     echo "${_devnam}"
 }

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -3,14 +3,14 @@ set -e
 LABELCHARS="AB"
 
 get_bootpart() {
-    _current_slot=$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)
+    _current_slot="$(nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null)"
     if [ -z "${_current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"
         return
     fi
     _cfglbl="\"RootfsPart${LABELCHARS:${_current_slot}:1}\""
-    _devnam=$(grep -h "${_cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')
+    _devnam="$(grep -h "${_cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')"
     echo "${_devnam}"
 }
 
@@ -25,7 +25,7 @@ if [ "${1}" = "-n" ]; then
 fi
 
 if [ -z "$1" ]; then
-    bootpart=$(get_bootpart)
+    bootpart="$(get_bootpart)"
     echo "mender_boot_part=${bootpart}"
     exit 0
 fi
@@ -33,13 +33,13 @@ fi
 while [ -n "${1}" ]; do
     case "${1}" in
         mender_boot_part)
-            bootpart=$(get_bootpart)
+            bootpart="$(get_bootpart)"
             [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "${bootpart}"
             ;;
         mender_boot_part_hex)
-            bootpart=$(get_bootpart)
-            bootpart_hex=$(echo 16o${bootpart}p | dc)
+            bootpart="$(get_bootpart)"
+            bootpart_hex="$(echo "16o${bootpart}p" | dc)"
             [ -n "${quiet}" ] || printf "%s=" "${1}"
             echo "${bootpart_hex}"
             ;;

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -4,21 +4,21 @@ LABELCHARS="AB"
 
 get_bootpart() {
     local current_slot=`nvbootctrl get-current-slot 2>/dev/null || tegra-boot-control --current-slot 2>/dev/null`
-    if [ -z "$current_slot" ]; then
+    if [ -z "${current_slot}" ]; then
         echo "ERR: could not identify current boot slot" >&2
         echo "UNKNOWN"
         return
     fi
-    local cfglbl="\"RootfsPart${LABELCHARS:$current_slot:1}\""
-    local devnam=`grep -h "$cfglbl:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$'`
-    echo "$devnam"
+    local cfglbl="\"RootfsPart${LABELCHARS:${current_slot}:1}\""
+    local devnam=`grep -h "${cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$'`
+    echo "${devnam}"
 }
 
 quiet=
-if [ "$1" = "-n" ]; then
+if [ "${1}" = "-n" ]; then
     quiet="yes"
     shift
-    if [ -z "$1" ]; then
+    if [ -z "${1}" ]; then
         echo "ERR: missing var name with -n" >&2
         exit 1
     fi
@@ -26,29 +26,29 @@ fi
 
 if [ -z "$1" ]; then
     bootpart=`get_bootpart`
-    echo "mender_boot_part=$bootpart"
+    echo "mender_boot_part=${bootpart}"
     exit 0
 fi
 
-while [ -n "$1" ]; do
-    case "$1" in
+while [ -n "${1}" ]; do
+    case "${1}" in
         mender_boot_part)
             bootpart=`get_bootpart`
-            [ -n "$quiet" ] || echo -n "$1="
-            echo "$bootpart"
+            [ -n "${quiet}" ] || echo -n "$1="
+            echo "${bootpart}"
             ;;
         mender_boot_part_hex)
             bootpart=`get_bootpart`
             bootpart_hex=`echo 16o${bootpart}p | dc`
-            [ -n "$quiet" ] || echo -n "$1="
-            echo "$bootpart_hex"
+            [ -n "${quiet}" ] || echo -n "${1}="
+            echo "${bootpart_hex}"
             ;;
         mender_uboot_separator)
-            [ -n "$quiet" ] || echo -n "$1="
+            [ -n "${quiet}" ] || echo -n "${1}="
             echo "something other than just 1"
             ;;
         upgrade_available)
-            [ -n "$quiet" ] || echo -n "$1="
+            [ -n "${quiet}" ] || echo -n "${1}="
             if [ -e "/var/lib/mender/upgrade_available" ]; then
                 echo "1"
             else
@@ -56,11 +56,11 @@ while [ -n "$1" ]; do
             fi
             ;;
         mender_check_saveenv_canary)
-            [ -n "$quiet" ] || echo -n "$1="
+            [ -n "${quiet}" ] || echo -n "${1}="
             echo "0"
             ;;
         *)
-           echo "ERR: no such variable: $1" >&2
+           echo "ERR: no such variable: ${1}" >&2
            exit 1
     esac
     shift

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -25,7 +25,10 @@ get_bootpart() {
         _cfglbl='"RootfsPartB"'
     fi
 
-    _devnam="$(grep -h "${_cfglbl}:" /etc/mender/mender.conf /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')"
+    _devnam="$(grep -h "${_cfglbl}:" /etc/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')"
+    if [ -z "${_devnam}" ]; then
+      _devnam="$(grep -h "${_cfglbl}:" /var/lib/mender/mender.conf | tr -d '" ,' | grep -o '[0-9]\+$')"
+    fi
     echo "${_devnam}"
 }
 

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_printenv
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 LABELCHARS="AB"
 
 get_bootpart() {

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
@@ -2,7 +2,7 @@
 set -e
 
 if [ "${1}" = "-s" ]; then
-    while IFS="= " read var restofline; do
+    while IFS="= " read -r var restofline; do
         if [ "${var}" = "upgrade_available" ]; then
             if [ "${restofline}" = "1" ]; then
                 touch /var/lib/mender/upgrade_available

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -e
+
 if [ "$1" = "-s" ]; then
     while IFS="= " read var restofline; do
         if [ "$var" = "upgrade_available" ]; then

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
@@ -1,18 +1,18 @@
 #!/bin/sh
 set -e
 
-if [ "$1" = "-s" ]; then
+if [ "${1}" = "-s" ]; then
     while IFS="= " read var restofline; do
-        if [ "$var" = "upgrade_available" ]; then
-            if [ "$restofline" = "1" ]; then
+        if [ "${var}" = "upgrade_available" ]; then
+            if [ "${restofline}" = "1" ]; then
                 touch /var/lib/mender/upgrade_available
             else
                 rm -f /var/lib/mender/upgrade_available
             fi
         fi
     done
-elif [ "$1" = "upgrade_available" ]; then
-    if [ "$2" = "1" ]; then
+elif [ "${1}" = "upgrade_available" ]; then
+    if [ "${2}" = "1" ]; then
         touch /var/lib/mender/upgrade_available
     else
         rm -f /var/lib/mender/upgrade_available

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/u-boot/libubootenv-fake/fw_setenv
@@ -1,13 +1,13 @@
 #!/bin/sh
 if [ "$1" = "-s" ]; then
     while IFS="= " read var restofline; do
-	if [ "$var" = "upgrade_available" ]; then
-	    if [ "$restofline" = "1" ]; then
-		touch /var/lib/mender/upgrade_available
-	    else
-		rm -f /var/lib/mender/upgrade_available
-	    fi
-	fi
+        if [ "$var" = "upgrade_available" ]; then
+            if [ "$restofline" = "1" ]; then
+                touch /var/lib/mender/upgrade_available
+            else
+                rm -f /var/lib/mender/upgrade_available
+            fi
+        fi
     done
 elif [ "$1" = "upgrade_available" ]; then
     if [ "$2" = "1" ]; then


### PR DESCRIPTION
Fix up the fw_setenv and fw_printenv scripts.

  - Fix all shellcheck warnings.
  - Rewrite some logic in fw_printenv surrounding devname parsing.