### PR TITLE
Fix: patch append for more target certainty

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/patches/0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch
@@ -1,6 +1,6 @@
-From ff1478653fca993f473c36a37ab20614b71fb34c Mon Sep 17 00:00:00 2001
-From: Josef Holzmayr <jester@theyoctojester.info>
-Date: Wed, 10 Sep 2025 07:59:11 +0000
+From c00463d256729f1dcd2d9a5c43dde2e4eb4de129 Mon Sep 17 00:00:00 2001
+From: Levi Shafter <lshafter@21sw.us>
+Date: Fri, 23 Jan 2026 11:53:08 -0700
 Subject: [PATCH] fix: disable bootdelay/keypress detection on Pi5-family
 
 The Raspberry Pi 5 and Compute Module 5 seem to receive spurious
@@ -9,20 +9,22 @@ characters on the debug UART which interrupts the boot process.
 Setting bootdelay to -2 prevents u-boot from stopping on the serial
 console.
 
-Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
+This is set at the top so as not to conflict with mender-specific
+U-Boot RPi configuration patches
+
+Modification of https://github.com/mendersoftware/meta-mender-community/commit/e3d4f8f555c937d370214dfd6828a65876ab3e89
+
+Signed-off-by: Levi Shafter <lshafter@21sw.us>
 ---
  configs/rpi_arm64_defconfig | 1 +
  1 file changed, 1 insertion(+)
 
 diff --git a/configs/rpi_arm64_defconfig b/configs/rpi_arm64_defconfig
-index 2710613d072..3082988d60d 100644
+index 9fe5d177943..9a380847e4a 100644
 --- a/configs/rpi_arm64_defconfig
 +++ b/configs/rpi_arm64_defconfig
-@@ -67,3 +67,4 @@ CONFIG_ENV_IS_IN_MMC=y
- CONFIG_ENV_OFFSET=0x800000
- CONFIG_ENV_OFFSET_REDUND=0x1000000
- CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
+@@ -1,3 +1,4 @@
 +CONFIG_BOOTDELAY=-2
--- 
-2.34.1
-
+ CONFIG_ARM=y
+ CONFIG_POSITION_INDEPENDENT=y
+ CONFIG_ARCH_BCM283X=y

--- a/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-mender-raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,3 +1,3 @@
 require u-boot-raspberrypi.inc
 
-SRC_URI:append = " file://0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch"
+SRC_URI:append:rpi = " file://0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch"


### PR DESCRIPTION
Sponsored by 21SoftWare

My team and I make use of the `meta-mender-raspberrypi` layer, but we noticed that RPi-specific patches were still being searched for when the target was not an RPi:

```
meta-lts-mixins/recipes-bsp/u-boot/u-boot_2025.04.bb: Unable to get checksum for u-boot SRC_URI entry 0001-fix-disable-bootdelay-keypress-detection-on-Pi5-fami.patch: file could not be found
```

This commit appends the patch while guarded by machine-specific syntax, in line with how other patches are appended. This adds certainty and prevents the error detailed above.