### PR TITLE
meta-mender-tegra: clean up state scripts

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
+set -e
 
 CAPTARGET="/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"
 
-if [ -f "$CAPTARGET" ]; then
-    rm "$CAPTARGET"
+if [ -f "${CAPTARGET}" ]; then
+    rm "${CAPTARGET}"
 fi

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -1,46 +1,56 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
+
 echo "$(mender-update show-artifact): $(basename "$0") was called!" >&2
 
 get_bootpart() {
-	local current_slot=`nvbootctrl get-current-slot 2>/dev/null`
-	if [ -z "$current_slot" ]; then
-    		echo "ERR: could not identify current boot slot" >&2
-    		echo "UNKNOWN"
-    		return
-    	fi
-	echo "$current_slot"
+    _current_slot_cmd="nvbootctrl get-current-slot 2>/dev/null"
+    _check=$(command -v nvbootctrl 2>/dev/null || true)
+    if [ -z "${_check}" ]; then
+        _check=$(command -v tegra-boot-control 2>/dev/null || true)
+        if [ -z "${_check}" ]; then
+            echo "ERR: Neither nvbootctrl nor tegra-boot-control where found!"
+            exit 1
+        fi
+        _current_slot_cmd="tegra-boot-control --current-slot 2>/dev/null"
+    fi
+
+    _current_slot="$(${_current_slot_cmd})"
+    if [ -z "${_current_slot}" ]; then
+            echo "ERR: could not identify current boot slot" >&2
+            echo "UNKNOWN"
+            return
+        fi
+    echo "${_current_slot}"
 }
 
 reset_unbootable_status() {
-	source /usr/bin/uefi_common.func
-
-	local AB="AB"
-	local slot="Slot${AB:$1:1}"
-	local value="\x00\x00\x00\x00"
-	set_efi_var "RootfsStatus${slot}" "781e084c-a330-417c-b678-38e696380cb9" "$value"
+    . /usr/bin/uefi_common.func
+    _slot="SlotA"
+    if [ "${1}" = "1" ]; then
+        _slot="SlotB"
+    fi
+    _value="\x00\x00\x00\x00"
+    set_efi_var "RootfsStatus${_slot}" "781e084c-a330-417c-b678-38e696380cb9" "${_value}"
 }
 
-current_slot=`get_bootpart`
-echo "current_slot=$current_slot" >&2
+current_slot="$(get_bootpart)"
+echo "current_slot=${current_slot}" >&2
 
-next_slot=
-next_rootfs_dev=
-if [ $current_slot = "0" ]; then
-	next_slot="1"
-	next_rootfs_dev="/dev/disk/by-partlabel/APP_b"
-else
-	next_slot="0"
-	next_rootfs_dev="/dev/disk/by-partlabel/APP"
+next_slot="0"
+next_rootfs_dev="/dev/disk/by-partlabel/APP"
+if [ "${current_slot}" = "0" ]; then
+    next_slot="1"
+    next_rootfs_dev="/dev/disk/by-partlabel/APP_b"
 fi
 
-tmp_mount=`mktemp -d`
+tmp_mount="$(mktemp -d)"
 
-reset_unbootable_status $next_slot
+reset_unbootable_status "${next_slot}"
 mkdir -p /boot/efi/EFI/UpdateCapsule
-mount -o ro $next_rootfs_dev $tmp_mount
-cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap
-umount $tmp_mount
+mount -o ro "${next_rootfs_dev}" "${tmp_mount}"
+cp "${tmp_mount}"/opt/nvidia/UpdateCapsule/tegra-bl.cap /boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap
+umount "${tmp_mount}"
 oe4t-set-uefi-OSIndications
 
 exit 0

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/verify-slot
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/verify-slot
@@ -1,6 +1,9 @@
-#!/bin/sh
+#!/usr/bin/env sh
+set -e
 
 boot_flag="/var/lib/mender/boot_attempted"
-
 /usr/sbin/nvbootctrl verify
-rm $boot_flag || true
+
+if [ -f "${boot_flag}" ]; then
+  rm ${boot_flag}
+fi


### PR DESCRIPTION
Much like the fw_printenv and fw_setenv cleanup, this pull request cleans up the state scripts in much the same way.

  - Remove all shellcheck warnings.
  - Do not rely on bash for abort-blupdate
  - Add set -e
  - Work with both nvbootctrl and tegra-boot-control