### PR TITLE
add explicit WIC demo

### DIFF
--- a/kas/demos/meta-mender-explicit-wic/LICENSE
+++ b/kas/demos/meta-mender-explicit-wic/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/kas/demos/meta-mender-explicit-wic/README
+++ b/kas/demos/meta-mender-explicit-wic/README
@@ -1,0 +1,101 @@
+This README file contains information on the contents of the meta-mender-explicit-wic layer.
+
+Please see the corresponding sections below for details.
+
+Dependencies
+============
+
+This layer depends on:
+
+  URI: git://git.yoctoproject.org/poky
+  layers: meta, meta-poky, meta-yocto-bsp
+  branch: scarthgap
+
+  URI: git://git.openembedded.org/meta-openembedded
+  layers: meta-oe
+  branch: scarthgap
+
+  URI: https://github.com/mendersoftware/meta-mender.git
+  layers: meta-mender-core
+  branch: scarthgap
+
+  URI: https://github.com/agherzan/meta-raspberrypi.git
+  branch: scarthgap
+
+Contributions
+=============
+
+Please the README file in the top level directory.
+
+Maintainer: Josef Holzmayr <jester@theyoctojester.info>
+
+Table of Contents
+=================
+
+  I. Adding the meta-mender-explicit-wic layer to your build
+ II. Layer Overview and Purpose
+III. WIC Files and Partition Layout
+ IV. Usage Instructions
+  V. Technical Implementation
+ VI. Customization Guide
+
+
+I. Adding the meta-mender-explicit-wic layer to your build
+==========================================================
+
+This layer is typically used as part of kas configurations. See section IV for usage examples.
+
+For manual integration:
+Run 'bitbake-layers add-layer meta-mender-explicit-wic'
+
+II. Layer Overview and Purpose
+==============================
+
+This demo layer demonstrates explicit WIC partitioning for Mender A/B updates
+as an alternative to Mender's dynamic image generation.
+
+The implementation generates both WIC disk images and .mender artifacts from
+the same build using standard Yocto mechanisms.
+
+III. WIC Files and Partition Layout
+====================================
+
+WIC Files Provided:
+- mender-explicit-raspberrypi4-64.wks - Standard configuration with empty Root B (better compression)
+- mender-explicit-raspberrypi4-64-dual-root.wks - Testing configuration with both roots populated
+
+Partition Layout:
+Both WIC files create the standard Mender 5-partition layout optimized for Raspberry Pi 4:
+
+1. U-Boot environment (8KB, no partition table entry) - A/B boot logic and state
+2. Boot partition (100MB, FAT32, bootable) - Kernel, device tree, U-Boot files  
+3. Root filesystem A (512MB, ext4, active) - Always populated with rootfs
+4. Root filesystem B (512MB, ext4, inactive) - Empty (standard) or populated (dual-root)
+5. Data partition (128MB, ext4, persistent) - Populated with /data contents
+
+Build Outputs:
+Each build generates:
+- WIC disk image (~1.4GB) - For SD card flashing and hardware deployment
+- .mender artifact (~53MB) - For OTA updates via Mender server
+
+IV. Usage Instructions
+======================
+
+Standard Build:
+kas build kas/demos/raspberrypi4-64-mender-explicit-wic.yml
+
+For dual-root testing (both partitions populated), override the WKS file:
+WKS_FILE=mender-explicit-raspberrypi4-64-dual-root.wks kas build kas/demos/raspberrypi4-64-mender-explicit-wic.yml
+
+V. Technical Implementation
+===========================
+
+The layer implements custom IMAGE_CMD:mender for .mender artifact generation
+without using mender-image features, and uses --change-directory=data in the
+WKS file to populate the data partition from rootfs /data contents.
+
+VI. Customization Guide
+=======================
+
+To adapt for other machines, create machine-specific WKS files in the wic/
+directory. Root A and B partitions must be equal size for Mender A/B updates.

--- a/kas/demos/meta-mender-explicit-wic/README
+++ b/kas/demos/meta-mender-explicit-wic/README
@@ -54,7 +54,7 @@ II. Layer Overview and Purpose
 This demo layer demonstrates explicit WIC partitioning for Mender A/B updates
 as an alternative to Mender's dynamic image generation.
 
-The implementation generates both WIC disk images and .mender artifacts from
+The implementation generates both WIC disk images and .mender Artifacts from
 the same build using standard Yocto mechanisms.
 
 III. WIC Files and Partition Layout
@@ -76,7 +76,7 @@ Both WIC files create the standard Mender 5-partition layout optimized for Raspb
 Build Outputs:
 Each build generates:
 - WIC disk image (~1.4GB) - For SD card flashing and hardware deployment
-- .mender artifact (~53MB) - For OTA updates via Mender server
+- .mender Artifact (~53MB) - For OTA updates via Mender server
 
 IV. Usage Instructions
 ======================
@@ -90,7 +90,7 @@ WKS_FILE=mender-explicit-raspberrypi4-64-dual-root.wks kas build kas/demos/raspb
 V. Technical Implementation
 ===========================
 
-The layer implements custom IMAGE_CMD:mender for .mender artifact generation
+The layer implements custom IMAGE_CMD:mender for .mender Artifact generation
 without using mender-image features, and uses --change-directory=data in the
 WKS file to populate the data partition from rootfs /data contents.
 

--- a/kas/demos/meta-mender-explicit-wic/classes/mender-explicit-wic.bbclass
+++ b/kas/demos/meta-mender-explicit-wic/classes/mender-explicit-wic.bbclass
@@ -1,6 +1,6 @@
 # Custom class to demonstrate explicit WIC partitioning while keeping Mender A/B functionality
 # This replaces Mender's dynamic image generation with explicit WKS files and adds
-# .mender artifact generation for OTA updates
+# .mender Artifact generation for OTA updates
 
 # Inherit essential Mender functionality but NOT image generation classes
 inherit mender-setup mender-systemd mender-uboot
@@ -31,7 +31,7 @@ ARTIFACTIMG_FSTYPE ?= "ext4"
 # Ensure U-Boot environment is created
 do_image_wic[depends] += "${@bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-uboot', 'u-boot:do_deploy', '', d)}"
 
-# Minimal implementation of Mender artifact generation
+# Minimal implementation of Mender Artifact generation
 # This creates .mender files without requiring mender-image feature
 IMAGE_CMD:mender() {
     # Validate required variables
@@ -59,8 +59,8 @@ IMAGE_CMD:mender() {
         DEVICE_TYPE_ARGS="${DEVICE_TYPE_ARGS} -t ${DEVICE_TYPE}"
     done
     
-    # Create the .mender artifact
-    bbnote "Creating Mender artifact: ${MENDER_ARTIFACT_NAME}"
+    # Create the .mender Artifact
+    bbnote "Creating Mender Artifact: ${MENDER_ARTIFACT_NAME}"
     mender-artifact write rootfs-image \
         --artifact-name ${MENDER_ARTIFACT_NAME} \
         ${DEVICE_TYPE_ARGS} \
@@ -75,7 +75,7 @@ IMAGE_CMD:mender() {
     fi
 }
 
-# Ensure mender artifact generation has proper dependencies
+# Ensure Mender Artifact generation has proper dependencies
 do_image_mender[depends] += " \
     mender-artifact-native:do_populate_sysroot \
     ${PN}:do_image_${ARTIFACTIMG_FSTYPE} \

--- a/kas/demos/meta-mender-explicit-wic/classes/mender-explicit-wic.bbclass
+++ b/kas/demos/meta-mender-explicit-wic/classes/mender-explicit-wic.bbclass
@@ -1,0 +1,82 @@
+# Custom class to demonstrate explicit WIC partitioning while keeping Mender A/B functionality
+# This replaces Mender's dynamic image generation with explicit WKS files and adds
+# .mender artifact generation for OTA updates
+
+# Inherit essential Mender functionality but NOT image generation classes
+inherit mender-setup mender-systemd mender-uboot
+
+# Enable only essential Mender features (no dynamic image generation)
+MENDER_FEATURES_ENABLE:append = " \
+    mender-uboot \
+    mender-auth-install \
+    mender-update-install \
+    mender-systemd \
+    mender-growfs-data \
+"
+
+# Explicitly disable dynamic partitioning features
+MENDER_FEATURES_DISABLE:append = " mender-image mender-part-images"
+
+# Use explicit WKS file instead of dynamic generation
+WKS_FILE = "mender-explicit-${MACHINE}.wks"
+WKS_SEARCH_PATH:prepend = "${LAYERDIR_meta-mender-explicit-wic}/wic:"
+
+# Image types: WIC for disk images, mender for OTA artifacts
+IMAGE_FSTYPES:append = " wic wic.bz2 mender"
+IMAGE_FSTYPES:remove = " bootimg dataimg sdimg"
+
+# Configure artifact generation
+ARTIFACTIMG_FSTYPE ?= "ext4"
+
+# Ensure U-Boot environment is created
+do_image_wic[depends] += "${@bb.utils.contains('MENDER_FEATURES_ENABLE', 'mender-uboot', 'u-boot:do_deploy', '', d)}"
+
+# Minimal implementation of Mender artifact generation
+# This creates .mender files without requiring mender-image feature
+IMAGE_CMD:mender() {
+    # Validate required variables
+    if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
+        bbfatal "MENDER_ARTIFACT_NAME not set. Please define it in your configuration."
+    fi
+    
+    if [ -z "${MENDER_DEVICE_TYPES_COMPATIBLE}" ]; then
+        bbfatal "MENDER_DEVICE_TYPES_COMPATIBLE not set. Please define it in your configuration."
+    fi
+    
+    # Input rootfs image
+    ROOTFS_IMG="${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${ARTIFACTIMG_FSTYPE}"
+    
+    if [ ! -f "${ROOTFS_IMG}" ]; then
+        bbfatal "Rootfs image ${ROOTFS_IMG} not found. Ensure ${ARTIFACTIMG_FSTYPE} is in IMAGE_FSTYPES."
+    fi
+    
+    # Output artifact
+    MENDER_ARTIFACT="${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender"
+    
+    # Build device type arguments
+    DEVICE_TYPE_ARGS=""
+    for DEVICE_TYPE in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
+        DEVICE_TYPE_ARGS="${DEVICE_TYPE_ARGS} -t ${DEVICE_TYPE}"
+    done
+    
+    # Create the .mender artifact
+    bbnote "Creating Mender artifact: ${MENDER_ARTIFACT_NAME}"
+    mender-artifact write rootfs-image \
+        --artifact-name ${MENDER_ARTIFACT_NAME} \
+        ${DEVICE_TYPE_ARGS} \
+        --file ${ROOTFS_IMG} \
+        --output-path ${MENDER_ARTIFACT} \
+        ${MENDER_ARTIFACT_EXTRA_ARGS}
+    
+    # Create symlink
+    if [ -n "${IMAGE_LINK_NAME}" ]; then
+        ln -sf ${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender \
+            ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mender
+    fi
+}
+
+# Ensure mender artifact generation has proper dependencies
+do_image_mender[depends] += " \
+    mender-artifact-native:do_populate_sysroot \
+    ${PN}:do_image_${ARTIFACTIMG_FSTYPE} \
+"

--- a/kas/demos/meta-mender-explicit-wic/conf/layer.conf
+++ b/kas/demos/meta-mender-explicit-wic/conf/layer.conf
@@ -1,0 +1,17 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-mender-explicit-wic"
+BBFILE_PATTERN_meta-mender-explicit-wic = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-mender-explicit-wic = "6"
+
+LAYERVERSION_meta-mender-explicit-wic = "1"
+LAYERDEPENDS_meta-mender-explicit-wic = "core"
+LAYERSERIES_COMPAT_meta-mender-explicit-wic = "scarthgap"
+
+# Variable to reference this layer directory in bbclass
+LAYERDIR_meta-mender-explicit-wic = "${LAYERDIR}"

--- a/kas/demos/meta-mender-explicit-wic/recipes-core/images/mender-explicit-demo-image.bb
+++ b/kas/demos/meta-mender-explicit-wic/recipes-core/images/mender-explicit-demo-image.bb
@@ -1,0 +1,42 @@
+SUMMARY = "Mender A/B demo image using explicit WIC partitioning"
+DESCRIPTION = "Demonstrates Mender A/B functionality with explicit WKS files instead of dynamic image generation"
+
+# Inherit from core-image-minimal and add our explicit WIC functionality
+inherit core-image mender-explicit-wic
+
+# Image configuration
+IMAGE_LINGUAS = " "
+LICENSE = "MIT"
+
+# Essential packages for Mender A/B functionality
+IMAGE_INSTALL = "\
+    packagegroup-core-boot \
+    ${CORE_IMAGE_EXTRA_INSTALL} \
+    mender-auth \
+    mender-update \
+    mender-configure \
+    mender-connect \
+    kernel-image \
+    kernel-devicetree \
+"
+
+# Remove incompatible packages
+IMAGE_INSTALL:remove = "packagegroup-core-device-devel"
+
+# Configure for A/B updates
+IMAGE_OVERHEAD_FACTOR = "1.3"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# Create /data directory structure in rootfs
+ROOTFS_POSTPROCESS_COMMAND += "create_mender_data_structure; "
+
+create_mender_data_structure() {
+    # Create basic /data directory structure that Mender expects
+    install -d ${IMAGE_ROOTFS}/data
+    install -d ${IMAGE_ROOTFS}/data/mender
+    install -d ${IMAGE_ROOTFS}/data/mender-configure
+    
+    # Add a demo file to show data persistence
+    echo "Mender explicit WIC demo - persistent data" > ${IMAGE_ROOTFS}/data/demo.txt
+    echo "Created: $(date)" >> ${IMAGE_ROOTFS}/data/demo.txt
+}

--- a/kas/demos/meta-mender-explicit-wic/wic/mender-explicit-raspberrypi4-64-dual-root.wks
+++ b/kas/demos/meta-mender-explicit-wic/wic/mender-explicit-raspberrypi4-64-dual-root.wks
@@ -1,0 +1,40 @@
+# short-description: Mender A/B partition layout using explicit WIC (dual-root configuration)
+# long-description: Creates the same 5-partition Mender A/B layout using explicit WKS
+# file with standard WIC sources instead of Mender's dynamic image generation.
+# Both root partitions are populated for immediate A/B testing (dual-root configuration).
+#
+# This demonstrates how to achieve identical Mender functionality using only
+# standard Yocto WIC mechanisms while maintaining full A/B update compatibility.
+#
+# Partition layout:
+# 1. U-Boot environment (8KB, no partition table entry)
+# 2. Boot partition (100MB, FAT32, bootable)
+# 3. Root filesystem A (512MB, ext4, active) - populated with rootfs
+# 4. Root filesystem B (512MB, ext4, inactive) - populated with rootfs (same as A)
+# 5. Data partition (128MB, ext4, persistent)
+
+# U-Boot environment partition (stored before partition table)
+# Contains A/B boot logic and state - essential for Mender updates
+part --source rawcopy --sourceparams="file=uboot.env" --ondisk mmcblk0 --align 8192 --no-table
+
+# Boot partition (100MB, FAT32, bootable)
+# Uses standard bootimg-partition source which merges IMAGE_BOOT_FILES with boot files from rootfs
+# This replicates exactly what mender-bootimg.bbclass would create
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8192 --size 100
+
+# Root filesystem A (512MB, ext4, active)
+# Standard rootfs source - this is the active root partition for booting
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 8192 --fixed-size 512M
+
+# Root filesystem B (512MB, ext4, inactive)
+# Also populated with rootfs content - same as Root A for immediate A/B testing
+# Mender client can immediately switch between partitions for testing
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 8192 --fixed-size 512M
+
+# Data partition (128MB, ext4, persistent)
+# Uses rootfs source with change-directory=data to populate with /data contents
+# This replicates what mender-dataimg.bbclass would create (minus bootstrap artifact)
+part /data --source rootfs --change-directory=data --ondisk mmcblk0 --fstype=ext4 --label data --align 8192 --size 128
+
+# Use MBR partition table (compatible with Raspberry Pi bootloader)
+bootloader --ptable msdos

--- a/kas/demos/meta-mender-explicit-wic/wic/mender-explicit-raspberrypi4-64.wks
+++ b/kas/demos/meta-mender-explicit-wic/wic/mender-explicit-raspberrypi4-64.wks
@@ -1,0 +1,40 @@
+# short-description: Mender A/B partition layout using explicit WIC (standard configuration)
+# long-description: Creates the same 5-partition Mender A/B layout using explicit WKS
+# file with standard WIC sources instead of Mender's dynamic image generation.
+# Root B partition is left empty for OTA updates (standard deployment configuration).
+#
+# This demonstrates how to achieve identical Mender functionality using only
+# standard Yocto WIC mechanisms while maintaining full A/B update compatibility.
+#
+# Partition layout:
+# 1. U-Boot environment (8KB, no partition table entry)
+# 2. Boot partition (100MB, FAT32, bootable)
+# 3. Root filesystem A (512MB, ext4, active) - populated with rootfs
+# 4. Root filesystem B (512MB, ext4, inactive) - empty for OTA updates
+# 5. Data partition (128MB, ext4, persistent)
+
+# U-Boot environment partition (stored before partition table)
+# Contains A/B boot logic and state - essential for Mender updates
+part --source rawcopy --sourceparams="file=uboot.env" --ondisk mmcblk0 --align 8192 --no-table
+
+# Boot partition (100MB, FAT32, bootable)
+# Uses standard bootimg-partition source which merges IMAGE_BOOT_FILES with boot files from rootfs
+# This replicates exactly what mender-bootimg.bbclass would create
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 8192 --size 100
+
+# Root filesystem A (512MB, ext4, active)
+# Standard rootfs source - this is the active root partition for booting
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 8192 --fixed-size 512M
+
+# Root filesystem B (512MB, ext4, inactive)
+# Empty partition with same size as Root A - used for A/B updates
+# Mender client will write new rootfs here during updates
+part --ondisk mmcblk0 --fstype=ext4 --label rootB --align 8192 --fixed-size 512M
+
+# Data partition (128MB, ext4, persistent)
+# Uses rootfs source with change-directory=data to populate with /data contents
+# This replicates what mender-dataimg.bbclass would create (minus bootstrap artifact)
+part /data --source rootfs --change-directory=data --ondisk mmcblk0 --fstype=ext4 --label data --align 8192 --size 128
+
+# Use MBR partition table (compatible with Raspberry Pi bootloader)
+bootloader --ptable msdos

--- a/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
+++ b/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
@@ -1,0 +1,84 @@
+header:
+  version: 14
+
+machine: raspberrypi4-64
+distro: poky
+
+repos:
+  poky:
+    url: git://git.yoctoproject.org/poky
+    commit: c162696dae5798e2ab1198403d0bc1d65d64068d
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: git://git.openembedded.org/meta-openembedded
+    commit: e92d0173a80ea7592c866618ef5293203c50544c
+    layers:
+      meta-oe:
+
+  meta-mender:
+    url: https://github.com/mendersoftware/meta-mender.git
+    commit: 0d393c2267a92091f975eb932338c07109f5f5fd
+    layers:
+      meta-mender-core:
+
+  meta-raspberrypi:
+    url: https://github.com/agherzan/meta-raspberrypi.git
+    commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+
+  meta-lts-mixins:
+    url: https://git.yoctoproject.org/meta-lts-mixins
+    commit: a44882db02a0ed0f149371831bfbe067665eb42b
+
+  meta-mender-community:
+    layers:
+      meta-mender-raspberrypi:
+      kas/demos/meta-mender-explicit-wic:
+
+local_conf_header:
+  base: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    INIT_MANAGER = "systemd"
+
+  mender-artifact: |
+    # Artifact configuration for OTA updates
+    MENDER_ARTIFACT_NAME = "explicit-wic"
+    MENDER_TENANT_TOKEN = ""
+    
+    # Ensure ext4 is built for artifact generation
+    IMAGE_FSTYPES:prepend = "ext4 "
+
+  raspberrypi: |
+    RPI_USE_U_BOOT = "1"
+    ENABLE_UART = "1"
+    MENDER_BOOT_PART_SIZE_MB = "100"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_FSTYPES:remove = " rpi-sdimg"
+
+  mender-explicit-demo: |
+    # Enable essential Mender features for A/B updates (but NOT image generation)
+    MENDER_FEATURES_ENABLE:append = " \
+        mender-uboot \
+        mender-auth-install \
+        mender-update-install \
+        mender-systemd \
+        mender-growfs-data \
+    "
+    
+    # Explicitly disable dynamic image generation features
+    MENDER_FEATURES_DISABLE:append = " mender-image mender-part-images"
+    
+    # Use our explicit WIC demo image
+    PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+
+    # Explicitly select Mender Client 4.x/5.x and later
+    PREFERRED_PROVIDER_mender-native =  "mender-native"
+    PREFERRED_RPROVIDER_mender-auth =   "mender"
+    PREFERRED_RPROVIDER_mender-update = "mender"
+
+target:
+  - mender-explicit-demo-image

--- a/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
+++ b/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
@@ -80,5 +80,8 @@ local_conf_header:
     PREFERRED_RPROVIDER_mender-auth =   "mender"
     PREFERRED_RPROVIDER_mender-update = "mender"
 
+    # Prefer mender-artifact 4.x series (scarthgap defaults to 3.x)
+    PREFERRED_VERSION_mender-artifact-native = "4.%"
+
 target:
   - mender-explicit-demo-image


### PR DESCRIPTION
In some use cases, being able to manually and explicitly control partitioning is beneficial for maintainability or covering special requirements. This commit adds a demo example configuration and metadata layer to show a build configuration using an explicit `wks` file for partitioning on a Raspberry Pi 4.