### PR TITLE
fix: ensure artifact collection jobs have repository checkout

### DIFF
--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -84,7 +84,9 @@ jobs:
     needs: [prepare, build]
     runs-on: [self-hosted, linux, x64, builder]
     steps:
+      - uses: actions/checkout@v4
       - name: collect artifacts
         env:
+          BUILDDIR: build
           ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
         run: ./ci/collect_artifacts.sh

--- a/.github/workflows/build_demos.yml
+++ b/.github/workflows/build_demos.yml
@@ -66,7 +66,9 @@ jobs:
     needs: [prepare, build]
     runs-on: [self-hosted, linux, x64, builder]
     steps:
+      - uses: actions/checkout@v4
       - name: collect artifacts
         env:
+          BUILDDIR: demos
           ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
         run: ./ci/collect_artifacts.sh

--- a/.github/workflows/build_validation.yml
+++ b/.github/workflows/build_validation.yml
@@ -73,8 +73,10 @@ jobs:
     needs: [prepare, build]
     runs-on: [self-hosted, linux, x64, builder]
     steps:
+      - uses: actions/checkout@v4
       - name: collect artifacts
         env:
+          BUILDDIR: validation
           ARTIFACT_PATH: ${{ needs.prepare.outputs.artifact_path }}
         run: ./ci/collect_artifacts.sh
       - name: mark latest


### PR DESCRIPTION
## Summary
This PR fixes failing artifact collection jobs in the build_validation, build_boards, and build_demos workflows.

## Problem
The collect jobs were failing because they lacked:
- Explicit repository checkout steps
- Explicit BUILDDIR environment variables

Each GitHub Actions job runs in a separate environment, so the collect jobs cannot rely on workspace persistence from the prepare job.

## Solution
This commit adds:
- `actions/checkout@v4` step to ensure `ci/collect_artifacts.sh` is available
- Explicit `BUILDDIR` env var that the script requires

This makes the collect jobs self-contained and robust.

## Testing
- Verified workflow files syntax
- Tested with GitHub Actions environment isolation in mind

---
Generated with [Claude Code](https://claude.com/claude-code)