### PR TITLE
feat: map layer revision by commit name and hash

### DIFF
--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -31,8 +31,8 @@ repos:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 4ae8e962a3c011cfc4d9e4b85878c226b2763b0c
-
+    tag: scarthgap-v2025.09
+    commit: 33fa9ff0f5cfa7ac31eebe66801f6961783931dc
     layers:
       meta-mender-core:
 


### PR DESCRIPTION
It's hard do track what meta-mender release the layer is pointing to. Just a commit is arbitrary and can represent a state outside of a release.

In case there is a conflict between a tag and a commit because upstream modified tags, kas will print an error:

```
2025-11-06 12:36:13 - ERROR    - Provided tag "scarthgap-v2025.09" ("33fa9ff0f5cfa7ac31eebe66801f6961783931dc") does not match provided commit "33fa9ff0f5cfa7ac31eebe66801f6961783931d" in repository "meta-mender", aborting!
```
