### PR TITLE
tegra/jp6: refresh KernelCommandLine runtime-access patch

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-jetpack6/recipes-bsp/uefi/files/0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch
+++ b/meta-mender-tegra/meta-mender-tegra-jetpack6/recipes-bsp/uefi/files/0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch
@@ -4,6 +4,11 @@ Date: Tue, 19 Nov 2024 09:24:56 +0100
 Subject: [PATCH] edk2-nvidia: Enable runtime access to KernelCommandLine
  efivar
 
+Upstream-Status: Inappropriate [Mender-specific: KernelCommandLine
+ efivar needs runtime access for Mender state flow]
+
+Signed-off-by: Alexander Knaub <alexander.knaub@faro.com>
+Signed-off-by: Josef Holzmayr <josef.holzmayr@northern.tech>
 ---
  Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c   | 2 +-
  Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr | 2 +-
@@ -11,10 +16,9 @@ Subject: [PATCH] edk2-nvidia: Enable runtime access to KernelCommandLine
  3 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
-index ad3b7cc6..25b8471c 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigDxe.c
-@@ -2316,7 +2316,7 @@ InitializeSettings (
+@@ -2316,7 +2316,7 @@
    if (KernelCmdLineLen < sizeof (CmdLine)) {
      KernelCmdLineLen = sizeof (CmdLine);
      ZeroMem (&CmdLine, KernelCmdLineLen);
@@ -24,10 +28,9 @@ index ad3b7cc6..25b8471c 100644
        DEBUG ((DEBUG_ERROR, "%a: Error setting command line variable %r\r\n", __FUNCTION__, Status));
      }
 diff --git a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
-index ca329886..5c1d2018 100644
 --- a/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
 +++ b/Silicon/NVIDIA/Drivers/NvidiaConfigDxe/NvidiaConfigHii.vfr
-@@ -61,7 +61,7 @@ formset
+@@ -61,7 +61,7 @@
      guid  = NVIDIA_TOKEN_SPACE_GUID;
  
    efivarstore NVIDIA_KERNEL_COMMAND_LINE,
@@ -37,10 +40,9 @@ index ca329886..5c1d2018 100644
      guid  = NVIDIA_PUBLIC_VARIABLE_GUID;
  
 diff --git a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
-index 91f8089e..80b6e3a2 100644
 --- a/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
 +++ b/Silicon/NVIDIA/Library/PlatformBootManagerLib/PlatformBm.c
-@@ -1318,7 +1318,7 @@ IsPlatformConfigurationNeeded (
+@@ -1318,7 +1318,7 @@
      ZeroMem (&AddlCmdLine, AddlCmdLen);
      Status = gRT->GetVariable (L"KernelCommandLine", &gNVIDIAPublicVariableGuid, &AddlCmdLineAttributes, &AddlCmdLen, &AddlCmdLine);
      if (EFI_ERROR (Status)) {


### PR DESCRIPTION
## Problem

The patch `meta-mender-tegra/meta-mender-tegra-jetpack6/recipes-bsp/uefi/files/0001-Enable-runtime-access-to-KernelCommandLine-efivar.patch` was authored against an older `edk2-nvidia` checkout with LF line endings. The current `edk2-nvidia@r36.5-updates` source files pinned by `meta-tegra` (SRCREV `79ad0c17…`) carry CRLF line terminators, so `quilt push` refuses every hunk with "different line endings" on most builds. On a couple of variants the hunks land with offset plus fuzz, which wrynose-era bitbake escalates as a fatal `[patch-fuzz]` QA error.

Observed in `edk2-firmware-tegra-36.5.0-r0 do_patch` across all four JetPack 6 machines (`jetson-agx-orin-devkit`, `jetson-agx-orin-devkit-64` / `p3737_0000_p3701_0005`, `jetson-orin-16gb-nx-p3786` / `p3768_0000_p3767_0000`, `jetson-orin-nano-devkit`).

## Fix

Regenerate the patch against the three target files in `edk2-nvidia@79ad0c17aa4f13fdd5164d5b026fa49436b34891` so context and line terminators match byte-for-byte. Logical change is unchanged: `EFI_VARIABLE_RUNTIME_ACCESS` is added to the `KernelCommandLine` efivar in three places. Also adds the `Upstream-Status: Inappropriate` header the Yocto patch-style guide requires, which wrynose treats as a hard failure when missing.

## Verification

`patch -p1` applies the refreshed patch to a clean `edk2-nvidia@79ad0c17` checkout with three files patched, zero fuzz, zero rejects, CRLF preserved.

## Notes

- The jp5 copy of this patch currently applies with offsets only (no fuzz) and isn't breaking CI, so it's left alone. Happy to refresh it in a follow-up if desired.
- Downstream (`mender-community-images`) kas configs pin `meta-mender-community` by commit hash, so a separate PR bumping those pins is needed before this fix reaches the scarthgap tegra CI jobs.