### PR TITLE
Broadens the application of the NVMe rootfs AB partition layout.

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI:append:p3768-0000-p3767-0000 = " \
+SRC_URI:append:tegra234 = " \
     file://flash_l4t_t234_nvme_rootfs_ab.xml \
 "
 
-PARTITION_FILE_EXTERNAL:p3768-0000-p3767-0000 = "${WORKDIR}/flash_l4t_t234_nvme_rootfs_ab.xml"
+PARTITION_FILE_EXTERNAL:tegra234 = "${WORKDIR}/flash_l4t_t234_nvme_rootfs_ab.xml"


### PR DESCRIPTION
Ensures all Orin-based devices (T234) use the common NVMe-based flash layout for Mender A/B support.