### PR TITLE
wrynose: fix UNPACKDIR usage and drop S = "${WORKDIR}/git"

### DIFF
--- a/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/update-firmware-state-script.bb
+++ b/meta-mender-raspberrypi/recipes-mender/update-firmware-state-script/update-firmware-state-script.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://ArtifactInstall_Leave_50.in"
 do_deploy() {
     sed -e 's#@@MENDER_ROOTFS_PART_A@@#'"${MENDER_ROOTFS_PART_A}"'#' \
         -e 's#@@MENDER_ROOTFS_PART_B@@#'"${MENDER_ROOTFS_PART_B}"'#' \
-        "${WORKDIR}/ArtifactInstall_Leave_50.in" > "${WORKDIR}/ArtifactInstall_Leave_50"
+        "${UNPACKDIR}/ArtifactInstall_Leave_50.in" > "${WORKDIR}/ArtifactInstall_Leave_50"
     cp ${WORKDIR}/ArtifactInstall_Leave_50 ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_50
 }
 

--- a/meta-mender-update-modules/dynamic-layers/virtualization/recipes-mender/mender-update-modules/mender-app-update_git.bb
+++ b/meta-mender-update-modules/dynamic-layers/virtualization/recipes-mender/mender-update-modules/mender-app-update_git.bb
@@ -8,8 +8,6 @@ SRC_URI = "git://github.com/mendersoftware/app-update-module;branch=master;proto
 
 SRCREV = "c9f28c6c6a8c4cfb5297520c0da832177be87002"
 
-S = "${WORKDIR}/git"
-
 RDEPENDS:${PN} = "docker-compose jq mender-update xdelta3"
 
 inherit allarch

--- a/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
+++ b/meta-mender-update-modules/recipes-mender/mender-update-modules/mender-update-modules.inc
@@ -5,5 +5,3 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=86d3f3a95c324c9479bd8986968f4327"
 SRC_URI = "git://github.com/mendersoftware/mender-update-modules.git;branch=master;protocol=https"
 
 SRCREV = "a9f676eefe2e482ba3f7a6ad2d8c15ab3327a54f"
-
-S = "${WORKDIR}/git"


### PR DESCRIPTION
## Summary

Two related fixes for building on OE-core **wrynose**, where `SRC_URI`
content now unpacks into `UNPACKDIR` (`${WORKDIR}/sources`) instead of
`${WORKDIR}`, and a git `SRC_URI` lands in `${UNPACKDIR}/${BP}` because
`bitbake.conf` sets `BB_GIT_DEFAULT_DESTSUFFIX = "${BP}"` (so the default
`S = "${UNPACKDIR}/${BP}"` now resolves correctly for git recipes).

### 1. meta-mender-raspberrypi: `update-firmware-state-script`
`do_deploy()` read its `file://ArtifactInstall_Leave_50.in` template via
`${WORKDIR}`, which no longer holds the unpacked source. Read it from
`${UNPACKDIR}` instead (the generated output stays in `${WORKDIR}`). This
mirrors the existing u-boot `do_mender_uboot_auto_configure` fix.

### 2. meta-mender-update-modules: drop `S = "${WORKDIR}/git"`
`insane.bbclass` `do_qa_unpack` now fatals on an explicit
`S = "${WORKDIR}/git"` (and on `S = "${UNPACKDIR}/git"`), requiring the
assignment to be removed. Dropped it from `mender-update-modules.inc`
(shared by `mender-dir-overlay`, `mender-ipk`,
`mender-rootfs-version-check`) and from `mender-app-update_git.bb`; the
default `S` resolves to where the git source now unpacks.

## Validation

Built on a wrynose RPi (`raspberrypi4-64`) configuration (oe-core/meta-yocto
`wrynose`, bitbake `master`, meta-mender `master-next`):

- `update-firmware-state-script`: full build incl. `do_deploy` succeeds;
  `S` resolves under `UNPACKDIR`.
- `mender-ipk`, `mender-dir-overlay`, `mender-rootfs-version-check`:
  `do_unpack` and `do_install` succeed with the default `S`
  (`${UNPACKDIR}/${BP}`); no `do_qa_unpack` fatal.

`mender-app-update` carries the identical one-line change; its recipe lives
behind the `virtualization-layer` dynamic layer and was not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
