### PR TITLE
feat: Raspberry Pi tryboot A/B support

### DIFF
--- a/kas/include/raspberrypi-tryboot.yml
+++ b/kas/include/raspberrypi-tryboot.yml
@@ -32,6 +32,12 @@ local_conf_header:
     MENDER_ROOTFS_PART_B = "/dev/mmcblk0p6"
     MENDER_DATA_PART = "/dev/mmcblk0p7"
 
+    # Suppress Mender's default /boot/efi fstab entry — the tryboot WKS has
+    # its own partition layout (p1=tryboot, p2=bootA, p3=bootB) and wic
+    # generates the correct fstab entries from the WKS mountpoints.
+    MENDER_BOOT_PART_SIZE_MB = "0"
+    MENDER_BOOT_PART = ""
+
     # Boot files in rootfs for the update module to extract
     IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
     IMAGE_INSTALL:append = " rpi-tryboot-rootfs data-partition wait-for-clock"

--- a/kas/include/raspberrypi-tryboot.yml
+++ b/kas/include/raspberrypi-tryboot.yml
@@ -1,0 +1,37 @@
+header:
+  version: 14
+  includes:
+  - kas/include/mender-base.yml
+
+repos:
+  meta-raspberrypi:
+    url: https://github.com/agherzan/meta-raspberrypi.git
+    # branch: scarthgap
+    commit: 2c646d29912dcc873469a57b1c207e1549c5094d
+
+  meta-mender-community:
+    layers:
+      meta-mender-raspberrypi-tryboot:
+
+local_conf_header:
+  raspberrypi-tryboot: |
+    # Tryboot: native RPi firmware A/B, no U-Boot
+    RPI_USE_U_BOOT = "0"
+    ENABLE_UART = "1"
+    IMAGE_FSTYPES = "wic ext4"
+    WKS_FILE = "sdimage-rpi-mender-tryboot.wks"
+
+    # Mender client without bootloader integration
+    # tryboot-cmdline post-processes the WIC to set per-partition root= in cmdline.txt
+    INHERIT += "mender-setup tryboot-cmdline"
+    MENDER_FEATURES_ENABLE:append = " mender-auth-install mender-update-install mender-systemd"
+
+    # Partition layout (7-partition tryboot WKS)
+    MENDER_STORAGE_DEVICE = "/dev/mmcblk0"
+    MENDER_ROOTFS_PART_A = "/dev/mmcblk0p5"
+    MENDER_ROOTFS_PART_B = "/dev/mmcblk0p6"
+    MENDER_DATA_PART = "/dev/mmcblk0p7"
+
+    # Boot files in rootfs for the update module to extract
+    IMAGE_INSTALL:append = " kernel-image kernel-devicetree"
+    IMAGE_INSTALL:append = " rpi-tryboot-rootfs data-partition wait-for-clock"

--- a/kas/include/validation-tryboot.yml
+++ b/kas/include/validation-tryboot.yml
@@ -1,0 +1,15 @@
+header:
+  version: 14
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-validation:
+
+local_conf_header:
+  validation-tryboot: |
+    IMAGE_INSTALL:append = " bootloader-validation"
+    MENDER_FEATURES_DISABLE:append = " mender-growfs-data"
+
+target:
+  - mender-validation-image

--- a/kas/raspberrypi4-64-tryboot.yml
+++ b/kas/raspberrypi4-64-tryboot.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+  includes:
+  - kas/include/raspberrypi-tryboot.yml
+
+machine: raspberrypi4-64

--- a/kas/raspberrypi5-tryboot.yml
+++ b/kas/raspberrypi5-tryboot.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+  includes:
+  - kas/include/raspberrypi-tryboot.yml
+
+machine: raspberrypi5

--- a/meta-mender-raspberrypi-tryboot/LICENSE
+++ b/meta-mender-raspberrypi-tryboot/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Northern.tech AS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/meta-mender-raspberrypi-tryboot/README
+++ b/meta-mender-raspberrypi-tryboot/README
@@ -1,0 +1,60 @@
+This README file contains information on the contents of the meta-mender-raspberrypi-tryboot layer.
+
+Please see the corresponding sections below for details.
+
+Dependencies
+============
+
+  URI: https://git.yoctoproject.org/poky
+  branch: scarthgap
+
+  URI: https://git.openembedded.org/meta-openembedded
+  branch: scarthgap
+
+  URI: https://github.com/agherzan/meta-raspberrypi
+  branch: scarthgap
+
+  URI: https://github.com/mendersoftware/meta-mender
+  branch: scarthgap
+
+Contributions
+=============
+
+Please the README file in the top level directory.
+
+Table of Contents
+=================
+
+  I. Adding the meta-mender-raspberrypi-tryboot layer to your build
+ II. Misc
+
+
+I. Adding the meta-mender-raspberrypi-tryboot layer to your build
+=================================================================
+
+Run 'bitbake-layers add-layer meta-mender-raspberrypi-tryboot'
+
+II. Misc
+========
+
+This layer provides Mender OTA update support for Raspberry Pi using the native
+RPi firmware tryboot A/B mechanism instead of U-Boot. It is mutually exclusive
+with meta-mender-raspberrypi — include one or the other, not both.
+
+Supported hardware: Raspberry Pi 4 (64-bit), Raspberry Pi 5
+
+The tryboot mechanism uses a 7-partition MBR layout. MBR supports at most
+4 primary partitions, so the three boot partitions occupy primary slots 1-3,
+and primary slot 4 holds an extended partition that contains the remaining
+three as logical partitions (numbered 5+):
+
+  p1 = tryboot   (FAT, autoboot.txt with A/B switching logic)
+  p2 = bootA     (FAT, kernel + DTBs + firmware for slot A)
+  p3 = bootB     (FAT, kernel + DTBs + firmware for slot B)
+  p4 = extended  (container for the logical partitions below)
+  p5 = rootA     (ext4, root filesystem for slot A)
+  p6 = rootB     (ext4, root filesystem for slot B)
+  p7 = data      (ext4, persistent Mender state and configuration)
+
+A custom update module (rpi-tryboot-rootfs) handles full system updates
+including rootfs and boot partition contents.

--- a/meta-mender-raspberrypi-tryboot/classes/tryboot-cmdline.bbclass
+++ b/meta-mender-raspberrypi-tryboot/classes/tryboot-cmdline.bbclass
@@ -1,0 +1,68 @@
+# Post-process WIC image to set per-boot-partition cmdline.txt root= values.
+# bootA (p2) -> root=/dev/mmcblk0p5 (rootA)
+# bootB (p3) -> root=/dev/mmcblk0p6 (rootB)
+#
+# Adapted from meta-raspberrypi-tryboot (Koch-AG, tryboot-4 branch)
+
+
+def get_wic_image(d):
+    import os
+
+    work_dir = d.getVar("WORKDIR")
+    image_link_name = d.getVar("IMAGE_NAME")
+    wic_image = os.path.join(work_dir, "deploy-" + d.getVar("PN") + "-image-complete",
+                             f"{image_link_name}.wic")
+
+    if not os.path.exists(wic_image):
+        bb.fatal(f"No WIC image found at {wic_image}")
+
+    return wic_image
+
+
+def get_partitions(wic_image):
+    import subprocess
+
+    fdisk_output = subprocess.check_output(
+        ["fdisk", "-l", "-o", "Start,Type", wic_image], text=True
+    )
+    vfat_partitions = []
+
+    for line in fdisk_output.splitlines():
+        if "FAT" in line:
+            offset_blocks = int(line.split()[0])
+            offset_bytes = offset_blocks * 512
+            partition = f"{wic_image}@@{offset_bytes}"
+            vfat_partitions.append(partition)
+
+    return vfat_partitions
+
+
+def update_cmdline(partition, root):
+    import subprocess
+
+    cmdline_data = subprocess.check_output(
+        ["mtype", "-i", partition, "::cmdline.txt"], text=True
+    )
+
+    new_cmdline = cmdline_data.replace("root=XXX", f"root={root}")
+
+    subprocess.run(
+        ["mcopy", "-Do", "-i", partition, "-", "::cmdline.txt"],
+        input=new_cmdline, text=True, check=True
+    )
+
+
+python do_update_tryboot_cmdline() {
+    wic_image = get_wic_image(d)
+    vfat_partitions = get_partitions(wic_image)
+
+    if len(vfat_partitions) < 3:
+        bb.fatal(f"Expected at least 3 FAT partitions, found {len(vfat_partitions)}")
+
+    # vfat_partitions[0] = tryboot (p1), [1] = bootA (p2), [2] = bootB (p3)
+    update_cmdline(vfat_partitions[1], "/dev/mmcblk0p5")
+    update_cmdline(vfat_partitions[2], "/dev/mmcblk0p6")
+}
+
+do_update_tryboot_cmdline[depends] += "mtools-native:do_populate_sysroot"
+addtask do_update_tryboot_cmdline after do_image_wic before do_image_complete

--- a/meta-mender-raspberrypi-tryboot/conf/layer.conf
+++ b/meta-mender-raspberrypi-tryboot/conf/layer.conf
@@ -1,0 +1,13 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-raspberrypi-tryboot"
+BBFILE_PATTERN_mender-raspberrypi-tryboot = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-raspberrypi-tryboot = "10"
+
+LAYERDEPENDS_mender-raspberrypi-tryboot = "core raspberrypi"
+LAYERSERIES_COMPAT_mender-raspberrypi-tryboot = "scarthgap"

--- a/meta-mender-raspberrypi-tryboot/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-mender-raspberrypi-tryboot/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,3 @@
+# Set root partition to placeholder; tryboot-cmdline.bbclass replaces it
+# per boot partition with the correct device path during WIC post-processing.
+CMDLINE_ROOT_PARTITION = "XXX"

--- a/meta-mender-raspberrypi-tryboot/recipes-core/data-partition/data-partition_1.0.bb
+++ b/meta-mender-raspberrypi-tryboot/recipes-core/data-partition/data-partition_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Mount unit for Mender data partition"
+DESCRIPTION = "Systemd mount unit for the persistent data partition at /data"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://data.mount"
+
+S = "${WORKDIR}"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "data.mount"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/data.mount ${D}${systemd_system_unitdir}/data.mount
+
+    install -d ${D}/data
+}
+
+FILES:${PN} = " \
+    ${systemd_system_unitdir}/data.mount \
+    /data \
+"

--- a/meta-mender-raspberrypi-tryboot/recipes-core/data-partition/files/data.mount
+++ b/meta-mender-raspberrypi-tryboot/recipes-core/data-partition/files/data.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mender data partition
+DefaultDependencies=no
+After=local-fs-pre.target
+Before=local-fs.target
+
+[Mount]
+What=/dev/mmcblk0p7
+Where=/data
+Type=ext4
+Options=defaults
+
+[Install]
+WantedBy=local-fs.target

--- a/meta-mender-raspberrypi-tryboot/recipes-mender/mender-client/mender_%.bbappend
+++ b/meta-mender-raspberrypi-tryboot/recipes-mender/mender-client/mender_%.bbappend
@@ -1,0 +1,27 @@
+# Without mender-image feature, the client installs state to /var/lib/mender
+# directly on the rootfs, which is lost on A/B switch. We override the
+# persistent dir to /data/mender and create the symlink ourselves.
+
+# Point persistent dir to /data/mender (same as mender-image would do)
+_MENDER_PERSISTENT_DIR = "/data/mender"
+
+# Create /data/mender before the base recipe tries to install files there
+do_install:prepend() {
+    install -m 755 -d ${D}/data/mender
+}
+
+# After base install, replace /var/lib/mender with symlink to persistent storage
+# and remove the generic rootfs-image update module which is incompatible with
+# the tryboot partition layout.
+do_install:append() {
+    if ! ${@bb.utils.contains('MENDER_FEATURES', 'mender-image', 'true', 'false', d)}; then
+        rm -rf ${D}/${localstatedir}/lib/mender
+        install -m 755 -d ${D}/${localstatedir}/lib
+        ln -s /data/mender ${D}/${localstatedir}/lib/mender
+    fi
+
+    rm -f ${D}${datadir}/mender/modules/v3/rootfs-image
+}
+
+# Include /data/mender in the package (not /data itself, owned by data-partition)
+FILES:mender-config += "/data/mender"

--- a/meta-mender-raspberrypi-tryboot/recipes-mender/mender-update-modules/files/rpi-tryboot-rootfs
+++ b/meta-mender-raspberrypi-tryboot/recipes-mender/mender-update-modules/files/rpi-tryboot-rootfs
@@ -1,0 +1,256 @@
+#!/bin/sh
+#
+# Mender update module: rpi-tryboot-rootfs
+#
+# Handles full system updates (rootfs + boot partition) using the
+# Raspberry Pi native tryboot A/B mechanism.
+#
+# Artifact payload: single rootfs ext4 image containing /boot with
+# kernel, DTBs, firmware, config.txt.
+
+set -e
+
+STATE="$1"
+FILES="$2"
+
+TRYBOOT_PENDING_FLAG="/data/mender/tryboot-pending"
+AUTOBOOT_PART="/dev/mmcblk0p1"
+AUTOBOOT_MOUNT="/tmp/mender-autoboot"
+
+# Determine active boot partition from device tree
+get_active_boot_part() {
+    if [ -f /proc/device-tree/chosen/bootloader/partition ]; then
+        # Big-endian 32-bit integer in device tree; read last byte for small values
+        tail -c1 /proc/device-tree/chosen/bootloader/partition | od -An -tu1 | tr -d ' '
+        return
+    fi
+    # Fallback: derive from cmdline root= parameter
+    root_dev=$(cat /proc/cmdline | tr ' ' '\n' | grep '^root=' | sed 's/root=//')
+    case "$root_dev" in
+        /dev/mmcblk0p5) echo 2 ;;
+        /dev/mmcblk0p6) echo 3 ;;
+        *) echo "ERROR: cannot determine active boot partition from root=$root_dev" >&2; exit 1 ;;
+    esac
+}
+
+# Derive inactive partitions from active boot partition number
+get_inactive_parts() {
+    active_boot=$1
+    case "$active_boot" in
+        2)
+            INACTIVE_BOOT_PART=3
+            INACTIVE_BOOT_DEV="/dev/mmcblk0p3"
+            INACTIVE_ROOT_DEV="/dev/mmcblk0p6"
+            INACTIVE_ROOT_LABEL="rootB"
+            ;;
+        3)
+            INACTIVE_BOOT_PART=2
+            INACTIVE_BOOT_DEV="/dev/mmcblk0p2"
+            INACTIVE_ROOT_DEV="/dev/mmcblk0p5"
+            INACTIVE_ROOT_LABEL="rootA"
+            ;;
+        *)
+            echo "ERROR: unexpected active boot partition: $active_boot" >&2
+            exit 1
+            ;;
+    esac
+}
+
+case "$STATE" in
+
+    ArtifactInstall)
+        active_boot=$(get_active_boot_part)
+        get_inactive_parts "$active_boot"
+
+        # Find the rootfs image in the artifact payload
+        rootfs_image=$(ls "$FILES"/files/*.ext4 2>/dev/null | head -1)
+        if [ -z "$rootfs_image" ]; then
+            echo "ERROR: no ext4 rootfs image found in artifact payload" >&2
+            exit 1
+        fi
+
+        echo "Active boot partition: $active_boot"
+        echo "Writing rootfs to $INACTIVE_ROOT_DEV"
+
+        # Write rootfs image to inactive rootfs partition
+        dd if="$rootfs_image" of="$INACTIVE_ROOT_DEV" bs=4M conv=fsync status=progress
+
+        # Mount the newly written rootfs to extract boot files
+        rootfs_mount=$(mktemp -d /tmp/mender-rootfs.XXXXXX)
+        mount -o ro "$INACTIVE_ROOT_DEV" "$rootfs_mount"
+
+        # Find active boot partition mount (may already be mounted by fstab)
+        active_boot_dev="/dev/mmcblk0p${active_boot}"
+        active_boot_mount=$(findmnt -n -o TARGET -f "$active_boot_dev" 2>/dev/null | head -1 || true)
+        active_boot_mounted_here=false
+        if [ -z "$active_boot_mount" ]; then
+            active_boot_mount=$(mktemp -d /tmp/mender-active-boot.XXXXXX)
+            mount -o ro "$active_boot_dev" "$active_boot_mount"
+            active_boot_mounted_here=true
+        fi
+        echo "Active boot partition at $active_boot_mount"
+
+        # Find or mount inactive boot partition (target)
+        boot_mount=$(findmnt -n -o TARGET -f "$INACTIVE_BOOT_DEV" 2>/dev/null | head -1 || true)
+        boot_mounted_here=false
+        if [ -z "$boot_mount" ]; then
+            boot_mount=$(mktemp -d /tmp/mender-boot.XXXXXX)
+            mount "$INACTIVE_BOOT_DEV" "$boot_mount"
+            boot_mounted_here=true
+        else
+            # Remount read-write if needed
+            mount -o remount,rw "$boot_mount" 2>/dev/null || true
+        fi
+        echo "Inactive boot partition at $boot_mount"
+
+        # Populate inactive boot partition:
+        # 1. Start with a copy of the active boot partition (firmware files,
+        #    config.txt, overlays, etc. that are not in the rootfs /boot)
+        # 2. Then overlay with kernel + DTBs from the new rootfs /boot
+        echo "Copying boot files to $INACTIVE_BOOT_DEV"
+        rm -rf "$boot_mount"/*
+        cp -aL --no-preserve=links "$active_boot_mount"/* "$boot_mount"/
+        echo "Copied firmware base from active boot partition $active_boot_dev"
+
+        # Overlay with new kernel, DTBs, and overlays from the rootfs
+        if [ -d "$rootfs_mount/boot" ]; then
+            cp -aL --no-preserve=links "$rootfs_mount/boot"/* "$boot_mount"/
+            echo "Overlaid kernel and DTBs from new rootfs"
+        fi
+
+        if [ "$active_boot_mounted_here" = true ]; then
+            umount "$active_boot_mount"
+            rmdir "$active_boot_mount"
+        fi
+
+        # Set cmdline.txt root= to the inactive rootfs partition
+        echo "Setting cmdline.txt root=$INACTIVE_ROOT_DEV"
+        if [ -f "$boot_mount/cmdline.txt" ]; then
+            sed -i "s|root=[^ ]*|root=$INACTIVE_ROOT_DEV|" "$boot_mount/cmdline.txt"
+        else
+            echo "dwc_otg.lpm_enable=0 console=serial0,115200 root=$INACTIVE_ROOT_DEV rootfstype=ext4 rootwait" \
+                > "$boot_mount/cmdline.txt"
+            echo "Generated cmdline.txt"
+        fi
+
+        sync
+        if [ "$boot_mounted_here" = true ]; then
+            umount "$boot_mount"
+            rmdir "$boot_mount"
+        fi
+        umount "$rootfs_mount"
+        rmdir "$rootfs_mount"
+
+        # Update autoboot.txt [tryboot] to point to the inactive partition.
+        # On some RPi firmware versions, [tryboot] boot_partition is used for
+        # all boots, so this ensures the tryboot reboot lands on the target.
+        autoboot_mount=$(findmnt -n -o TARGET -f "$AUTOBOOT_PART" 2>/dev/null | head -1 || true)
+        autoboot_mounted_here=false
+        if [ -z "$autoboot_mount" ]; then
+            autoboot_mount="$AUTOBOOT_MOUNT"
+            mkdir -p "$autoboot_mount"
+            mount "$AUTOBOOT_PART" "$autoboot_mount"
+            autoboot_mounted_here=true
+        fi
+        cat > "$autoboot_mount/autoboot.txt" <<EOF
+[all]
+tryboot_a_b=1
+boot_partition=$active_boot
+
+[tryboot]
+boot_partition=$INACTIVE_BOOT_PART
+EOF
+        sync
+        if [ "$autoboot_mounted_here" = true ]; then
+            umount "$autoboot_mount"
+            rmdir "$autoboot_mount"
+        fi
+
+        # Set tryboot pending flag
+        mkdir -p "$(dirname "$TRYBOOT_PENDING_FLAG")"
+        echo "$INACTIVE_BOOT_PART" > "$TRYBOOT_PENDING_FLAG"
+
+        echo "Install complete. Tryboot pending for boot partition $INACTIVE_BOOT_PART."
+        ;;
+
+    NeedsArtifactReboot)
+        echo "Yes"
+        ;;
+
+    ArtifactReboot)
+        echo "Performing tryboot reboot..."
+        reboot '0 tryboot'
+        # Wait for the system to shut down; this process will be killed by reboot
+        sleep 300
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactVerifyReboot)
+        if [ ! -f "$TRYBOOT_PENDING_FLAG" ]; then
+            echo "ERROR: tryboot pending flag not found, unexpected state" >&2
+            exit 1
+        fi
+
+        expected_boot=$(cat "$TRYBOOT_PENDING_FLAG")
+        active_boot=$(get_active_boot_part)
+
+        if [ "$active_boot" != "$expected_boot" ]; then
+            echo "ERROR: expected boot partition $expected_boot but booted from $active_boot" >&2
+            exit 1
+        fi
+
+        echo "Verified: booted from expected partition $active_boot"
+        ;;
+
+    ArtifactCommit)
+        active_boot=$(get_active_boot_part)
+        get_inactive_parts "$active_boot"
+
+        echo "Committing: making partition $active_boot the permanent default"
+
+        # Update autoboot.txt
+        autoboot_mount=$(findmnt -n -o TARGET -f "$AUTOBOOT_PART" 2>/dev/null | head -1 || true)
+        autoboot_mounted_here=false
+        if [ -z "$autoboot_mount" ]; then
+            autoboot_mount="$AUTOBOOT_MOUNT"
+            mkdir -p "$autoboot_mount"
+            mount "$AUTOBOOT_PART" "$autoboot_mount"
+            autoboot_mounted_here=true
+        fi
+
+        # Set both [all] and [tryboot] to the committed partition so that
+        # subsequent boots (normal or tryboot-style) stay on this slot.
+        cat > "$autoboot_mount/autoboot.txt" <<EOF
+[all]
+tryboot_a_b=1
+boot_partition=$active_boot
+
+[tryboot]
+boot_partition=$active_boot
+EOF
+
+        sync
+        if [ "$autoboot_mounted_here" = true ]; then
+            umount "$autoboot_mount"
+            rmdir "$autoboot_mount"
+        fi
+
+        # Remove tryboot pending flag
+        rm -f "$TRYBOOT_PENDING_FLAG"
+
+        echo "Commit complete. Default boot partition is now $active_boot."
+        ;;
+
+    ArtifactRollback)
+        # The tryboot flag is one-shot. A plain reboot automatically
+        # goes back to the previous (committed) partition.
+        echo "Rollback: tryboot flag is one-shot, no action needed."
+        rm -f "$TRYBOOT_PENDING_FLAG"
+        ;;
+
+esac
+
+exit 0

--- a/meta-mender-raspberrypi-tryboot/recipes-mender/mender-update-modules/rpi-tryboot-rootfs_1.0.bb
+++ b/meta-mender-raspberrypi-tryboot/recipes-mender/mender-update-modules/rpi-tryboot-rootfs_1.0.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Mender update module for Raspberry Pi tryboot A/B rootfs updates"
+DESCRIPTION = "Custom Mender update module that handles full system updates \
+using the Raspberry Pi native tryboot A/B boot switching mechanism."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://rpi-tryboot-rootfs"
+
+S = "${WORKDIR}"
+
+inherit allarch
+
+RDEPENDS:${PN} = "util-linux coreutils sed"
+
+do_install() {
+    install -d ${D}${datadir}/mender/modules/v3
+    install -m 0755 ${WORKDIR}/rpi-tryboot-rootfs ${D}${datadir}/mender/modules/v3/rpi-tryboot-rootfs
+}
+
+FILES:${PN} = "${datadir}/mender/modules/v3/rpi-tryboot-rootfs"

--- a/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/files/mender-authd-wait.conf
+++ b/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/files/mender-authd-wait.conf
@@ -1,0 +1,3 @@
+[Unit]
+After=wait-for-clock.service
+Requires=wait-for-clock.service

--- a/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/files/wait-for-clock.service
+++ b/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/files/wait-for-clock.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Wait for system clock to be synchronized
+After=network-online.target systemd-timesyncd.service
+Wants=network-online.target systemd-timesyncd.service
+Before=mender-authd.service mender-updated.service mender-connect.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'for i in $(seq 1 60); do [ $(date +%%Y) -gt 2000 ] && exit 0; sleep 1; done; echo "WARNING: clock not synced after 60s" >&2'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/wait-for-clock_1.0.bb
+++ b/meta-mender-raspberrypi-tryboot/recipes-support/wait-for-clock/wait-for-clock_1.0.bb
@@ -1,0 +1,28 @@
+SUMMARY = "Wait for NTP clock sync before Mender services"
+DESCRIPTION = "Systemd oneshot service that blocks until the system clock is \
+past year 2000, ensuring SSL connections work on RTC-less boards."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = " \
+    file://wait-for-clock.service \
+    file://mender-authd-wait.conf \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "wait-for-clock.service"
+
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/wait-for-clock.service ${D}${systemd_system_unitdir}/
+
+    # Drop-in overrides for mender services
+    for svc in mender-authd mender-updated mender-connect; do
+        install -d ${D}${systemd_system_unitdir}/${svc}.service.d
+        install -m 0644 ${WORKDIR}/mender-authd-wait.conf \
+            ${D}${systemd_system_unitdir}/${svc}.service.d/wait-for-clock.conf
+    done
+}
+
+FILES:${PN} += "${systemd_system_unitdir}"

--- a/meta-mender-raspberrypi-tryboot/scripts/lib/wic/plugins/source/tryboot-partition.py
+++ b/meta-mender-raspberrypi-tryboot/scripts/lib/wic/plugins/source/tryboot-partition.py
@@ -1,0 +1,40 @@
+import logging
+import os
+
+from wic.pluginbase import SourcePlugin
+from wic.misc import exec_cmd
+
+logger = logging.getLogger('wic')
+
+
+class TrybootPartitionPlugin(SourcePlugin):
+
+    name = 'tryboot-partition'
+
+    @classmethod
+    def do_configure_partition(cls, part, source_params, cr, cr_workdir,
+                               oe_builddir, bootimg_dir, kernel_dir,
+                               native_sysroot):
+        hdddir = f"{cr_workdir}/boot.{part.lineno}"
+        install_cmd = f"install -d {hdddir}"
+        exec_cmd(install_cmd)
+
+        autoboot = "[all]\n"
+        autoboot += "tryboot_a_b=1\n"
+        autoboot += "boot_partition=2\n"
+        autoboot += "\n"
+        autoboot += "[tryboot]\n"
+        autoboot += "boot_partition=3\n"
+
+        with open(f"{hdddir}/autoboot.txt", "w") as cfg:
+            cfg.write(autoboot)
+
+    @classmethod
+    def do_prepare_partition(cls, part, source_params, cr, cr_workdir,
+                             oe_builddir, bootimg_dir, kernel_dir,
+                             rootfs_dir, native_sysroot):
+        hdddir = f"{cr_workdir}/boot.{part.lineno}"
+
+        logger.debug(f"Prepare tryboot partition using content in {hdddir}")
+        part.prepare_rootfs(cr_workdir, oe_builddir, hdddir,
+                            native_sysroot, False)

--- a/meta-mender-raspberrypi-tryboot/wic/sdimage-rpi-mender-tryboot.wks
+++ b/meta-mender-raspberrypi-tryboot/wic/sdimage-rpi-mender-tryboot.wks
@@ -3,9 +3,9 @@
 # native A/B boot switching via autoboot.txt. 7-partition MBR layout:
 # p1=tryboot, p2=bootA, p3=bootB, p4=extended, p5=rootA, p6=rootB, p7=data
 
-part /boot/tryboot --source tryboot-partition --ondisk mmcblk0 --fstype=vfat --label tryboot --active --align 4096 --size 10
-part /boot/bootA --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootA --align 4096 --size 100
-part /boot/bootB --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootB --align 4096 --size 100
+part /boot/tryboot --source tryboot-partition --ondisk mmcblk0 --fstype=vfat --label tryboot --active --align 4096 --size 10 --mkfs-extraopts "-s 32"
+part /boot/bootA --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootA --align 4096 --size 100 --mkfs-extraopts "-s 32"
+part /boot/bootB --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootB --align 4096 --size 100 --mkfs-extraopts "-s 32"
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096
 part /data --source rootfs --change-directory=data --fixed-size 1024M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096

--- a/meta-mender-raspberrypi-tryboot/wic/sdimage-rpi-mender-tryboot.wks
+++ b/meta-mender-raspberrypi-tryboot/wic/sdimage-rpi-mender-tryboot.wks
@@ -1,0 +1,11 @@
+# short-description: Create Raspberry Pi SD card image with tryboot A/B and Mender data partition
+# long-description: Creates a partitioned SD card image for Raspberry Pi with
+# native A/B boot switching via autoboot.txt. 7-partition MBR layout:
+# p1=tryboot, p2=bootA, p3=bootB, p4=extended, p5=rootA, p6=rootB, p7=data
+
+part /boot/tryboot --source tryboot-partition --ondisk mmcblk0 --fstype=vfat --label tryboot --active --align 4096 --size 10
+part /boot/bootA --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootA --align 4096 --size 100
+part /boot/bootB --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label bootB --align 4096 --size 100
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096
+part /data --source rootfs --change-directory=data --fixed-size 1024M --ondisk mmcblk0 --fstype=ext4 --label data --align 4096

--- a/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_git.bb
+++ b/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 PV = "0.2+git"
 
 SRC_URI = "git://github.com/theyoctojester/mender-validation.git;protocol=https;branch=main"
-SRCREV = "5d8ee06f350eae02fb98c21ed0dc2aff07ef5a63"
+SRCREV = "c850447495d6fe433b95f907c34a7bc57ab98055"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"

--- a/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_git.bb
+++ b/meta-mender-validation/recipes-mender/bootloader-validation/bootloader-validation_git.bb
@@ -3,8 +3,10 @@ DESCRIPTION = "Automated validation of the Mender bootloader integration"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 
+PV = "0.2+git"
+
 SRC_URI = "git://github.com/theyoctojester/mender-validation.git;protocol=https;branch=main"
-SRCREV = "45033cda680a586d75bb07e0edec81cb92e5e4c9"
+SRCREV = "5d8ee06f350eae02fb98c21ed0dc2aff07ef5a63"
 
 do_configure[noexec] = "1"
 do_compile[noexec] = "1"


### PR DESCRIPTION
## Summary

Add Raspberry Pi native tryboot A/B boot switching as an alternative to U-Boot for Mender OTA updates.

- **New layer `meta-mender-raspberrypi-tryboot/`**: Uses the RPi firmware's `autoboot.txt` mechanism with a 7-partition MBR layout (tryboot, bootA, bootB, rootA, rootB, data) and a custom Mender update module (`rpi-tryboot-rootfs`). Mutually exclusive with `meta-mender-raspberrypi` (U-Boot).
- **Kas configs**: `kas/include/raspberrypi-tryboot.yml` base include, board configs for RPi4-64 and RPi5, and a validation overlay.
- **Updated `bootloader-validation` recipe**: Bumped to include a backend abstraction layer with automatic detection of U-Boot, GRUB, and tryboot backends. Backward-compatible with existing setups. Recipe renamed from `_0.1` to `_git` per Yocto convention.

### Key design decisions

- Separate layer rather than extending `meta-mender-raspberrypi` — tryboot and U-Boot are mutually exclusive boot mechanisms
- Uses `mender-setup` (not `mender-full`) since there is no bootloader integration to inherit
- The generic `rootfs-image` update module is removed as it is incompatible with the tryboot partition layout
- No `meta-lts-mixins` dependency — tryboot does not use U-Boot

### Hardware tested

- Raspberry Pi 4 (64-bit) on physical hardware via labgrid
- Boot test: PASSED
- Bootloader validation suite (6-boot cycle: init → switch → update → rollback → rollback_verify → end): PASSED (`BOOTLOADER VALIDATION: SUCCESS`)

## Test plan

- [x] `kas build kas/raspberrypi4-64-tryboot.yml` produces correct 7-partition WIC image
- [x] Flash to RPi4, device boots successfully
- [x] Validation suite passes full 6-boot cycle on RPi4 hardware
- [x] Verify existing U-Boot/GRUB validation builds are unaffected by the `bootloader-validation` recipe update

🤖 Generated with [Claude Code](https://claude.com/claude-code)