### PR TITLE
kas: migrate to kas >= 4.8 and security updates

### DIFF
--- a/kas/beaglebone-ai64.yml
+++ b/kas/beaglebone-ai64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/arm.yml

--- a/kas/beaglebone-uboot.yml
+++ b/kas/beaglebone-uboot.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/beaglebone.yml
 

--- a/kas/beaglebone.yml
+++ b/kas/beaglebone.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
 

--- a/kas/beagleplay-ti.yml
+++ b/kas/beagleplay-ti.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/arm.yml

--- a/kas/demos/qemuarm64-bootloader-validation.yml
+++ b/kas/demos/qemuarm64-bootloader-validation.yml
@@ -1,5 +1,5 @@
 header:
-  version: 11
+  version: 19
   includes:
   - kas/qemuarm64.yml
 

--- a/kas/demos/qemuarm64-client-only.yml
+++ b/kas/demos/qemuarm64-client-only.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-base.yml
 

--- a/kas/demos/qemuarm64-sulka.yml
+++ b/kas/demos/qemuarm64-sulka.yml
@@ -1,5 +1,5 @@
 header:
-  version: 11
+  version: 19
   includes:
   - kas/qemuarm64.yml
   - kas/include/sulka.yml

--- a/kas/demos/raspberrypi4-64-app-updates.yml
+++ b/kas/demos/raspberrypi4-64-app-updates.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/raspberrypi4-64.yml
 
@@ -12,7 +12,9 @@ repos:
 
   meta-virtualization:
     url: git://git.yoctoproject.org/meta-virtualization
-    refspec: scarthgap
+    branch: scarthgap
+    commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc
+    signed: false
 
   meta-mender:
     layers:

--- a/kas/demos/raspberrypi4-64-wifi.yml
+++ b/kas/demos/raspberrypi4-64-wifi.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/raspberrypi4-64.yml
 

--- a/kas/imx93-var-som.yml
+++ b/kas/imx93-var-som.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/arm.yml
@@ -19,30 +19,42 @@ repos:
 
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale
-    refspec: scarthgap
+    branch: scarthgap
+    commit: 90cb4c15f033042376c38f90878459089cd10576
+    signed: false
 
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty
-    refspec: scarthgap
+    branch: scarthgap
+    commit: 70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d
+    signed: false
 
   meta-freescale-distro:
     url: https://github.com/Freescale/meta-freescale-distro
-    refspec: scarthgap
+    branch: scarthgap
+    commit: b9d6a5d9931922558046d230c1f5f4ef6ee72345
+    signed: false
 
   meta-nxp:
     url: https://github.com/nxp-imx/meta-imx
-    refspec: scarthgap
+    tag: rel_imx_6.6.52_2.2.1
+    commit: 89c4d98c236ac1a2fbfcc92e5adf6571e41bd2da
+    signed: false
     layers:
       meta-bsp:
       meta-sdk:
 
   meta-variscite-bsp-common:
     url: https://github.com/varigit/meta-variscite-bsp-common
-    refspec: scarthgap
+    branch: scarthgap_6.6.52-2.2.0_var01
+    commit: 3444cb784cc7f769dfc8cdbf236878c571298bfa
+    signed: false
 
   meta-variscite-bsp-imx:
     url: https://github.com/varigit/meta-variscite-bsp-imx
-    refspec: scarthgap
+    branch: scarthgap_6.6.52-2.2.0_var01
+    commit: 9efe6ed3d8a76b87b8990741a2919b3b8f0741e3
+    signed: false
 
 local_conf_header:
   imx93-var-som: |

--- a/kas/include/arm.yml
+++ b/kas/include/arm.yml
@@ -1,10 +1,14 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
+    tag: yocto-5.0.2
     commit: 8e0f8af90fefb03f08cd2228cde7a89902a6b37c
+    signed: true
+    allowed_signers:
+      - MetaArm
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -1,12 +1,25 @@
 header:
-  version: 14
+  version: 19
+
+signers:
+  YoctoBuildandRelease:
+    fingerprint: 2AFB13F28FBBB0D1B9DAF63087EB3D32FB631AD9
+    gpg_keyserver: keyserver.ubuntu.com
+
+  MetaArm:
+    fingerprint: A04F5BF5CDD4D89C57F7C9AA6E664BAC7A8BD223
+    gpg_keyserver: keyserver.ubuntu.com
 
 distro: poky
 
 repos:
   poky:
     url: git://git.yoctoproject.org/poky
-    commit: c162696dae5798e2ab1198403d0bc1d65d64068d
+    tag: scarthgap-5.0.11
+    commit: ae2d52758fc2fcb0ed996aa234430464ebf4b310
+    signed: true
+    allowed_signers:
+      - YoctoBuildandRelease
     layers:
       meta:
       meta-poky:
@@ -14,14 +27,17 @@ repos:
 
   meta-openembedded:
     url: git://git.openembedded.org/meta-openembedded
-    commit: e92d0173a80ea7592c866618ef5293203c50544c
+    branch: scarthgap
+    commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
+    signed: false
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 0d393c2267a92091f975eb932338c07109f5f5fd
-
+    tag: scarthgap-v2025.07
+    commit: 0c43da078f550e5bd42000f71a7f4e9ae19b7faf
+    signed: false
     layers:
       meta-mender-core:
 

--- a/kas/include/mender-full-ubi.yml
+++ b/kas/include/mender-full-ubi.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-base.yml
 

--- a/kas/include/mender-full.yml
+++ b/kas/include/mender-full.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-base.yml
 

--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -1,19 +1,22 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale.git
-    # branch: scarthgap
-    commit: f52fe2b709e70d1d864adfad2754213bce7abcd7
+    branch: scarthgap
+    commit: 90cb4c15f033042376c38f90878459089cd10576
+    signed: false
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty.git
-    # branch: scarthgap
+    branch: scarthgap
     commit: 70c83e96c7f75e73245cb77f1b0cada9ed4bbc6d
+    signed: false
   meta-freescale-distro:
     url: https://github.com/Freescale/meta-freescale-distro.git
-    # branch: scarthgap
+    branch: scarthgap
     commit: b9d6a5d9931922558046d230c1f5f4ef6ee72345
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/qemu.yml
+++ b/kas/include/qemu.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-mender:

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -1,14 +1,18 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+    branch: scarthgap
+    commit: 1f2045321afd6ef20b457266ac3e97c8577eb1c4
+    signed: false
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins
+    branch: scarthgap/u-boot
     commit: a44882db02a0ed0f149371831bfbe067665eb42b
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/rockchip.yml
+++ b/kas/include/rockchip.yml
@@ -1,10 +1,12 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-rockchip:
     url: https://git.yoctoproject.org/meta-rockchip
-    commit: 63a3d6fa336318dffb3e5bb913bc239026ae9015
+    branch: scarthgap
+    commit: 9690180b7e9953361958c962b80d891eda8c1028
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/sulka.yml
+++ b/kas/include/sulka.yml
@@ -1,12 +1,13 @@
 header:
-  version: 14
+  version: 19
 
 distro: sulka
 
 repos:
   meta-sulka-distro:
     url: https://codeberg.org/AltidSec/meta-sulka-distro.git
-    commit: 64c1f5c0d484bd201e7f2f617040e2c5973d17cb
+    branch: scarthgap
+    commit: 7e5d62b7272cb2a4fbf46d72bc76561d82a71288
 
   meta-openembedded:
     layers:
@@ -15,6 +16,7 @@ repos:
 
   meta-security:
     url: git://git.yoctoproject.org/meta-security.git
+    branch: scarthgap
     commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
 
 local_conf_header:

--- a/kas/include/tegra-base.yml
+++ b/kas/include/tegra-base.yml
@@ -1,10 +1,8 @@
 header:
-  version: 14
+  version: 19
 
 repos:
-  meta-mender:
-    commit: 2f70dbad1441055c299332b7ef33dfe1e4f50c1c # this one fixes the persistent-id for now!
-  
+
   meta-tegra:
     url: https://github.com/OE4T/meta-tegra.git
   meta-tegra-community:
@@ -24,7 +22,9 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization.git
-    commit: 6a80f140e387621f62964209a2e07d3bcfb125ce
+    branch: scarthgap
+    commit: a5449c0c50aa07d02186f548fe6bb6c1ce8823dc
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack5.yml
+++ b/kas/include/tegra-jetpack5.yml
@@ -1,19 +1,22 @@
 header:
-  version: 14
+  version: 19
 
   includes:
   - kas/include/tegra-base.yml
 
 repos:
   meta-tegra:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: e836736de0a439c8893ede4cef6973bd6347affa
+    branch: scarthgap-l4t-r35.x
+    commit: f0dd06b12ea4cbc45b66263a7d64d22b4fb55268
+    signed: false
   meta-tegra-community:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: c03675e45fa229a4c067f5bd2e8461b713d789f4
+    branch: scarthgap-l4t-r35.x
+    commit: 4d4630b087e731b7eacc6e70528956ea8bcb9fef
+    signed: false
   meta-tegrademo:
-    # refers to the scarthgap-l4t-r35.x branch
-    commit: a9132a76ae8f35a962e5970fdd422fa0c2fc6fc1
+    branch: scarthgap-l4t-r35.x
+    commit: b1ffec8e4641394e6d1696d8a00ea2bb85953adb
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack6.yml
+++ b/kas/include/tegra-jetpack6.yml
@@ -1,19 +1,22 @@
 header:
-  version: 14
+  version: 19
 
   includes:
   - kas/include/tegra-base.yml
 
 repos:
   meta-tegra:
-    # refers to the scarthgap branch
-    commit: 8f9748b0178a4d93bceffd86d9d436cd0e685750
+    branch: scarthgap
+    commit: 89bdb09158d60dc90b316ee7bbb97c340cbe2a3c
+    signed: false
   meta-tegra-community:
-    # refers to the scarthgap branch
+    branch: scarthgap
     commit: 241d1073ba8e610ef8da3fe8470b0a4d0567521f
+    signed: false
   meta-tegrademo:
-    # refers to the scarthgap branch
-    commit: 3f2641444d6c50c3fa4eea8a4c770bd30db70ee9
+    branch: scarthgap
+    commit: 48fc2272c996cd41b7bcadd1f4eaacf37d75c119
+    signed: false
 
   meta-mender-community:
     layers:

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -1,9 +1,11 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-ti:
     url: https://git.yoctoproject.org/meta-ti
-    commit: d62c047d4b8424603c6996a5755cf7004bd13254
+    tag: cicd.scarthgap.202507231325
+    commit: 4b943f75bfeb04278b11c477a1e3b9ed768c56c1
+    signed: false
     layers:
       meta-ti-bsp:

--- a/kas/include/validation.yml
+++ b/kas/include/validation.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
 
 repos:
   meta-mender-community:

--- a/kas/nezha-allwinner-d1.yml
+++ b/kas/nezha-allwinner-d1.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
 
@@ -10,7 +10,9 @@ repos:
 
   meta-riscv:
     url: https://github.com/riscv/meta-riscv
+    branch: scarthgap
     commit: 76727db91108f53afc8a5b72651167c4446b5fcb
+    signed: false
 
 machine: nezha-allwinner-d1
 

--- a/kas/olimex-imx8mp-evb.yml
+++ b/kas/olimex-imx8mp-evb.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/nxp.yml

--- a/kas/qemuarm64.yml
+++ b/kas/qemuarm64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/arm.yml

--- a/kas/qemux86-64.yml
+++ b/kas/qemux86-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/qemu.yml

--- a/kas/raspberrypi-cm.yml
+++ b/kas/raspberrypi-cm.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi-cm3.yml
+++ b/kas/raspberrypi-cm3.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi.yml
+++ b/kas/raspberrypi.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi0-2w-64.yml
+++ b/kas/raspberrypi0-2w-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi0-2w.yml
+++ b/kas/raspberrypi0-2w.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi0-wifi.yml
+++ b/kas/raspberrypi0-wifi.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi0.yml
+++ b/kas/raspberrypi0.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi2.yml
+++ b/kas/raspberrypi2.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi3-64.yml
+++ b/kas/raspberrypi3-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi3.yml
+++ b/kas/raspberrypi3.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi4-64.yml
+++ b/kas/raspberrypi4-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi4.yml
+++ b/kas/raspberrypi4.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/raspberrypi5.yml
+++ b/kas/raspberrypi5.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/raspberrypi.yml

--- a/kas/rock-4c-plus.yml
+++ b/kas/rock-4c-plus.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/arm.yml

--- a/kas/tegra/jetpack5/jetson-agx-orin-devkit-64.yml
+++ b/kas/tegra/jetpack5/jetson-agx-orin-devkit-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/tegra-jetpack5.yml

--- a/kas/tegra/jetpack5/jetson-agx-orin-devkit.yml
+++ b/kas/tegra/jetpack5/jetson-agx-orin-devkit.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/tegra-jetpack5.yml

--- a/kas/tegra/jetpack5/jetson-agx-xavier-devkit.yml
+++ b/kas/tegra/jetpack5/jetson-agx-xavier-devkit.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
 
   includes:
   - kas/include/mender-full.yml

--- a/kas/tegra/jetpack5/jetson-orin-16gb-nx-p3786.yml
+++ b/kas/tegra/jetpack5/jetson-orin-16gb-nx-p3786.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
     - kas/include/mender-full.yml
     - kas/include/tegra-jetpack5.yml

--- a/kas/tegra/jetpack5/jetson-orin-nano-devkit.yml
+++ b/kas/tegra/jetpack5/jetson-orin-nano-devkit.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
     - kas/include/mender-full.yml
     - kas/include/tegra-jetpack5.yml

--- a/kas/tegra/jetpack6/jetson-agx-orin-devkit-64.yml
+++ b/kas/tegra/jetpack6/jetson-agx-orin-devkit-64.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/tegra-jetpack6.yml

--- a/kas/tegra/jetpack6/jetson-agx-orin-devkit.yml
+++ b/kas/tegra/jetpack6/jetson-agx-orin-devkit.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
   - kas/include/tegra-jetpack6.yml

--- a/kas/tegra/jetpack6/jetson-orin-16gb-nx-p3786.yml
+++ b/kas/tegra/jetpack6/jetson-orin-16gb-nx-p3786.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
     - kas/include/mender-full.yml
     - kas/include/tegra-jetpack6.yml

--- a/kas/tegra/jetpack6/jetson-orin-nano-devkit.yml
+++ b/kas/tegra/jetpack6/jetson-orin-nano-devkit.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
     - kas/include/mender-full.yml
     - kas/include/tegra-jetpack6.yml

--- a/kas/vexpress-qemu-flash.yml
+++ b/kas/vexpress-qemu-flash.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full-ubi.yml
   - kas/include/qemu.yml

--- a/kas/vexpress-qemu.yml
+++ b/kas/vexpress-qemu.yml
@@ -1,5 +1,5 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-base.yml
   - kas/include/qemu.yml

--- a/kas/x86-virtual.yml
+++ b/kas/x86-virtual.yml
@@ -1,12 +1,16 @@
 header:
-  version: 14
+  version: 19
   includes:
   - kas/include/mender-full.yml
 
 repos:
   meta-intel:
     url: https://git.yoctoproject.org/meta-intel
-    refspec: scarthgap
+    tag: 21.0-scarthgap-5.0
+    commit: f4de3fa1fdfd97b652ec427ba584f11f110cab58
+    signed: true
+    allowed_signers:
+      - YoctoBuildandRelease
 
 local_conf_header:
   x86-virtual: |


### PR DESCRIPTION
Kas 4.8 introduced some compelling new security features that are quire useful for verification purposes. As mender prides itself on security, now would be a great time to update to kas 4.8 and add signature support where possible.

  - Update all .yml files to version 19.

  - Add YoctoBuildandRelease, MetaArm, and NorthernTech signers in the kas/include/mender-base.yml file.

  - Add tags where possible for all repositories.

  - Add branches where possible for all repositories. Note: If a tag exists, branches may not be used.

  - Update commits to the latest tag or commit for all scarthgap branches.

  - Add signed: true wherever possible.

  - Even though signed: false is the default, it is best to explicitly add it to every repository that doesn't have a signed tag. This lets the user know that the commit isn't signed and leaves no room for ambiguity.