### PR TITLE
kirkstone: fix qemuboot patch for kirkstone class path

### DIFF
--- a/patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
+++ b/patches/openembedded-core/0001-qemuboot-handle-QB_DEFAULT_KERNEL-none-properly.patch
@@ -1,0 +1,43 @@
+From 51259c7e933a2ac8ebc01604d6e65607b76b7b56 Mon Sep 17 00:00:00 2001
+From: Josef Holzmayr <jester@theyoctojester.info>
+Date: Thu, 24 Jul 2025 16:26:33 +0000
+Subject: [PATCH] qemuboot: handle QB_DEFAULT_KERNEL="none" properly
+
+This fixes the qemuboot.bbclass to properly handle when QB_DEFAULT_KERNEL
+is set to "none". Previously, the class tried to resolve "none" as a
+file path which failed. Now it checks for the "none" value and writes
+it directly to the qemuboot.conf, allowing runqemu to skip kernel loading
+and use UEFI boot instead.
+
+Signed-off-by: Josef Holzmayr <jester@theyoctojester.info>
+---
+ meta/classes/qemuboot.bbclass | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/meta/classes/qemuboot.bbclass b/meta/classes/qemuboot.bbclass
+index f2ebe94..d1d637b 100644
+--- a/meta/classes/qemuboot.bbclass
++++ b/meta/classes/qemuboot.bbclass
+@@ -148,11 +148,15 @@ python do_write_qemuboot_conf() {
+     # QB_DEFAULT_KERNEL's value of KERNEL_IMAGETYPE is the name of a symlink
+     # to the kernel file, which hinders relocatability of the qb conf.
+     # Read the link and replace it with the full filename of the target.
+-    kernel_link = os.path.join(d.getVar('DEPLOY_DIR_IMAGE'), d.getVar('QB_DEFAULT_KERNEL'))
+-    kernel = os.path.realpath(kernel_link)
+-    # we only want to write out relative paths so that we can relocate images
+-    # and still run them
+-    kernel = os.path.relpath(kernel, finalpath)
++    qb_default_kernel = d.getVar('QB_DEFAULT_KERNEL')
++    if qb_default_kernel == "none":
++        kernel = "none"
++    else:
++        kernel_link = os.path.join(d.getVar('DEPLOY_DIR_IMAGE'), qb_default_kernel)
++        kernel = os.path.realpath(kernel_link)
++        # we only want to write out relative paths so that we can relocate images
++        # and still run them
++        kernel = os.path.relpath(kernel, finalpath)
+     cf.set('config_bsp', 'QB_DEFAULT_KERNEL', kernel)
+
+     bb.utils.mkdirhier(os.path.dirname(qemuboot))
+--
+2.34.1


### PR DESCRIPTION
## Summary

- Fix the qemuboot patch to target `meta/classes/qemuboot.bbclass` (kirkstone) instead of `meta/classes-recipe/qemuboot.bbclass` (scarthgap)
- The previous PR #506 carried over the scarthgap version of the patch verbatim, but kirkstone's openembedded-core has `qemuboot.bbclass` under `meta/classes/`, not `meta/classes-recipe/` which was introduced in later releases

## Context

Build error after #506:
```
error: meta/classes-recipe/qemuboot.bbclass: No such file or directory
```

The logic of the patch is identical - only the file path in the diff header changes.

## Test plan

- [ ] Verify `git apply` succeeds against kirkstone openembedded-core at `036f76ea`
- [ ] Rebuild kirkstone qemuarm64 tagged config after merging and updating commit pin

🤖 Generated with [Claude Code](https://claude.ai/code)