### PR TITLE
kirkstone: add qemuboot QB_DEFAULT_KERNEL=none patch

### DIFF
--- a/patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
+++ b/patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
@@ -1,0 +1,50 @@
+From 8d3cfd5e52f25453f58677f05bcf0b591b4cd607 Mon Sep 17 00:00:00 2001
+From: Josef Holzmayr <jester@theyoctojester.info>
+Date: Thu, 24 Jul 2025 16:26:33 +0000
+Subject: [PATCH] qemuboot: handle QB_DEFAULT_KERNEL="none" properly
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This fixes the qemuboot.bbclass to properly handle when QB_DEFAULT_KERNEL
+is set to "none". Previously, the class tried to resolve "none" as a
+file path which failed. Now it checks for the "none" value and writes
+it directly to the qemuboot.conf, allowing runqemu to skip kernel loading
+and use UEFI boot instead.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
+---
+ meta/classes-recipe/qemuboot.bbclass | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/meta/classes-recipe/qemuboot.bbclass b/meta/classes-recipe/qemuboot.bbclass
+index 0f80c60ab5..1273a0a8f5 100644
+--- a/meta/classes-recipe/qemuboot.bbclass
++++ b/meta/classes-recipe/qemuboot.bbclass
+@@ -170,11 +170,15 @@ python do_write_qemuboot_conf() {
+     # QB_DEFAULT_KERNEL's value of KERNEL_IMAGETYPE is the name of a symlink
+     # to the kernel file, which hinders relocatability of the qb conf.
+     # Read the link and replace it with the full filename of the target.
+-    kernel_link = os.path.join(d.getVar('DEPLOY_DIR_IMAGE'), d.getVar('QB_DEFAULT_KERNEL'))
+-    kernel = os.path.realpath(kernel_link)
+-    # we only want to write out relative paths so that we can relocate images
+-    # and still run them
+-    kernel = os.path.relpath(kernel, finalpath)
++    qb_default_kernel = d.getVar('QB_DEFAULT_KERNEL')
++    if qb_default_kernel == "none":
++        kernel = "none"
++    else:
++        kernel_link = os.path.join(d.getVar('DEPLOY_DIR_IMAGE'), qb_default_kernel)
++        kernel = os.path.realpath(kernel_link)
++        # we only want to write out relative paths so that we can relocate images
++        # and still run them
++        kernel = os.path.relpath(kernel, finalpath)
+     cf.set('config_bsp', 'QB_DEFAULT_KERNEL', kernel)
+ 
+     bb.utils.mkdirhier(os.path.dirname(qemuboot))
+-- 
+2.34.1
+


### PR DESCRIPTION
## Summary

- Backport the `qemuboot.bbclass` patch from scarthgap to kirkstone
- The patch allows `QB_DEFAULT_KERNEL="none"` to work correctly, which is required for UEFI boot in qemuarm64 builds
- Without it, the class tries to resolve `"none"` as a file path and fails

## Context

The patch was added to scarthgap in commit ab73518 but was never carried to kirkstone. The `mender-community-images` kirkstone kas configs for qemuarm64 reference this patch from the `meta-mender-community` repo, causing builds to fail with:

```
Could not find patch. (patch path: .../patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch, repo: openembedded-core, patch entry: qemuboot-none-fix)
```

🤖 Generated with [Claude Code](https://claude.ai/code)