### PR TITLE
Fixed Raspberry Pi patches for current Scarthgap release (5.0.13)

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-configs-rpi-enable-mender-requirements.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-configs-rpi-enable-mender-requirements.patch
@@ -1,6 +1,6 @@
-From 986e13859a26952597b1e5cd479522949ca04938 Mon Sep 17 00:00:00 2001
-From: Josef Holzmayr <jester@theyoctojester.info>
-Date: Wed, 26 Jul 2023 10:53:51 +0200
+From 98f539e2dc4ed6abbf5e0b92a1886b9b598a7ace Mon Sep 17 00:00:00 2001
+From: Tom van Dijk <t.vandijk@alflex.nl>
+Date: Mon, 24 Nov 2025 15:51:29 +0100
 Subject: [PATCH] configs: rpi: enable mender requirements
 
 Which are CONFIG_BOOTCOUNT_ENV and CONFIG_BOOTCOUNT_LIMIT.
@@ -9,14 +9,6 @@ Mender also requires that the environment is on MMC
 (CONFIG_ENV_IS_IN_MMC)
 
 Upstream-Status: Inappropriate
-Signed-off-by: Mirza Krak <mirza.krak@gmail.com>
-Signed-off-by: Drew Moseley <drew.moseley@northern.tech>
-Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
-
-This patch is a refresh.
-
-Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
-Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
 ---
  configs/rpi_0_w_defconfig      | 5 ++++-
  configs/rpi_2_defconfig        | 5 ++++-
@@ -32,53 +24,33 @@ Signed-off-by: Leon Anavi <leon.anavi@konsulko.com>
  11 files changed, 41 insertions(+), 10 deletions(-)
 
 diff --git a/configs/rpi_0_w_defconfig b/configs/rpi_0_w_defconfig
-index 8d29d991606..ec1922a19cd 100644
+index ac3b40c1c10..390477e36a7 100644
 --- a/configs/rpi_0_w_defconfig
 +++ b/configs/rpi_0_w_defconfig
-@@ -25,7 +25,6 @@ CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
+@@ -25,7 +25,6 @@ CONFIG_CMD_MMC=y
  CONFIG_CMD_USB=y
  CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
 -CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_TFTP_TSIZE=y
-@@ -49,3 +48,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
- CONFIG_VIDEO_BCM2835=y
+@@ -50,3 +49,7 @@ CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
+ CONFIG_EFI_LOADER=y
 +CONFIG_ENV_IS_IN_MMC=y
 +CONFIG_ENV_OFFSET=0x800000
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 diff --git a/configs/rpi_2_defconfig b/configs/rpi_2_defconfig
-index 1b8676e1d10..63b9c60de58 100644
+index b6e06cfe20b..9375b8df6de 100644
 --- a/configs/rpi_2_defconfig
 +++ b/configs/rpi_2_defconfig
-@@ -25,7 +25,6 @@ CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
+@@ -26,7 +26,6 @@ CONFIG_CMD_MMC=y
  CONFIG_CMD_USB=y
  CONFIG_CMD_FS_UUID=y
--CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
- CONFIG_SYS_RELOC_GD_ENV_ADDR=y
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_TFTP_TSIZE=y
-@@ -49,3 +48,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
- CONFIG_VIDEO_BCM2835=y
- CONFIG_CONSOLE_SCROLL_LINES=10
- CONFIG_PHYS_TO_BUS=y
-+CONFIG_ENV_IS_IN_MMC=y
-+CONFIG_ENV_OFFSET=0x800000
-+CONFIG_ENV_OFFSET_REDUND=0x1000000
-+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
-index abc10a79ada..37f5083c6fb 100644
---- a/configs/rpi_3_32b_defconfig
-+++ b/configs/rpi_3_32b_defconfig
-@@ -24,7 +24,6 @@ CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
- CONFIG_CMD_USB=y
- CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
 -CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
@@ -91,48 +63,68 @@ index abc10a79ada..37f5083c6fb 100644
 +CONFIG_ENV_OFFSET=0x800000
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-diff --git a/configs/rpi_3_b_plus_defconfig b/configs/rpi_3_b_plus_defconfig
-index b05a9193666..7142d3bc8b3 100644
---- a/configs/rpi_3_b_plus_defconfig
-+++ b/configs/rpi_3_b_plus_defconfig
-@@ -27,7 +27,6 @@ CONFIG_CMD_MMC=y
+diff --git a/configs/rpi_3_32b_defconfig b/configs/rpi_3_32b_defconfig
+index eadc4189272..d9883507df9 100644
+--- a/configs/rpi_3_32b_defconfig
++++ b/configs/rpi_3_32b_defconfig
+@@ -25,7 +25,6 @@ CONFIG_CMD_MMC=y
  CONFIG_CMD_USB=y
- CONFIG_CMD_EFIDEBUG=y
  CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
 -CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_TFTP_TSIZE=y
-@@ -57,3 +56,7 @@ CONFIG_VIDEO_BCM2835=y
+@@ -51,3 +50,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
- # CONFIG_HEXDUMP is not set
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_OFFSET=0x800000
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+diff --git a/configs/rpi_3_b_plus_defconfig b/configs/rpi_3_b_plus_defconfig
+index 0e2faeec64e..59805918c33 100644
+--- a/configs/rpi_3_b_plus_defconfig
++++ b/configs/rpi_3_b_plus_defconfig
+@@ -24,7 +24,6 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
+-CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_TFTP_TSIZE=y
+@@ -50,3 +49,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
 +CONFIG_ENV_IS_IN_MMC=y
 +CONFIG_ENV_OFFSET=0x800000
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 diff --git a/configs/rpi_3_defconfig b/configs/rpi_3_defconfig
-index 267e4978e6e..8be4fa9706b 100644
+index 6890af4d1d2..3baabdab458 100644
 --- a/configs/rpi_3_defconfig
 +++ b/configs/rpi_3_defconfig
-@@ -27,7 +27,6 @@ CONFIG_CMD_MMC=y
+@@ -24,7 +24,6 @@ CONFIG_CMD_MMC=y
  CONFIG_CMD_USB=y
- CONFIG_CMD_EFIDEBUG=y
  CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
 -CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_TFTP_TSIZE=y
-@@ -57,3 +56,7 @@ CONFIG_VIDEO_BCM2835=y
+@@ -50,3 +49,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
- # CONFIG_HEXDUMP is not set
 +CONFIG_ENV_IS_IN_MMC=y
 +CONFIG_ENV_OFFSET=0x800000
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 diff --git a/configs/rpi_4_32b_defconfig b/configs/rpi_4_32b_defconfig
-index fc58ea1fa65..d0f4dbdb907 100644
+index 734335cbf04..786b88127fe 100644
 --- a/configs/rpi_4_32b_defconfig
 +++ b/configs/rpi_4_32b_defconfig
 @@ -26,7 +26,6 @@ CONFIG_CMD_MMC=y
@@ -152,58 +144,18 @@ index fc58ea1fa65..d0f4dbdb907 100644
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 diff --git a/configs/rpi_4_defconfig b/configs/rpi_4_defconfig
-index 993b79703b7..18ce6bda136 100644
+index 2541b83a3df..0fc07882bd6 100644
 --- a/configs/rpi_4_defconfig
 +++ b/configs/rpi_4_defconfig
-@@ -30,7 +30,6 @@ CONFIG_CMD_PCI=y
- CONFIG_CMD_USB=y
- CONFIG_CMD_EFIDEBUG=y
- CONFIG_CMD_FS_UUID=y
--CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
- CONFIG_SYS_RELOC_GD_ENV_ADDR=y
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_TFTP_TSIZE=y
-@@ -70,3 +69,7 @@ CONFIG_VIDEO_BCM2835=y
- CONFIG_CONSOLE_SCROLL_LINES=10
- CONFIG_PHYS_TO_BUS=y
- # CONFIG_HEXDUMP is not set
-+CONFIG_ENV_IS_IN_MMC=y
-+CONFIG_ENV_OFFSET=0x800000
-+CONFIG_ENV_OFFSET_REDUND=0x1000000
-+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
-index 9fe5d177943..2710613d072 100644
---- a/configs/rpi_arm64_defconfig
-+++ b/configs/rpi_arm64_defconfig
-@@ -27,7 +27,6 @@ CONFIG_CMD_PCI=y
- CONFIG_CMD_USB=y
- CONFIG_CMD_EFIDEBUG=y
- CONFIG_CMD_FS_UUID=y
--CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
- CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
- CONFIG_TFTP_TSIZE=y
- CONFIG_DM_DMA=y
-@@ -64,3 +63,7 @@ CONFIG_VIDEO_BCM2835=y
- CONFIG_CONSOLE_SCROLL_LINES=10
- CONFIG_PHYS_TO_BUS=y
- # CONFIG_HEXDUMP is not set
-+CONFIG_ENV_IS_IN_MMC=y
-+CONFIG_ENV_OFFSET=0x800000
-+CONFIG_ENV_OFFSET_REDUND=0x1000000
-+CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
-diff --git a/configs/rpi_defconfig b/configs/rpi_defconfig
-index 64e6df41d83..878941695e8 100644
---- a/configs/rpi_defconfig
-+++ b/configs/rpi_defconfig
-@@ -25,7 +25,6 @@ CONFIG_CMD_GPIO=y
- CONFIG_CMD_MMC=y
+@@ -26,7 +26,6 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
  CONFIG_CMD_USB=y
  CONFIG_CMD_FS_UUID=y
 -CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
  CONFIG_SYS_RELOC_GD_ENV_ADDR=y
  CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
  CONFIG_TFTP_TSIZE=y
-@@ -49,3 +48,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+@@ -65,3 +64,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
  CONFIG_VIDEO_BCM2835=y
  CONFIG_CONSOLE_SCROLL_LINES=10
  CONFIG_PHYS_TO_BUS=y
@@ -211,11 +163,51 @@ index 64e6df41d83..878941695e8 100644
 +CONFIG_ENV_OFFSET=0x800000
 +CONFIG_ENV_OFFSET_REDUND=0x1000000
 +CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
+index f9dade18f6a..d267cd7c87d 100644
+--- a/configs/rpi_arm64_defconfig
++++ b/configs/rpi_arm64_defconfig
+@@ -25,7 +25,6 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_PCI=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+-CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_TFTP_TSIZE=y
+ CONFIG_DM_DMA=y
+@@ -57,3 +56,7 @@ CONFIG_SYS_WHITE_ON_BLACK=y
+ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_OFFSET=0x800000
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+diff --git a/configs/rpi_defconfig b/configs/rpi_defconfig
+index 29c10060cf7..b5a1b9dac48 100644
+--- a/configs/rpi_defconfig
++++ b/configs/rpi_defconfig
+@@ -25,7 +25,6 @@ CONFIG_CMD_MMC=y
+ CONFIG_CMD_USB=y
+ CONFIG_CMD_FS_UUID=y
+ CONFIG_OF_EMBED=y
+-CONFIG_ENV_FAT_DEVICE_AND_PART="0:1"
+ CONFIG_SYS_RELOC_GD_ENV_ADDR=y
+ CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
+ CONFIG_TFTP_TSIZE=y
+@@ -50,3 +49,7 @@ CONFIG_VIDEO_BCM2835=y
+ CONFIG_CONSOLE_SCROLL_LINES=10
+ CONFIG_PHYS_TO_BUS=y
+ CONFIG_EFI_LOADER=y
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_ENV_OFFSET=0x800000
++CONFIG_ENV_OFFSET_REDUND=0x1000000
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
 diff --git a/env/Kconfig b/env/Kconfig
-index 4438f0b392c..53b37d094dc 100644
+index f5f09692332..68d7569755d 100644
 --- a/env/Kconfig
 +++ b/env/Kconfig
-@@ -109,7 +109,6 @@ config ENV_IS_IN_EEPROM
+@@ -96,7 +96,6 @@ config ENV_IS_IN_EEPROM
  config ENV_IS_IN_FAT
  	bool "Environment is in a FAT filesystem"
  	depends on !CHAIN_OF_TRUST
@@ -237,6 +229,3 @@ index 8e56bdc84a8..62726d84609 100644
 +#define CONFIG_BOOTCOUNT_LIMIT
 +
  #endif
--- 
-2.44.3
-

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch
@@ -10,6 +10,8 @@ Setting bootdelay to -2 prevents u-boot from stopping on the serial
 console.
 
 Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
+
+Upstream-Status: Inappropriate [Mender specific]
 ---
  configs/rpi_arm64_defconfig | 1 +
  1 file changed, 1 insertion(+)

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0002-Integration-of-Mender-boot-code-into-U-Boot.patch
@@ -18,7 +18,7 @@ diff --git a/include/env_default.h b/include/env_default.h
 index aa3dd40f3fa..ecb48f79a3b 100644
 --- a/include/env_default.h
 +++ b/include/env_default.h
-@@ -13,6 +13,8 @@
+@@ -12,6 +12,8 @@
  
  #include <generated/environment.h>
  
@@ -27,7 +27,7 @@ index aa3dd40f3fa..ecb48f79a3b 100644
  #ifdef DEFAULT_ENV_INSTANCE_EMBEDDED
  env_t embedded_environment __UBOOT_ENV_SECTION__(environment) = {
  	ENV_CRC,	/* CRC Sum */
-@@ -27,6 +29,7 @@ char default_environment[] = {
+@@ -26,6 +28,7 @@ char default_environment[] = {
  #else
  const char default_environment[] = {
  #endif
@@ -40,7 +40,7 @@ index c1eab2f3a1d..646374f7800 100644
 --- a/scripts/Makefile.autoconf
 +++ b/scripts/Makefile.autoconf
 @@ -116,7 +116,8 @@ define filechk_config_h
- 	$(if $(CONFIG_SYS_CONFIG_NAME),echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\> ;) \
+	echo \#include \<configs/$(CONFIG_SYS_CONFIG_NAME).h\>;		\
  	echo \#include \<asm/config.h\>;				\
  	echo \#include \<linux/kconfig.h\>;				\
 -	echo \#include \<config_fallbacks.h\>;)


### PR DESCRIPTION
Due to some changes to unrelated upstream U-Boot configuration, the Raspberry Pi U-Boot patches did not apply cleanly anymore. This prevents a build from completing successfully.

The fix basically consists of manually applying the offending patches and regenerating the patch files in question.