### PR TITLE
add mender-setup recipe

### DIFF
--- a/meta-mender-validation/recipes-mender/images/mender-validation-image.bb
+++ b/meta-mender-validation/recipes-mender/images/mender-validation-image.bb
@@ -2,5 +2,5 @@ require recipes-core/images/core-image-minimal.bb
 
 DESCRIPTION = "Small image capable of running the Mender validation suite"
 
-IMAGE_INSTALL:append = " bootloader-validation "
+IMAGE_INSTALL:append = " bootloader-validation mender-setup "
 IMAGE_FEATURES:append = " allow-empty-password empty-root-password allow-root-login "

--- a/meta-mender-validation/recipes-mender/mender-setup/mender-setup.inc
+++ b/meta-mender-validation/recipes-mender/mender-setup/mender-setup.inc
@@ -1,0 +1,29 @@
+DESCRIPTION = "Mender tool for configuring the client interactively."
+HOMEPAGE = "https://mender.io"
+
+DEPENDS:append = " glib-2.0"
+RDEPENDS:${PN} = "glib-2.0 mender-update (>= 4.0)"
+
+B = "${WORKDIR}/build"
+
+inherit go-mod
+inherit go-ptest
+
+GO_IMPORT = "github.com/mendersoftware/mender-setup"
+
+do_compile() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1
+}
+
+do_install() {
+    oe_runmake \
+        -C ${B}/src/${GO_IMPORT} \
+        V=1 \
+        prefix=${D} \
+        bindir=${bindir} \
+        datadir=${datadir} \
+        sysconfdir=${sysconfdir} \
+        install-bin
+}

--- a/meta-mender-validation/recipes-mender/mender-setup/mender-setup_1.0.0.bb
+++ b/meta-mender-validation/recipes-mender/mender-setup/mender-setup_1.0.0.bb
@@ -1,0 +1,43 @@
+require mender-setup.inc
+
+################################################################################
+#-------------------------------------------------------------------------------
+# THINGS TO CONSIDER FOR EACH RELEASE:
+# - SRC_URI (particularly "branch")
+# - SRCREV
+# - DEFAULT_PREFERENCE
+#-------------------------------------------------------------------------------
+
+SRC_URI = "git://github.com/mendersoftware/mender-setup.git;protocol=https;branch=1.0.x"
+
+# Tag: 1.0.0
+SRCREV = "9607bbfbc032e80bb0c1724e6b026f8bdd3fcbd1"
+
+# Enable this in Betas, and in branches that cannot carry this major version as
+# default.
+# Downprioritize this recipe in version selections.
+# DEFAULT_PREFERENCE = "-1"
+
+################################################################################
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+LICENSE = "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT & ISC"
+
+LIC_FILES_CHKSUM = " \
+    file://src/github.com/mendersoftware/mender-setup/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/cpuguy83/go-md2man/v2/LICENSE.md;md5=80794f9009df723bbc6fe19234c9f517 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/davecgh/go-spew/LICENSE;md5=c06795ed54b2a35ebeeb543cd3a73e56 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/pkg/errors/LICENSE;md5=6fe682a02df52c6653f33bd0f7126b5a \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/pmezard/go-difflib/LICENSE;md5=e9a2ebb8de779a07500ddecca806145e \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/russross/blackfriday/v2/LICENSE.txt;md5=ecf8a8a60560c35a862a4a545f2db1b3 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/sirupsen/logrus/LICENSE;md5=8dadfef729c08ec4e631c4f6fc5d43a0 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/stretchr/testify/LICENSE;md5=188f01994659f3c0d310612333d2a26f \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/urfave/cli/v2/LICENSE;md5=51992c80b05795f59c22028d39f9b74c \
+    file://src/github.com/mendersoftware/mender-setup/vendor/github.com/xrash/smetrics/LICENSE;md5=68418a2b5d025376b21bcbd2d9289f22 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/golang.org/x/sys/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/golang.org/x/term/LICENSE;md5=5d4950ecb7b26d2c5e4e7b4e0dd74707 \
+    file://src/github.com/mendersoftware/mender-setup/vendor/gopkg.in/yaml.v3/LICENSE;md5=3c91c17266710e16afdbb2b6d15c761c \
+"

--- a/meta-mender-validation/recipes-mender/mender-setup/mender-setup_git.bb
+++ b/meta-mender-validation/recipes-mender/mender-setup/mender-setup_git.bb
@@ -1,0 +1,67 @@
+require mender-setup.inc
+
+# The revision listed below is not really important, it's just a way to avoid
+# network probing during parsing if we are not gonna build the git version
+# anyway. If git version is enabled, the AUTOREV will be chosen instead of the
+# SHA.
+def mender_setup_autorev_if_git_version(d):
+    version = d.getVar("PREFERRED_VERSION")
+    if not version:
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if not d.getVar("EXTERNALSRC") and version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "fb1d7eeb05b7c56b3a55f16747d70c1fd142b00f"
+SRCREV ?= '${@mender_setup_autorev_if_git_version(d)}'
+
+def mender_setup_branch_from_preferred_version(d):
+    import re
+    version = d.getVar("PREFERRED_VERSION")
+    if version is None or version == "":
+        version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is None:
+        version = ""
+    match = re.match(r"^[0-9]+\.[0-9]+\.", version)
+    if match is not None:
+        # If the preferred version is some kind of version, use the branch name
+        # for that one (1.0.x style).
+        return match.group(0) + "x"
+    else:
+        # Else return master as branch.
+        return "master"
+MENDER_SETUP_BRANCH = "${@mender_setup_branch_from_preferred_version(d)}"
+
+def mender_setup_version_from_preferred_version(d, srcpv):
+    pref_version = d.getVar("PREFERRED_VERSION")
+    if pref_version is None:
+        pref_version = d.getVar("PREFERRED_VERSION_%s" % d.getVar("PN"))
+    if pref_version is not None and pref_version.find("-git") >= 0:
+        # If "-git" is in the version, remove it along with any suffix it has,
+        # and then readd it with commit SHA.
+        return "%s-git%s" % (pref_version[0:pref_version.index("-git")], srcpv)
+    elif pref_version is not None and pref_version.find("-build") >= 0:
+        # If "-build" is in the version, use the version as is. This means that
+        # we can build tags with "-build" in them from this recipe, but not
+        # final tags, which will need their own recipe.
+        return pref_version
+    else:
+        # Else return the default "master-git".
+        return "master-git%s" % srcpv
+PV = "${@mender_setup_version_from_preferred_version(d, '${SRCPV}')}"
+
+SRC_URI = "git://${GO_IMPORT};protocol=https;branch=${MENDER_SETUP_BRANCH}"
+
+# DO NOT change the checksum here without make sure that ALL licenses (including
+# dependencies) are included in the LICENSE variable below. Note that for
+# releases, we must check the LIC_FILES_CHKSUM.sha256 file, not the LICENSE
+# file.
+def mender_setup_license(branch):
+    # Only one currently. If the sub licenses change we may introduce more.
+    return {
+               "license": "Apache-2.0 & BSD-2-Clause & BSD-3-Clause & MIT",
+    }
+LIC_FILES_CHKSUM = "file://src/${GO_IMPORT}/LICENSE;md5=30b4554c64108561c0cb1c57e8a044f0"
+LICENSE = "${@mender_setup_license(d.getVar('MENDER_SETUP_BRANCH'))['license']}"
+
+# Downprioritize this recipe in version selections.
+DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
The [`mender-setup'](https://github.com/mendersoftware/mender-setup) tool helps with interactive, on-target configuration of the Mender Client. It usually is not required in a Yocto-style context, as the images are fully build time configured in most cases, specifically in production.

For evaluation cases it is useful thought being able to provide an image with the Mender Client readily installed which users can then point to their backend. To enable this, the `mender-setup` tool should be provided as part of `meta-mender-community`.