### PR TITLE
kas: bump repository revisions to latest upstream

### DIFF
--- a/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
+++ b/kas/demos/raspberrypi4-64-mender-explicit-wic.yml
@@ -7,7 +7,8 @@ distro: poky
 repos:
   poky:
     url: git://git.yoctoproject.org/poky
-    commit: c162696dae5798e2ab1198403d0bc1d65d64068d
+    # yocto-5.0.15
+    commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
     layers:
       meta:
       meta-poky:
@@ -15,19 +16,22 @@ repos:
 
   meta-openembedded:
     url: git://git.openembedded.org/meta-openembedded
-    commit: e92d0173a80ea7592c866618ef5293203c50544c
+    # branch: scarthgap
+    commit: ec0469748be4159fb83fb0fa0148d786484c88cf
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 0d393c2267a92091f975eb932338c07109f5f5fd
+    # scarthgap-v2025.11
+    commit: 00d4dfc36625a27ca0d6ad7aa33eeeab397281a9
     layers:
       meta-mender-core:
 
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+    # branch: scarthgap
+    commit: 2c646d29912dcc873469a57b1c207e1549c5094d
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins

--- a/kas/demos/raspberrypi4-64-tpm.yml
+++ b/kas/demos/raspberrypi4-64-tpm.yml
@@ -17,7 +17,8 @@ repos:
 
   meta-security:
     url: git://git.yoctoproject.org/meta-security.git
-    commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
+    # branch: scarthgap
+    commit: 97e482b71688b62ac1109d16e89368122f039cbf
     layers:
       meta-tpm:
 

--- a/kas/include/arm.yml
+++ b/kas/include/arm.yml
@@ -4,7 +4,8 @@ header:
 repos:
   meta-arm:
     url: https://git.yoctoproject.org/meta-arm
-    commit: 8e0f8af90fefb03f08cd2228cde7a89902a6b37c
+    # yocto-5.0.3
+    commit: a81c19915b5b9e71ed394032e9a50fd06919e1cd
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -6,32 +6,37 @@ distro: poky
 repos:
   openembedded-core:
     url: git://git.openembedded.org/openembedded-core.git
-    commit: 95888aa944847cf6dbfac501997a3e2980344b66
+    # yocto-5.0.15
+    commit: 6988157ad983978ffd6b12bcefedd4deaffdbbd1
     layers:
       meta:
 
   bitbake:
     url: git://git.openembedded.org/bitbake.git
-    commit: b00f85cf00dd3a5c1858b409b831194edf148659
+    # yocto-5.0.15
+    commit: 8dcf084522b9c66a6639b5f117f554fde9b6b45a
     layers:
       bitbake: disabled
 
   meta-yocto:
     url: git://git.yoctoproject.org/git/meta-yocto.git
-    commit: 82602cda1a89644d1acbe230a81c93e3fb5031c8
+    # yocto-5.0.15
+    commit: 9bb6e6e8b016a0c9dfe290369a6ed91ef4020535
     layers:
       meta-poky:
       meta-yocto-bsp:
 
   meta-openembedded:
     url: git://git.openembedded.org/meta-openembedded
-    commit: e621da947048842109db1b4fd3917a02e0501aa2
+    # branch: scarthgap
+    commit: ec0469748be4159fb83fb0fa0148d786484c88cf
     layers:
       meta-oe:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    commit: 4ae8e962a3c011cfc4d9e4b85878c226b2763b0c
+    # scarthgap-v2025.11
+    commit: 00d4dfc36625a27ca0d6ad7aa33eeeab397281a9
 
     layers:
       meta-mender-core:

--- a/kas/include/nxp.yml
+++ b/kas/include/nxp.yml
@@ -5,7 +5,7 @@ repos:
   meta-freescale:
     url: https://github.com/Freescale/meta-freescale.git
     # branch: scarthgap
-    commit: f52fe2b709e70d1d864adfad2754213bce7abcd7
+    commit: 902dde8c5bd29bb507ac8d37772565a6c9ab77cd
   meta-freescale-3rdparty:
     url: https://github.com/Freescale/meta-freescale-3rdparty.git
     # branch: scarthgap

--- a/kas/include/raspberrypi.yml
+++ b/kas/include/raspberrypi.yml
@@ -4,7 +4,8 @@ header:
 repos:
   meta-raspberrypi:
     url: https://github.com/agherzan/meta-raspberrypi.git
-    commit: 1091bde25e9ebaea33114edb85e4aee931d105f3
+    # branch: scarthgap
+    commit: 2c646d29912dcc873469a57b1c207e1549c5094d
 
   meta-lts-mixins:
     url: https://git.yoctoproject.org/meta-lts-mixins

--- a/kas/include/rockchip.yml
+++ b/kas/include/rockchip.yml
@@ -4,7 +4,8 @@ header:
 repos:
   meta-rockchip:
     url: https://git.yoctoproject.org/meta-rockchip
-    commit: 63a3d6fa336318dffb3e5bb913bc239026ae9015
+    # branch: scarthgap
+    commit: 9690180b7e9953361958c962b80d891eda8c1028
 
   meta-mender-community:
     layers:

--- a/kas/include/sulka.yml
+++ b/kas/include/sulka.yml
@@ -6,7 +6,8 @@ distro: sulka
 repos:
   meta-sulka-distro:
     url: https://codeberg.org/AltidSec/meta-sulka-distro.git
-    commit: 64c1f5c0d484bd201e7f2f617040e2c5973d17cb
+    # branch: scarthgap
+    commit: e988c135e7eaf1c7a202697342e90da5b8fa5234
 
   meta-openembedded:
     layers:
@@ -15,7 +16,8 @@ repos:
 
   meta-security:
     url: git://git.yoctoproject.org/meta-security.git
-    commit: bc865c5276c2ab4031229916e8d7c20148dfbac3
+    # branch: scarthgap
+    commit: 97e482b71688b62ac1109d16e89368122f039cbf
 
 local_conf_header:
   sulka: |

--- a/kas/include/tegra-base.yml
+++ b/kas/include/tegra-base.yml
@@ -2,9 +2,6 @@ header:
   version: 14
 
 repos:
-  meta-mender:
-    commit: 2f70dbad1441055c299332b7ef33dfe1e4f50c1c # this one fixes the persistent-id for now!
-  
   meta-tegra:
     url: https://github.com/OE4T/meta-tegra.git
   meta-tegra-community:
@@ -24,7 +21,8 @@ repos:
 
   meta-virtualization:
     url: https://git.yoctoproject.org/meta-virtualization.git
-    commit: 6a80f140e387621f62964209a2e07d3bcfb125ce
+    # branch: scarthgap
+    commit: 8b1543e121deda2445f80f74d85c10316d5b31f4
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack5.yml
+++ b/kas/include/tegra-jetpack5.yml
@@ -7,13 +7,13 @@ header:
 repos:
   meta-tegra:
     # refers to the scarthgap-l4t-r35.x branch
-    commit: e836736de0a439c8893ede4cef6973bd6347affa
+    commit: a6be5231c53bf21136f04cf7f4ac641de27ed5be
   meta-tegra-community:
     # refers to the scarthgap-l4t-r35.x branch
-    commit: c03675e45fa229a4c067f5bd2e8461b713d789f4
+    commit: 4d4630b087e731b7eacc6e70528956ea8bcb9fef
   meta-tegrademo:
     # refers to the scarthgap-l4t-r35.x branch
-    commit: a9132a76ae8f35a962e5970fdd422fa0c2fc6fc1
+    commit: 65f9a50499ce07f2882eb5d0aab3faf010b848de
 
   meta-mender-community:
     layers:

--- a/kas/include/tegra-jetpack6.yml
+++ b/kas/include/tegra-jetpack6.yml
@@ -7,13 +7,13 @@ header:
 repos:
   meta-tegra:
     # refers to the scarthgap branch
-    commit: 8f9748b0178a4d93bceffd86d9d436cd0e685750
+    commit: 447c21467f65be2389f68a189b6871f13729d222
   meta-tegra-community:
     # refers to the scarthgap branch
     commit: 241d1073ba8e610ef8da3fe8470b0a4d0567521f
   meta-tegrademo:
     # refers to the scarthgap branch
-    commit: 3f2641444d6c50c3fa4eea8a4c770bd30db70ee9
+    commit: f3a42d04fef1f0448f2ee504e99ab565ef5e7285
 
   meta-mender-community:
     layers:

--- a/kas/include/ti.yml
+++ b/kas/include/ti.yml
@@ -4,6 +4,7 @@ header:
 repos:
   meta-ti:
     url: https://git.yoctoproject.org/meta-ti
-    commit: cd2b3b89819ea58115e6be9213795fab0848298e
+    # 10.01.10
+    commit: 50acaea23568f72121020a97bf13869770929cb7
     layers:
       meta-ti-bsp:


### PR DESCRIPTION
Update pinned commit SHAs across all kas configuration files:

- openembedded-core, bitbake, meta-yocto: yocto-5.0.15
- meta-mender: scarthgap-v2025.11
- meta-openembedded, meta-raspberrypi, meta-rockchip, meta-freescale, meta-security, meta-virtualization: scarthgap HEAD
- meta-arm: yocto-5.0.3
- meta-ti: 10.01.10
- meta-tegra, meta-tegra-community, meta-tegrademo: latest per branch
- meta-sulka-distro: scarthgap HEAD
- poky (explicit-wic demo): yocto-5.0.15

Also remove the meta-mender commit override in tegra-base.yml, as the persistent-id fix is now included in the base scarthgap-v2025.11 pin.