### PR TITLE
scarthgap: add jetson-orin-nano-devkit-nvme board - Jetpack 6

### DIFF
--- a/.github/workflows/build_experimental.yml
+++ b/.github/workflows/build_experimental.yml
@@ -48,6 +48,8 @@ jobs:
             subpath: tegra/jetpack6
           - board: jetson-orin-16gb-nx-p3786
             subpath: tegra/jetpack6
+          - board: jetson-orin-nano-devkit-nvme
+            subpath: tegra/jetpack6
 
     runs-on: [self-hosted, linux, x64, builder]
     container:

--- a/kas/tegra/jetpack6/jetson-orin-nano-devkit-nvme.yml
+++ b/kas/tegra/jetpack6/jetson-orin-nano-devkit-nvme.yml
@@ -1,0 +1,21 @@
+header:
+  version: 14
+  includes:
+    - kas/include/mender-full.yml
+    - kas/include/tegra-jetpack6.yml
+
+machine: jetson-orin-nano-devkit-nvme
+
+local_conf_header:
+  AB-upgrades: |
+    UBOOT_EXTLINUX = "1"
+    USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
+  eMMC: |
+    TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
+    # Mender tegra_mender_calc_total_size workaround
+    # Setting MENDER_STORAGE_TOTAL_SIZE_MB to 16Gb and no EMMC
+    EMMC_SIZE = "0"
+    MENDER_STORAGE_TOTAL_SIZE_MB = "16384"
+  Permanent Data Partition: |
+    MENDER_DATA_PART_NUMBER:tegra = "17"
+    MENDER_STORAGE_DEVICE:tegra = "/dev/nvme0n1"

--- a/kas/tegra/jetpack6/jetson-orin-nano-devkit-nvme.yml
+++ b/kas/tegra/jetpack6/jetson-orin-nano-devkit-nvme.yml
@@ -11,7 +11,6 @@ local_conf_header:
     UBOOT_EXTLINUX = "1"
     USE_REDUNDANT_FLASH_LAYOUT_DEFAULT = "1"
   eMMC: |
-    TEGRAFLASH_NO_INTERNAL_STORAGE = "1"
     # Mender tegra_mender_calc_total_size workaround
     # Setting MENDER_STORAGE_TOTAL_SIZE_MB to 16Gb and no EMMC
     EMMC_SIZE = "0"

--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -64,6 +64,7 @@ The following configuration files for building using the `kas` tool are provided
 - [jetson-agx-orin-devkit.yml](../kas/tegra/jetpack6/jetson-agx-orin-devkit.yml)
 - [jetson-orin-16gb-nx-p3786.yml](../kas/tegra/jetpack6/jetson-orin-16gb-nx-p3786.yml)
 - [jetson-orin-nano-devkit.yml](../kas/tegra/jetpack6/jetson-orin-nano-devkit.yml)
+- [jetson-orin-nano-devkit-nvme.yml](../kas/tegra/jetpack6/jetson-orin-nano-devkit-nvme.yml)
 
 ### Jetson Orin NX
 

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout/flash_l4t_t234_nvme_rootfs_ab.xml
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout/flash_l4t_t234_nvme_rootfs_ab.xml
@@ -188,7 +188,7 @@
               the "2" for id as it is physically put to the end of the device, so that it
               can be accessed as the fixed known special device `/dev/nvme0n1p2`. </description>
         </partition>
-        <partition name="permanet_user_storage" id= "17" type="data">
+        <partition name="permanent_user_storage" id= "17" type="data">
             <allocation_policy> sequential </allocation_policy>
             <filesystem_type> basic </filesystem_type>
             <size> 419430400 </size>

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
@@ -1,7 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append:p3768-0000-p3767-0000 = " \
+SRC_URI:append = " \
     file://flash_l4t_t234_nvme_rootfs_ab.xml \
 "
 
 PARTITION_FILE_EXTERNAL:p3768-0000-p3767-0000 = "${WORKDIR}/flash_l4t_t234_nvme_rootfs_ab.xml"
+PARTITION_FILE_EXTERNAL:jetson-orin-nano-devkit-nvme = "${WORKDIR}/flash_l4t_t234_nvme_rootfs_ab.xml"


### PR DESCRIPTION
1. Add Jetpack 6 support for board `jetson-orin-nano-devkit-nvme`.
2. Fix typo in partition 17's name in layout file `flash_l4t_t234_nvme_rootfs_ab.xml`.