### PR TITLE
kas: fix qemuarm64-bootloader-validation

### DIFF
--- a/kas/demos/qemuarm64-bootloader-validation.yml
+++ b/kas/demos/qemuarm64-bootloader-validation.yml
@@ -4,11 +4,6 @@ header:
   - kas/qemuarm64.yml
 
 repos:
-  meta-mender:
-    # note: this is the first commit to support the
-    # "mender-prepopulate-inactive-partition"
-    commit: 3d6099368742f1a461fb0aa14eccd2284c98f3b2
-
   meta-mender-community:
     layers:
       meta-mender-validation:


### PR DESCRIPTION
The bootloader validation script requires the
"mender-prepopulate-inactive-partition" feature to be present for A/B switch testing. As this feature was not available in upstream meta-mender on the scarthgap branch yet, the revision was pinned.

This led to build breakage after version bumps, and can be removed as not necessary anymore.