### PR TITLE
 fix: prevent u-boot interruption during startup on RPi5/CM5

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot/0001-Adding-boot-delay-2.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot/0001-Adding-boot-delay-2.patch
@@ -1,0 +1,21 @@
+From fa95623689df037102fb41ac675fc82b6a236c1b Mon Sep 17 00:00:00 2001
+From: Ed Watson <edmundwatson@gmail.com>
+Date: Fri, 5 Sep 2025 11:06:16 +0200
+Subject: [PATCH] Adding boot delay -2 This prevents u boot from being able to
+ be stopped by a keypress or something else. This has been seen on CM5 and
+ RPi5
+
+---
+ configs/rpi_arm64_defconfig | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
+index 2710613d072..5be6a508b0e 100644
+--- a/configs/rpi_arm64_defconfig
++++ b/configs/rpi_arm64_defconfig
+@@ -67,3 +67,4 @@ CONFIG_ENV_IS_IN_MMC=y
+ CONFIG_ENV_OFFSET=0x800000
+ CONFIG_ENV_OFFSET_REDUND=0x1000000
+ CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++BOOTDELAY=-2
+\ No newline at end of file

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,1 +1,5 @@
 require u-boot-raspberrypi.inc
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-Adding-boot-delay-2.patch"
+


### PR DESCRIPTION
It has been noticed that sometimes RPi5 and CM5 get stuck at boot, staying in the u-boot console. Possibly this is caused by spurious characters on the UART RX.

Setting the bootdelay value to -2 disables this functionality: https://docs.u-boot.org/en/latest/usage/environment.html#list-of-environment-variables

Note: this only applies to RPi5/CM5.
Todo: revisit on u-boot version bumps