### PR TITLE
chore: fix TI builds including base version bumps

### DIFF
--- a/.github/workflows/build_boards.yml
+++ b/.github/workflows/build_boards.yml
@@ -25,7 +25,7 @@ jobs:
         board: [
           beaglebone,
           beaglebone-ai64,
-          beagleplay,
+          beagleplay-ti,
           raspberrypi,
           raspberrypi-cm,
           raspberrypi0,

--- a/kas/beaglebone-ai64.yml
+++ b/kas/beaglebone-ai64.yml
@@ -7,6 +7,11 @@ header:
 
 machine: beaglebone-ai64
 
+repos:
+  meta-ti:
+    layers:
+      meta-beagle:
+
 local_conf_header:
   beagleplay: |
     MENDER_FEATURES_ENABLE:append = " mender-image-sd"

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -6,13 +6,13 @@ distro: poky
 repos:
   openembedded-core:
     url: git://git.openembedded.org/openembedded-core.git
-    commit: baa5e7ea5f37f54c2a00080798ad7fb4c0664f69
+    commit: 95888aa944847cf6dbfac501997a3e2980344b66
     layers:
       meta:
 
   bitbake:
     url: git://git.openembedded.org/bitbake.git
-    commit: 1c9ec1ffde75809de34c10d3ec2b40d84d258cb4
+    commit: b00f85cf00dd3a5c1858b409b831194edf148659
     layers:
       bitbake: excluded
 
@@ -25,13 +25,13 @@ repos:
 
   meta-openembedded:
     url: git://git.openembedded.org/meta-openembedded
-    commit: e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943
+    commit: e621da947048842109db1b4fd3917a02e0501aa2
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 52b332b61d26c97b8e6cc1badb80db0bb6a1666b
+    commit: 4ae8e962a3c011cfc4d9e4b85878c226b2763b0c
 
     layers:
       meta-mender-core:

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -4,6 +4,6 @@ header:
 repos:
   meta-ti:
     url: https://git.yoctoproject.org/meta-ti
-    commit: d62c047d4b8424603c6996a5755cf7004bd13254
+    commit: cd2b3b89819ea58115e6be9213795fab0848298e
     layers:
       meta-ti-bsp:


### PR DESCRIPTION
The `meta-ti` layer did change its structure to introduce the additional `meta-beagle`-layer.

Bump the base layers for compatibility and adjust `beaglebone-ai64` build configuration accordingly.