### PR TITLE
feat: kas: add raspberrypi4-64-tpm configuration

### DIFF
--- a/.github/workflows/build_demos.yml
+++ b/.github/workflows/build_demos.yml
@@ -32,7 +32,8 @@ jobs:
           qemuarm64-bootloader-validation,
           qemuarm64-client-only,
           raspberrypi4-64-wifi,
-          qemuarm64-sulka
+          qemuarm64-sulka,
+          raspberrypi4-64-tpm
         ]
         subpath: [demos]
 

--- a/kas/demos/meta-mender-raspberrypi-tpm/LICENSE
+++ b/kas/demos/meta-mender-raspberrypi-tpm/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/kas/demos/meta-mender-raspberrypi-tpm/README
+++ b/kas/demos/meta-mender-raspberrypi-tpm/README
@@ -1,0 +1,110 @@
+This README file contains information on the contents of the meta-mender-raspberrypi-tpm layer.
+
+Please see the corresponding sections below for details.
+
+Dependencies
+============
+  URI: https://git.yoctoproject.org/poky
+  branch: scarthgap
+
+  URI: https://git.openembedded.org/meta-openembedded
+  branch: scarthgap
+
+  URI: https://github.com/mendersoftware/meta-mender
+  branch: scarthgap
+
+  URI: https://github.com/agherzan/meta-raspberrypi
+  branch: scarthgap
+
+  URI: git://git.yoctoproject.org/meta-security.git
+  branch: scarthgap
+
+  URI: https://github.com/ejaaskel/meta-slb9670-rpi.git
+  branch: scarthgap
+
+Contributions
+=============
+
+Please the README file in the top level directory.
+
+Table of Contents
+=================
+
+  I. Adding the meta-mender-raspberrypi-tpm layer to your build
+ II. Purpose
+III. Included functionality
+
+
+I. Adding the meta-mender-raspberrypi-tpm layer to your build
+=================================================
+
+Run 'bitbake-layers add-layer meta-mender-raspberrypi-tpm'
+
+II. Purpose
+===========
+
+The layer contains an example setup for a Yocto build which enables
+TPM-based disk encryption on a Raspberry Pi 4 using LUKS2 and systemd-cryptenroll.
+
+The example image "core-image-cryptsetup-tpm" extends a base image with
+TPM2 tools and cryptsetup functionality for secure storage encryption.
+
+III. Included functionality
+===========================
+
+The TPM-based encryption setup requires:
+- TPM 2.0 hardware support (available on Raspberry Pi 4 via LetsTrust.de TPM module)
+- cryptsetup and LUKS2 support
+- systemd-cryptenroll for TPM integration
+- TPM2 tools for PCR management
+
+The setup includes a firstboot-init service that automatically encrypts the 
+static partition on first boot. The encryption flow is:
+
+1. Check if partition is already encrypted (exits if yes)
+2. Generate a random password and save temporarily
+3. Format the partition with LUKS2 encryption using the password
+4. Create an ext4 filesystem on the encrypted partition
+5. Enroll the TPM2 chip to automatically unlock the partition using PCR 7
+6. Securely delete the temporary password file
+7. Add the partition to /etc/fstab for automatic mounting at /mnt/static
+8. Reboot the system to complete the setup
+
+Note: The /etc/crypttab file is pre-installed by the recipe and contains the 
+entry for automatic TPM-based unlocking of the static partition.
+
+The automated flow (performed by firstboot-init.sh):
+```bash
+# Generate random password
+openssl rand -base64 44 > /root/static-key
+
+# Format partition with LUKS2
+cat /root/static-key | cryptsetup luksFormat --type luks2 /dev/mmcblk0p6
+
+# Create filesystem
+cat /root/static-key | cryptsetup open /dev/mmcblk0p6 static
+mkfs.ext4 /dev/mapper/static
+uuid=$(lsblk -o UUID /dev/mapper/static -n)
+cryptsetup close static
+
+# Enroll TPM2 for automatic unlock
+export PASSWORD=$(cat /root/static-key)
+systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 /dev/mmcblk0p6
+
+# Secure cleanup
+shred -vfz /root/static-key
+
+# Configure automatic mounting
+# (crypttab is pre-installed by the recipe)
+echo "UUID=$uuid /mnt/static ext4 defaults,x-systemd.device-timeout=30 0 0" >> /etc/fstab
+
+# Reboot to complete setup
+reboot
+```
+
+The setup uses PCR 7 for secure boot measurements to ensure the encrypted
+partition can only be unlocked on a system with the expected boot state.
+
+After this setup, the `/mnt/static` persistent partition is encrypted and will 
+be automatically unlocked via TPM and mounted upon boot only on the specific 
+device where it was enrolled, ensuring data protection if the storage is removed. 

--- a/kas/demos/meta-mender-raspberrypi-tpm/conf/layer.conf
+++ b/kas/demos/meta-mender-raspberrypi-tpm/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-mender-raspberrypi-tpm"
+BBFILE_PATTERN_meta-mender-raspberrypi-tpm = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-mender-raspberrypi-tpm = "6"
+
+LAYERDEPENDS_meta-mender-raspberrypi-tpm = "core"
+LAYERSERIES_COMPAT_meta-mender-raspberrypi-tpm = "scarthgap"

--- a/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/crypttab
+++ b/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/crypttab
@@ -1,0 +1,1 @@
+static /dev/mmcblk0p6 none tpm2-device=auto

--- a/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/firstboot-init.service
+++ b/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/firstboot-init.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Encrypt persistent static partition
+After=systemd-remount-fs.service
+After=systemd-tmpfiles-setup.service
+#Before=systemd-cryptsetup@static.service
+ConditionPathExists=!/mnt/static
+ConditionPathExists=!/etc/cryptsetup-done
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/firstboot-init.sh
+ExecStartPost=/usr/bin/touch /etc/cryptsetup-done
+User=root
+Group=root
+TimeoutSec=600
+SuccessExitStatus=0
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/firstboot-init.sh
+++ b/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/files/firstboot-init.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+set -e
+
+STATIC_DEVICE="/dev/mmcblk0p6"
+
+/usr/bin/echo "[firstboot-init] Starting TPM-based encryption setup"
+
+# Check if already encrypted
+if /usr/sbin/cryptsetup isLuks "${STATIC_DEVICE}"; then
+	/usr/bin/echo "[firstboot-init] Static partition is already encrypted"
+	exit 0
+fi
+
+# Ensure root filesystem is writable
+if ! touch /root/.test_write 2>/dev/null; then
+	/usr/bin/echo "[firstboot-init] ERROR: Root filesystem is read-only, cannot proceed"
+	exit 1
+fi
+rm -f /root/.test_write
+
+PASSWORD_FILE="/root/static-key"
+
+# Generate random password
+/usr/bin/openssl rand -base64 44 > ${PASSWORD_FILE} || {
+	/usr/bin/echo "[firstboot-init] ERROR: Failed to generate password"
+	exit 1
+}
+/bin/sync
+
+/usr/bin/echo "[firstboot-init] Formatting partition with LUKS2..."
+/usr/bin/cat "${PASSWORD_FILE}" | /usr/sbin/cryptsetup luksFormat --batch-mode --type luks2 "${STATIC_DEVICE}"
+
+/usr/bin/cat "${PASSWORD_FILE}" | /usr/sbin/cryptsetup open --batch-mode "${STATIC_DEVICE}" static
+/usr/bin/echo "[firstboot-init] Creating ext4 filesystem..."
+/usr/sbin/mkfs.ext4 -q /dev/mapper/static
+/bin/sync
+
+uuid=$(/usr/bin/lsblk -o UUID /dev/mapper/static -n)
+/usr/sbin/cryptsetup close static
+/bin/sync
+
+/usr/bin/echo "[firstboot-init] Enrolling TPM2 for automatic unlock..."
+export PASSWORD="$(cat ${PASSWORD_FILE})"
+/usr/bin/systemd-cryptenroll --tpm2-device=auto --tpm2-pcrs=7 "${STATIC_DEVICE}" || {
+	/usr/bin/echo "[firstboot-init] ERROR: Failed to enroll TPM2"
+	unset PASSWORD
+	rm -f ${PASSWORD_FILE}
+	exit 1
+}
+unset PASSWORD
+
+# Securely remove password file
+shred -vfz ${PASSWORD_FILE} 2>/dev/null || rm -f ${PASSWORD_FILE}
+
+/usr/bin/mkdir -p /mnt/static
+/usr/bin/echo "UUID=$uuid /mnt/static ext4 defaults,x-systemd.device-timeout=30 0 0" >> /etc/fstab
+
+/usr/bin/echo "[firstboot-init] TPM-based encryption setup completed successfully!"
+
+/usr/sbin/reboot
+
+exit 0

--- a/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/firstboot-init.bb
+++ b/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/firstboot-init/firstboot-init.bb
@@ -1,0 +1,38 @@
+SUMMARY = "TPM-based encrypted partition setup service"
+DESCRIPTION = "Systemd service that runs on boot to set up TPM-based disk encryption on the persistent partition"
+HOMEPAGE = "https://github.com/mendersoftware/meta-mender-community"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+SRC_URI = " \
+    file://crypttab \
+    file://firstboot-init.sh \
+    file://firstboot-init.service \
+"
+
+S = "${WORKDIR}"
+
+SYSTEMD_SERVICE:${PN} = "firstboot-init.service"
+
+# Runtime dependencies
+RDEPENDS:${PN} = " \
+    cryptsetup \
+    systemd-crypt \
+    tpm2-tools \
+"
+
+do_install() {
+    # Install the initialization script
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/firstboot-init.sh ${D}${sbindir}/firstboot-init.sh
+    
+    # Install the systemd service
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/firstboot-init.service ${D}${systemd_system_unitdir}/firstboot-init.service
+
+    # Install the crypttab
+    install -d ${D}${sysconfdir}
+    install -m 0400 ${S}/crypttab ${D}${sysconfdir}
+}

--- a/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/images/core-image-cryptsetup-tpm.bb
+++ b/kas/demos/meta-mender-raspberrypi-tpm/recipes-tpm/images/core-image-cryptsetup-tpm.bb
@@ -1,0 +1,14 @@
+include recipes-core/images/core-image-base.bb
+
+LICENSE = "MIT"
+DESCRIPTION = "A Core image based on core-image-base for rpi"
+
+# add device tree overlay for the LetsTrust TPM
+KERNEL_DEVICETREE:append = " overlays/letstrust-tpm.dtbo"
+
+IMAGE_INSTALL:append = " \
+    firstboot-init \
+    cryptsetup \
+    systemd-crypt \
+    util-linux-lsblk \
+"

--- a/kas/demos/raspberrypi4-64-tpm.yml
+++ b/kas/demos/raspberrypi4-64-tpm.yml
@@ -1,0 +1,32 @@
+header:
+  version: 14
+  includes:
+  - kas/raspberrypi4-64.yml
+
+distro: poky
+target: core-image-slb9670-rpi
+
+repos:
+  meta-openembedded:
+    layers:
+      meta-python:
+
+  meta-security:
+    url: git://git.yoctoproject.org/meta-security.git
+    commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
+    layers:
+      meta-tpm:
+
+  meta-slb9670-rpi:
+    url: https://github.com/ejaaskel/meta-slb9670-rpi.git
+    commit: b2e614da8f49b6e7cb536b1cf946460d5c1f6484
+
+local_conf_header:
+  tpm2: |
+    MACHINE_FEATURES:append = "tpm2"
+    DISTRO_FEATURES:append = " tpm2"
+    LICENSE_FLAGS_ACCEPTED += "synaptics-killswitch"
+    ENABLE_SPI_BUS = "1"
+    RPI_EXTRA_CONFIG = "dtoverlay=letstrust-tpm"
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "2000"

--- a/kas/demos/raspberrypi4-64-tpm.yml
+++ b/kas/demos/raspberrypi4-64-tpm.yml
@@ -4,9 +4,13 @@ header:
   - kas/raspberrypi4-64.yml
 
 distro: poky
-target: core-image-slb9670-rpi
+target: core-image-cryptsetup-tpm
 
 repos:
+  meta-mender-community:
+    layers:
+      kas/demos/meta-mender-raspberrypi-tpm:
+
   meta-openembedded:
     layers:
       meta-python:
@@ -30,3 +34,8 @@ local_conf_header:
     RPI_EXTRA_CONFIG = "dtoverlay=letstrust-tpm"
     IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
     MENDER_STORAGE_TOTAL_SIZE_MB = "2000"
+    PACKAGECONFIG:append:pn-systemd = " cryptsetup tpm2 "
+  static-partition: |
+    MENDER_EXTRA_PARTS = "part1"
+    MENDER_EXTRA_PARTS[part1] = "--label=static --fstype=ext4"
+    MENDER_EXTRA_PARTS_SIZES_MB[part1] = "64"


### PR DESCRIPTION
This commit adds an example build configuration for enabling the LetsTrust TPM on a Raspberry Pi 4.

Changelog: Title
Ticket: None