### PR TITLE
chore: kas: replace "excluded" with "disabled"

### DIFF
--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -14,7 +14,7 @@ repos:
     url: git://git.openembedded.org/bitbake.git
     commit: b00f85cf00dd3a5c1858b409b831194edf148659
     layers:
-      bitbake: excluded
+      bitbake: disabled
 
   meta-yocto:
     url: git://git.yoctoproject.org/git/meta-yocto.git


### PR DESCRIPTION
The bitbake checkout should not be treated as a layer. The kas configuration format deprecated the "excluded" flag, update to "disabled" accordingly.

Changelog: Title
Ticket: None