### PR TITLE
fix: relocate firmware DTB to fdt_addr_r before booti on RPi

### DIFF
--- a/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-mender-raspberrypi/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -2,5 +2,11 @@ fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 run mender_setup
 mmc dev ${mender_uboot_dev}
 load ${mender_uboot_root} ${kernel_addr_r} /boot/@@KERNEL_IMAGETYPE@@
-@@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr}
+# Relocate the firmware-placed DTB to fdt_addr_r before booti. U-Boot
+# >= 2026.01 tightened lmb_reserve() in image_setup_libfdt() and rejects
+# the firmware's high placement (start4.elf parks the DTB near the top
+# of ARM-visible RAM). fdt_addr_r is a fixed low slot defined in
+# rpi_arm64's ENV_MEM_LAYOUT_SETTINGS and is safe on all CM4 variants.
+fdt move ${fdt_addr} ${fdt_addr_r}
+@@KERNEL_BOOTCMD@@ ${kernel_addr_r} - ${fdt_addr_r}
 run mender_try_to_recover


### PR DESCRIPTION
U-Boot 2026.01 tightened lmb_reserve() in image_setup_libfdt(). The firmware-placed DTB (parked by start4.elf near the top of ARM-visible RAM) now fails reservation:

    Working FDT set to 3af36f30
    Failed to reserve memory for fdt at 0x3af36f30
    FDT creation failed!
    resetting ...

Move the blob to fdt_addr_r (a fixed low slot defined in rpi_arm64's ENV_MEM_LAYOUT_SETTINGS) and hand that address to booti instead. This is the same pattern meta-mender's generic boot code already uses for non-RPi targets, so it aligns RPi with the rest of the ecosystem rather than introducing anything new. Works on all CM4 variants (1/2/4/8 GB); the symptom actually grows worse on larger parts because start4.elf places the DTB proportionally higher.

Verified on a 1 GB CM4 with U-Boot 2026.01 and linux 6.18.

AI disclosure: Claude Code.