### PR TITLE
feat: Add qemux86-64 U-Boot EFI demo with Mender A/B support

### DIFF
--- a/kas/demos/meta-mender-x86-uboot-efi/LICENSE
+++ b/kas/demos/meta-mender-x86-uboot-efi/LICENSE
@@ -1,0 +1,202 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/kas/demos/meta-mender-x86-uboot-efi/README
+++ b/kas/demos/meta-mender-x86-uboot-efi/README
@@ -1,0 +1,100 @@
+meta-mender-x86-uboot-efi
+=========================
+
+Demo layer for running U-Boot as an EFI application on x86-64 with Mender A/B
+update support. This replaces GRUB with U-Boot for a GPLv3-free boot chain.
+
+Based on: https://hub.mender.io/t/u-boot-efi-on-intel-corei7-64/8216
+
+Dependencies
+============
+
+  URI: git://git.yoctoproject.org/poky
+  layers: meta, meta-poky, meta-yocto-bsp
+  branch: scarthgap
+
+  URI: git://git.openembedded.org/meta-openembedded
+  layers: meta-oe
+  branch: scarthgap
+
+  URI: https://github.com/mendersoftware/meta-mender.git
+  layers: meta-mender-core
+  branch: scarthgap
+
+  layer: meta-mender-explicit-wic (from this repository)
+
+Contributions
+=============
+
+Please see the README file in the top level directory.
+
+Maintainer: Josef Holzmayr <jester@theyoctojester.info>
+
+Usage
+=====
+
+Build the demo image:
+
+  kas build kas/demos/qemux86-64-uboot-efi.yml
+
+Build with bootloader validation suite:
+
+  kas build kas/demos/qemux86-64-uboot-efi-bootloader-validation.yml
+
+Running in QEMU
+===============
+
+runqemu cannot produce the correct command line for this setup (it lacks pflash
+OVMF support and IDE/AHCI drive selection). Launch QEMU manually instead:
+
+  DEPLOY=build/tmp/deploy/images/qemux86-64
+  QEMU=$DEPLOY/../../../work/x86_64-linux/qemu-helper-native/1.0/recipe-sysroot-native/usr/bin/qemu-system-x86_64
+
+  cp $DEPLOY/mender-explicit-demo-image-qemux86-64.wic /tmp/test.wic
+  cp $DEPLOY/ovmf.vars.qcow2 /tmp/ovmf-vars.qcow2
+
+  $QEMU \
+    -device virtio-net-pci,netdev=net0,mac=52:54:00:12:35:02 \
+    -netdev user,id=net0,hostfwd=tcp:127.0.0.1:2222-:22 \
+    -drive id=disk0,file=/tmp/test.wic,format=raw,if=none \
+    -device ide-hd,drive=disk0 \
+    -cpu IvyBridge -machine q35,i8042=off -smp 4 -m 2048 \
+    -serial mon:stdio -serial null -nographic \
+    -drive if=pflash,format=qcow2,file=$DEPLOY/ovmf.code.qcow2,readonly=on \
+    -drive if=pflash,format=qcow2,file=/tmp/ovmf-vars.qcow2
+
+The WIC image and OVMF vars are copied so the originals stay untouched. The
+OVMF CODE file is used read-only; the VARS copy is writable for NVRAM
+persistence across reboots.
+
+Boot chain
+==========
+
+  QEMU -> OVMF (UEFI firmware) -> u-boot-app.efi (from ESP) -> Linux kernel
+
+Partition layout (GPT, SATA/AHCI disk):
+
+  1. ESP        (16 MB, FAT)  - EFI/BOOT/bootx64.efi + startup.nsh
+  2. U-Boot env  (4 MB, FAT)  - uboot.env + uboot-redund.env (128 KB each)
+  3. Root A    (512 MB, ext4) - Active rootfs
+  4. Root B    (512 MB, ext4) - Inactive rootfs (for A/B updates)
+  5. Data      (128 MB, ext4) - Persistent data (/data)
+
+The ESP and env partitions are deliberately separated: U-Boot writes env files
+to partition 2, keeping the ESP (partition 1) read-only. This prevents FAT
+corruption that would break OVMF boot discovery after guest reboots.
+
+Design decisions
+================
+
+SATA/AHCI storage (not virtio): virtio devices are not re-enumerated by OVMF
+after a guest reboot in QEMU, breaking the boot chain.
+
+EFI block I/O interface: U-Boot EFI app accesses disks through the "efi"
+interface (EFI block I/O protocol from OVMF), not native drivers.
+
+No 'reset' in recovery: In EFI app mode, U-Boot's 'reset' command causes OVMF
+to fall through to its setup UI. Recovery runs altbootcmd inline instead.
+
+Pre-populated env via mkenvimage: avoids saveenv on first boot, which would
+fail if the env partition were empty.

--- a/kas/demos/meta-mender-x86-uboot-efi/README
+++ b/kas/demos/meta-mender-x86-uboot-efi/README
@@ -6,11 +6,31 @@ update support. This replaces GRUB with U-Boot for a GPLv3-free boot chain.
 
 Based on: https://hub.mender.io/t/u-boot-efi-on-intel-corei7-64/8216
 
+Why mender-explicit-demo-image
+==============================
+
+This demo builds mender-explicit-demo-image, not a generic core-image-minimal.
+The standard Mender integration (mender-full / mender-image) generates its
+partition layout dynamically, but this setup needs a hand-crafted 5-partition
+GPT layout with a separate ESP and U-Boot environment partition. To achieve
+that, the mender-image and mender-part-images features are disabled, and the
+mender-explicit-wic class takes over: it applies an explicit WKS file for
+partitioning and handles .mender Artifact generation independently. A plain
+core-image-minimal does not inherit mender-explicit-wic and therefore cannot
+produce the correct disk image or OTA artifacts for this boot chain.
+
 Dependencies
 ============
 
-  URI: git://git.yoctoproject.org/poky
-  layers: meta, meta-poky, meta-yocto-bsp
+  URI: git://git.openembedded.org/openembedded-core.git
+  layers: meta
+  branch: scarthgap
+
+  URI: git://git.openembedded.org/bitbake.git
+  branch: scarthgap
+
+  URI: git://git.yoctoproject.org/git/meta-yocto.git
+  layers: meta-poky, meta-yocto-bsp
   branch: scarthgap
 
   URI: git://git.openembedded.org/meta-openembedded

--- a/kas/demos/meta-mender-x86-uboot-efi/conf/layer.conf
+++ b/kas/demos/meta-mender-x86-uboot-efi/conf/layer.conf
@@ -1,0 +1,17 @@
+# We have a conf directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-mender-x86-uboot-efi"
+BBFILE_PATTERN_meta-mender-x86-uboot-efi = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-mender-x86-uboot-efi = "6"
+
+LAYERVERSION_meta-mender-x86-uboot-efi = "1"
+LAYERDEPENDS_meta-mender-x86-uboot-efi = "core meta-mender-explicit-wic"
+LAYERSERIES_COMPAT_meta-mender-x86-uboot-efi = "scarthgap"
+
+# Variable to reference this layer directory in recipes
+LAYERDIR_meta-mender-x86-uboot-efi = "${LAYERDIR}"

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/libubootenv/libubootenv_%.bbappend
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/libubootenv/libubootenv_%.bbappend
@@ -1,0 +1,16 @@
+# Override fw_env.config for x86-64 U-Boot EFI mode.
+# The mender-uboot class creates /etc/fw_env.config pointing to device-offset
+# based config. We override it to use file-based config for the env partition
+# mounted at /uboot (FAT partition 2, separate from ESP).
+#
+# Redundant env: uboot.env + uboot-redund.env, both 128KB (0x20000).
+do_install[postfuncs] += "fixup_fw_env_config"
+
+fixup_fw_env_config() {
+    if [ -d "${D}/data/u-boot" ]; then
+        printf '/uboot/uboot.env\t0x0\t0x20000\n/uboot/uboot-redund.env\t0x0\t0x20000\n' > ${D}/data/u-boot/fw_env.config
+    fi
+    rm -f ${D}${sysconfdir}/fw_env.config
+    install -d ${D}${sysconfdir}
+    printf '/uboot/uboot.env\t0x0\t0x20000\n/uboot/uboot-redund.env\t0x0\t0x20000\n' > ${D}${sysconfdir}/fw_env.config
+}

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/files/startup.nsh
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/files/startup.nsh
@@ -1,0 +1,4 @@
+EFI\BOOT\bootx64.efi
+fs0:EFI\BOOT\bootx64.efi
+fs1:EFI\BOOT\bootx64.efi
+fs2:EFI\BOOT\bootx64.efi

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/u-boot-2024.01/0001-configs-efi-x86-enable-mender-requirements.patch
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/u-boot-2024.01/0001-configs-efi-x86-enable-mender-requirements.patch
@@ -1,0 +1,59 @@
+From 0ab3397479c688b26e8c39b90b090e53ad8b01a9 Mon Sep 17 00:00:00 2001
+From: Josef Holzmayr <jester@theyoctojester.info>
+Date: Wed, 8 Apr 2026 19:28:00 +0000
+Subject: [PATCH] configs: efi-x86_app64: enable mender requirements
+
+Configure efi-x86_app64_defconfig for Mender A/B boot support:
+- Redundant env stored as FAT files on partition 2 (dedicated env
+  partition, separate from ESP) to prevent OVMF boot discovery
+  failures caused by FAT writes to the ESP.
+- Bootcount limit for automatic rollback on failed updates.
+- Mender-aware BOOTCOMMAND with conditional kernel load (&&) to
+  prevent booting stale kernel data from RAM on load failure.
+- Load address 0x70000000 (above EFI app reserved memory region).
+- LMB_ARCH_MEM_MAP disabled to allow memory access in EFI app mode.
+
+Upstream-Status: Inappropriate [Mender specific]
+Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
+---
+ configs/efi-x86_app64_defconfig | 14 ++++++++++++--
+ 1 file changed, 12 insertions(+), 2 deletions(-)
+
+diff --git a/configs/efi-x86_app64_defconfig b/configs/efi-x86_app64_defconfig
+index e0cfe3e..31c3602 100644
+--- a/configs/efi-x86_app64_defconfig
++++ b/configs/efi-x86_app64_defconfig
+@@ -1,6 +1,6 @@
+ CONFIG_X86=y
+ CONFIG_NR_DRAM_BANKS=8
+-CONFIG_ENV_SIZE=0x1000
++CONFIG_ENV_SIZE=0x20000
+ CONFIG_DEFAULT_DEVICE_TREE="efi-x86_app"
+ CONFIG_DEBUG_UART_BASE=0x0
+ CONFIG_DEBUG_UART_CLOCK=0
+@@ -14,7 +14,7 @@ CONFIG_SHOW_BOOT_PROGRESS=y
+ CONFIG_USE_BOOTARGS=y
+ CONFIG_BOOTARGS="root=/dev/sdb3 init=/sbin/init rootwait ro"
+ CONFIG_USE_BOOTCOMMAND=y
+-CONFIG_BOOTCOMMAND="ext2load scsi 0:3 01000000 /boot/vmlinuz; zboot 01000000"
++CONFIG_BOOTCOMMAND="run mender_setup; setenv bootargs console=ttyS0,115200 root=\${mender_kernel_root} rootwait rw; load \${mender_uboot_root} 0x70000000 /boot/bzImage && zboot 0x70000000 \$filesize; run mender_try_to_recover"
+ CONFIG_SYS_CONSOLE_INFO_QUIET=y
+ CONFIG_DISPLAY_BOARDINFO_LATE=y
+ CONFIG_HUSH_PARSER=y
+@@ -46,3 +46,13 @@ CONFIG_CMD_DHRYSTONE=y
+ # CONFIG_GZIP is not set
+ CONFIG_EFI=y
+ CONFIG_EFI_APP_64BIT=y
++CONFIG_BOOTCOUNT_ENV=y
++CONFIG_BOOTCOUNT_LIMIT=y
++CONFIG_ENV_IS_IN_FAT=y
++CONFIG_ENV_FAT_INTERFACE="efi"
++CONFIG_ENV_FAT_DEVICE_AND_PART="0:2"
++CONFIG_ENV_FAT_FILE="uboot.env"
++CONFIG_SYS_REDUNDAND_ENVIRONMENT=y
++CONFIG_ENV_FAT_FILE_REDUND="uboot-redund.env"
++CONFIG_FAT_WRITE=y
++CONFIG_LMB_ARCH_MEM_MAP=n
+-- 
+2.34.1
+

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,0 +1,70 @@
+# U-Boot configuration for x86-64 EFI application mode with Mender A/B support
+#
+# This builds U-Boot as an EFI application (u-boot-app.efi) that runs under
+# OVMF firmware, providing Mender A/B boot partition selection.
+#
+# Boot chain: OVMF -> u-boot-app.efi (from ESP) -> Linux kernel (from rootfs)
+
+MENDER_X86_UBOOT_EFI_DIR := "${THISDIR}"
+FILESEXTRAPATHS:prepend:qemux86-64 = "${MENDER_X86_UBOOT_EFI_DIR}/${BPN}-${PV}:${MENDER_X86_UBOOT_EFI_DIR}/files:"
+
+COMPATIBLE_MACHINE:qemux86-64 = "qemux86-64"
+
+# Disable Mender auto-configure — the EFI app defconfig is non-standard
+MENDER_UBOOT_AUTO_CONFIGURE:qemux86-64 = "0"
+
+# The EFI app defconfig produces u-boot-app.efi
+UBOOT_BINARY:qemux86-64 = "u-boot-app.efi"
+
+# The Mender integration patch (env_mender.h + config_mender.h) is applied
+# automatically by the mender-uboot class from meta-mender-core.
+SRC_URI:append:qemux86-64:mender-uboot = " \
+    file://0001-configs-efi-x86-enable-mender-requirements.patch \
+    file://startup.nsh \
+"
+
+DEPENDS:append:qemux86-64 = " dosfstools-native mtools-native"
+
+do_deploy:append:qemux86-64() {
+    if [ -f "${B}/u-boot-app.efi" ]; then
+        install -m 0644 ${B}/u-boot-app.efi ${DEPLOYDIR}/u-boot-app.efi
+    fi
+
+    # fw_env.config pointing to the env partition mounted at /uboot
+    printf '/uboot/uboot.env\t0x0\t0x20000\n/uboot/uboot-redund.env\t0x0\t0x20000\n' > ${DEPLOYDIR}/fw_env.config.default
+
+    # Generate valid initial env with mender_saveenv_canary=1 pre-set
+    ENVTXT="${WORKDIR}/initial-env.txt"
+    if [ -f "${DEPLOYDIR}/u-boot-initial-env" ]; then
+        cp "${DEPLOYDIR}/u-boot-initial-env" "${ENVTXT}"
+    elif [ -f "${DEPLOYDIR}/u-boot-initial-env-${MACHINE}" ]; then
+        cp "${DEPLOYDIR}/u-boot-initial-env-${MACHINE}" "${ENVTXT}"
+    else
+        echo "mender_saveenv_canary=1" > "${ENVTXT}"
+    fi
+    if ! grep -q "mender_saveenv_canary=1" "${ENVTXT}"; then
+        echo "mender_saveenv_canary=1" >> "${ENVTXT}"
+    fi
+
+    # Override mender_try_to_recover: In EFI app mode, 'reset' causes OVMF
+    # to fall through to its UI instead of retrying U-Boot. Handle recovery
+    # inline by running altbootcmd + bootcmd directly.
+    sed -i '/^mender_try_to_recover=/d' "${ENVTXT}"
+    echo 'mender_try_to_recover=if test ${upgrade_available} = 1; then run mender_altbootcmd; run bootcmd; fi' >> "${ENVTXT}"
+    mkenvimage -r -s 0x20000 -o ${DEPLOYDIR}/uboot.env "${ENVTXT}"
+    mkenvimage -r -s 0x20000 -o ${DEPLOYDIR}/uboot-redund.env "${ENVTXT}"
+
+    # Create a 4MB FAT image containing the env files for the dedicated
+    # env partition (partition 2). This keeps env writes OFF the ESP so
+    # OVMF's view of the ESP FAT stays clean across reboots.
+    ENVIMG="${DEPLOYDIR}/uboot-env-partition.img"
+    dd if=/dev/zero of=${ENVIMG} bs=1M count=4 2>/dev/null
+    mkfs.vfat -n uboot-env ${ENVIMG}
+    mcopy -i ${ENVIMG} ${DEPLOYDIR}/uboot.env ::uboot.env
+    mcopy -i ${ENVIMG} ${DEPLOYDIR}/uboot-redund.env ::uboot-redund.env
+
+    # Deploy startup.nsh for EFI Shell fallback
+    install -m 0644 ${WORKDIR}/startup.nsh ${DEPLOYDIR}/startup.nsh
+}
+
+do_deploy[depends] += "u-boot-tools-native:do_populate_sysroot"

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/files/uboot-efi-bootentry.service
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/files/uboot-efi-bootentry.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Create persistent UEFI boot entry for U-Boot EFI
+After=local-fs.target uboot.mount
+ConditionPathExists=!/data/uboot-efi-bootentry-done
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/uboot-efi-bootentry.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/files/uboot-efi-bootentry.sh
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/files/uboot-efi-bootentry.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Create a persistent UEFI boot entry for U-Boot EFI application.
+# This ensures OVMF/UEFI firmware can find and boot U-Boot after reboots,
+# even if the auto-discovered boot entry is lost.
+
+MARKER="/data/uboot-efi-bootentry-done"
+
+if [ -f "$MARKER" ]; then
+    exit 0
+fi
+
+# Check if efibootmgr is available
+if ! command -v efibootmgr >/dev/null 2>&1; then
+    echo "efibootmgr not found, skipping UEFI boot entry creation"
+    exit 0
+fi
+
+# Check if efivars are accessible
+if [ ! -d /sys/firmware/efi/efivars ]; then
+    echo "EFI variables not accessible, skipping"
+    exit 0
+fi
+
+# Find the ESP disk and partition (ESP is at /boot/efi, NOT /uboot)
+ESP_DEV=$(findmnt -n -o SOURCE /boot/efi 2>/dev/null)
+if [ -z "$ESP_DEV" ]; then
+    echo "ESP not mounted at /boot/efi, skipping"
+    exit 0
+fi
+
+# Extract disk and partition number (e.g., /dev/vda1 -> /dev/vda + 1)
+DISK=$(echo "$ESP_DEV" | sed 's/[0-9]*$//')
+PARTNUM=$(echo "$ESP_DEV" | grep -o '[0-9]*$')
+
+echo "Creating UEFI boot entry: disk=$DISK part=$PARTNUM loader=EFI/BOOT/bootx64.efi"
+efibootmgr -c -d "$DISK" -p "$PARTNUM" -l '\EFI\BOOT\bootx64.efi' -L 'U-Boot EFI' 2>&1
+
+if [ $? -eq 0 ]; then
+    touch "$MARKER"
+    echo "UEFI boot entry created successfully"
+else
+    echo "WARNING: Failed to create UEFI boot entry"
+fi

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/x86-uboot-efi-env_1.0.bb
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-bsp/x86-uboot-efi-env/x86-uboot-efi-env_1.0.bb
@@ -1,0 +1,35 @@
+SUMMARY = "ESP mount point and UEFI boot entry for U-Boot EFI on x86-64"
+DESCRIPTION = "Creates the /uboot mount point and a first-boot service that \
+registers U-Boot as a persistent UEFI boot entry via efibootmgr. This ensures \
+OVMF can find and boot U-Boot after guest reboots."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://uboot-efi-bootentry.sh \
+    file://uboot-efi-bootentry.service \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "uboot-efi-bootentry.service"
+RDEPENDS:${PN} = "efibootmgr"
+
+do_install() {
+    # Create ESP mount point
+    install -d ${D}/uboot
+
+    # Install the boot entry creation script
+    install -d ${D}${bindir}
+    install -m 0755 ${WORKDIR}/uboot-efi-bootentry.sh ${D}${bindir}/uboot-efi-bootentry.sh
+
+    # Install the systemd service
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/uboot-efi-bootentry.service ${D}${systemd_system_unitdir}/uboot-efi-bootentry.service
+}
+
+FILES:${PN} = " \
+    /uboot \
+    ${bindir}/uboot-efi-bootentry.sh \
+    ${systemd_system_unitdir}/uboot-efi-bootentry.service \
+"

--- a/kas/demos/meta-mender-x86-uboot-efi/recipes-core/images/mender-explicit-demo-image.bbappend
+++ b/kas/demos/meta-mender-x86-uboot-efi/recipes-core/images/mender-explicit-demo-image.bbappend
@@ -1,0 +1,24 @@
+# Override fw_env.config for x86-64 U-Boot EFI mode at rootfs assembly time.
+# The Mender class creates a symlink /etc/fw_env.config -> /data/u-boot/fw_env.config
+# and populates /data/u-boot/ with device-offset config. We override BOTH locations
+# with file-based ESP config (environment stored on mounted FAT ESP at /uboot/).
+# This MUST use :append:mender-uboot to run AFTER the Mender class setup.
+ROOTFS_POSTPROCESS_COMMAND:append:mender-uboot = " fixup_fw_env_for_efi;"
+
+fixup_fw_env_for_efi() {
+    # Override the data partition copy (symlink target)
+    install -d ${IMAGE_ROOTFS}/data/u-boot
+    printf '/uboot/uboot.env\t0x0\t0x20000\n/uboot/uboot-redund.env\t0x0\t0x20000\n' > ${IMAGE_ROOTFS}/data/u-boot/fw_env.config
+
+    # Also replace /etc/fw_env.config if it's a symlink or file
+    rm -f ${IMAGE_ROOTFS}${sysconfdir}/fw_env.config
+    printf '/uboot/uboot.env\t0x0\t0x20000\n/uboot/uboot-redund.env\t0x0\t0x20000\n' > ${IMAGE_ROOTFS}${sysconfdir}/fw_env.config
+
+    # Rewrite fstab: keep stock entries, then add our mount points once.
+    # This avoids duplicates from Mender class + WIC both adding entries.
+    local fstab="${IMAGE_ROOTFS}${sysconfdir}/fstab"
+    sed -i '/\/uboot\|\/data\|\/boot\/efi/d' "$fstab"
+    printf '/dev/sda1\t/boot/efi\tvfat\tdefaults\t0\t0\n' >> "$fstab"
+    printf '/dev/sda2\t/uboot\tvfat\tdefaults,sync\t0\t0\n' >> "$fstab"
+    printf '/dev/sda5\t/data\text4\tdefaults\t0\t0\n' >> "$fstab"
+}

--- a/kas/demos/meta-mender-x86-uboot-efi/wic/mender-explicit-qemux86-64-validation.wks
+++ b/kas/demos/meta-mender-x86-uboot-efi/wic/mender-explicit-qemux86-64-validation.wks
@@ -1,0 +1,21 @@
+# short-description: Mender A/B partition layout for x86-64 U-Boot EFI — validation
+# long-description: Same as mender-explicit-qemux86-64.wks but with Root B
+# pre-populated for the bootloader validation suite (which tests A/B switching,
+# update simulation, and rollback).
+
+# ESP
+part --source bootimg-partition --ondisk sda --fstype=vfat --label ESP --align 1024 --size 16 --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+
+# U-Boot env partition
+part --source rawcopy --sourceparams="file=uboot-env-partition.img" --ondisk sda --align 1024 --fixed-size 4M
+
+# Root filesystem A
+part / --source rootfs --ondisk sda --fstype=ext4 --label rootA --align 1024 --fixed-size 512M
+
+# Root filesystem B — pre-populated so the validation suite can boot into it
+part --source rootfs --ondisk sda --fstype=ext4 --label rootB --align 1024 --fixed-size 512M
+
+# Data partition
+part --source rootfs --change-directory=data --ondisk sda --fstype=ext4 --label data --align 1024 --size 128
+
+bootloader --ptable gpt

--- a/kas/demos/meta-mender-x86-uboot-efi/wic/mender-explicit-qemux86-64.wks
+++ b/kas/demos/meta-mender-x86-uboot-efi/wic/mender-explicit-qemux86-64.wks
@@ -1,0 +1,32 @@
+# short-description: Mender A/B partition layout for x86-64 U-Boot EFI (QEMU)
+# long-description: GPT layout with separate ESP (read-only) and U-Boot env
+# partition. Keeping env writes off the ESP prevents FAT corruption that
+# breaks OVMF boot discovery after guest reboots.
+#
+# Boot chain: OVMF -> u-boot-app.efi (from ESP) -> Linux kernel (from rootfs)
+#
+# Partition layout:
+# 1. ESP (16MB, FAT) - bootx64.efi + startup.nsh (never written by U-Boot)
+# 2. U-Boot env (4MB, FAT) - uboot.env + uboot-redund.env
+# 3. Root A (512MB, ext4)
+# 4. Root B (512MB, ext4)
+# 5. Data (128MB, ext4)
+
+# ESP - no mount point here; fstab entry is managed by image postprocess
+# to avoid duplicates with Mender class entries
+part --source bootimg-partition --ondisk sda --fstype=vfat --label ESP --align 1024 --size 16 --part-type C12A7328-F81F-11D2-BA4B-00A0C93EC93B
+
+# U-Boot env partition - pre-built FAT image with valid env files
+# No mount point; fstab managed by image postprocess
+part --source rawcopy --sourceparams="file=uboot-env-partition.img" --ondisk sda --align 1024 --fixed-size 4M
+
+# Root filesystem A
+part / --source rootfs --ondisk sda --fstype=ext4 --label rootA --align 1024 --fixed-size 512M
+
+# Root filesystem B (empty; populated via OTA update or validation overlay)
+part --ondisk sda --fstype=ext4 --label rootB --align 1024 --fixed-size 512M
+
+# Data partition - no mount point; fstab managed by image postprocess
+part --source rootfs --change-directory=data --ondisk sda --fstype=ext4 --label data --align 1024 --size 128
+
+bootloader --ptable gpt

--- a/kas/demos/qemux86-64-uboot-efi-bootloader-validation.yml
+++ b/kas/demos/qemux86-64-uboot-efi-bootloader-validation.yml
@@ -1,0 +1,15 @@
+header:
+  version: 14
+  includes:
+  - kas/demos/qemux86-64-uboot-efi.yml
+
+repos:
+  meta-mender-community:
+    layers:
+      meta-mender-validation:
+
+local_conf_header:
+  bootloader-validation: |
+    # Pre-populate Root B so the validation suite can boot into it
+    WKS_FILE = "mender-explicit-qemux86-64-validation.wks"
+    IMAGE_INSTALL:append = " bootloader-validation"

--- a/kas/demos/qemux86-64-uboot-efi.yml
+++ b/kas/demos/qemux86-64-uboot-efi.yml
@@ -1,0 +1,122 @@
+header:
+  version: 14
+
+machine: qemux86-64
+distro: poky
+
+repos:
+  poky:
+    url: git://git.yoctoproject.org/poky
+    # yocto-5.0.15
+    commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+    patches:
+      qemuboot-none-fix:
+        repo: meta-mender-community
+        path: patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
+
+  meta-openembedded:
+    url: git://git.openembedded.org/meta-openembedded
+    # branch: scarthgap
+    commit: ec0469748be4159fb83fb0fa0148d786484c88cf
+    layers:
+      meta-oe:
+
+  meta-mender:
+    url: https://github.com/mendersoftware/meta-mender.git
+    # scarthgap-v2025.11
+    commit: 00d4dfc36625a27ca0d6ad7aa33eeeab397281a9
+    layers:
+      meta-mender-core:
+
+  meta-mender-community:
+    layers:
+      kas/demos/meta-mender-explicit-wic:
+      kas/demos/meta-mender-x86-uboot-efi:
+
+local_conf_header:
+  base: |
+    CONF_VERSION = "2"
+    PACKAGE_CLASSES = "package_ipk"
+    INIT_MANAGER = "systemd"
+
+  mender-artifact: |
+    MENDER_ARTIFACT_NAME = "x86-uboot-efi-demo"
+    MENDER_TENANT_TOKEN = ""
+    IMAGE_FSTYPES:prepend = "ext4 "
+
+  uboot-efi: |
+    # U-Boot as EFI application (replaces GRUB for GPLv3-free boot chain)
+    PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+    UBOOT_MACHINE = "efi-x86_app64_defconfig"
+    MENDER_UBOOT_AUTO_CONFIGURE = "0"
+
+    # ESP gets ONLY the EFI binary and startup.nsh — NO env files.
+    # Env lives on a separate FAT partition (part 2) to prevent writes
+    # from corrupting the ESP FAT for OVMF.
+    IMAGE_BOOT_FILES = "u-boot-app.efi;EFI/BOOT/bootx64.efi startup.nsh"
+
+    # EFI/UEFI platform configuration
+    MACHINE_FEATURES += "efi"
+    MENDER_EFI_LOADER = ""
+
+  qemu: |
+    # SATA/AHCI storage — virtio devices are NOT re-enumerated by OVMF
+    # after a guest reboot in QEMU, breaking the boot chain.
+    MENDER_STORAGE_DEVICE = "/dev/sda"
+    MENDER_BOOT_PART = "/dev/sda2"
+    MENDER_ROOTFS_PART_A = "/dev/sda3"
+    MENDER_ROOTFS_PART_B = "/dev/sda4"
+    MENDER_DATA_PART = "/dev/sda5"
+    QB_MEM = "-m 2048"
+    QB_DEFAULT_FSTYPE = "wic"
+    QB_DEFAULT_BIOS = "ovmf.qcow2"
+    QB_ROOTFS_OPT = ""
+    QB_DEFAULT_KERNEL = "none"
+    QB_DRIVE_TYPE = "/dev/sd"
+    QB_KERNEL_ROOT = "/dev/sda3"
+
+  mender: |
+    # Mender A/B update features — must be set globally (local.conf) so that
+    # individual recipes like mender-connect also see them, not only the
+    # image recipe which inherits mender-explicit-wic.
+    MENDER_FEATURES_ENABLE:append = " \
+        mender-uboot \
+        mender-auth-install \
+        mender-update-install \
+        mender-systemd \
+    "
+    MENDER_FEATURES_DISABLE:append = " \
+        mender-image \
+        mender-part-images \
+        mender-growfs-data \
+        mender-grub \
+    "
+
+    # Mender Client 4.x/5.x
+    PREFERRED_PROVIDER_mender-native =  "mender-native"
+    PREFERRED_RPROVIDER_mender-auth =   "mender"
+    PREFERRED_RPROVIDER_mender-update = "mender"
+    PREFERRED_VERSION_mender-artifact-native = "4.%"
+
+  x86-uboot-efi: |
+    # In EFI app mode, block devices use the "efi" interface
+    MENDER_UBOOT_STORAGE_INTERFACE = "efi"
+    MENDER_UBOOT_STORAGE_DEVICE = "0"
+    BOOTENV_SIZE = "0x20000"
+
+    # x86 does not use device trees
+    MENDER_DTB_NAME_FORCE = "none"
+
+    # WKS search path: include our layer's wic/ directory
+    WKS_SEARCH_PATH:prepend = "${LAYERDIR_meta-mender-x86-uboot-efi}/wic:"
+
+    IMAGE_INSTALL:append = " x86-uboot-efi-env efibootmgr"
+    IMAGE_INSTALL:remove = "kernel-devicetree"
+    EXTRA_IMAGEDEPENDS += "ovmf"
+
+target:
+  - mender-explicit-demo-image

--- a/kas/demos/qemux86-64-uboot-efi.yml
+++ b/kas/demos/qemux86-64-uboot-efi.yml
@@ -5,18 +5,31 @@ machine: qemux86-64
 distro: poky
 
 repos:
-  poky:
-    url: git://git.yoctoproject.org/poky
+  openembedded-core:
+    url: git://git.openembedded.org/openembedded-core.git
     # yocto-5.0.15
-    commit: 72983ac391008ebceb45edc7a8f0f6d5f4fe715c
+    commit: 6988157ad983978ffd6b12bcefedd4deaffdbbd1
     layers:
       meta:
-      meta-poky:
-      meta-yocto-bsp:
     patches:
       qemuboot-none-fix:
         repo: meta-mender-community
         path: patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
+
+  bitbake:
+    url: git://git.openembedded.org/bitbake.git
+    # yocto-5.0.15
+    commit: 8dcf084522b9c66a6639b5f117f554fde9b6b45a
+    layers:
+      bitbake: disabled
+
+  meta-yocto:
+    url: git://git.yoctoproject.org/git/meta-yocto.git
+    # yocto-5.0.15
+    commit: 9bb6e6e8b016a0c9dfe290369a6ed91ef4020535
+    layers:
+      meta-poky:
+      meta-yocto-bsp:
 
   meta-openembedded:
     url: git://git.openembedded.org/meta-openembedded


### PR DESCRIPTION
Add a QEMU-testable demo that replaces GRUB with U-Boot running as an EFI application under OVMF on x86-64, providing a GPLv3-free boot chain with Mender A/B rootfs updates.

Boot chain: QEMU -> OVMF -> u-boot-app.efi (from ESP) -> Linux kernel

The implementation uses a 5-partition GPT layout with a dedicated FAT partition for the U-Boot environment, separate from the ESP, to prevent FAT corruption that breaks OVMF boot discovery after guest reboots.

Notable adaptations for EFI app mode:
- SATA/AHCI storage instead of virtio (OVMF reboot re-enumeration)
- Inline altbootcmd recovery instead of reset (OVMF exits to UI)
- Conditional kernel load (load && zboot) to avoid stale RAM boots
- Pre-populated env via mkenvimage with redundant env support

Includes a kas overlay for the bootloader validation suite.

Based on: https://hub.mender.io/t/u-boot-efi-on-intel-corei7-64/8216