### PR TITLE
meta-mender-qcom: Arduino Uno Q Mender integration (A/B rootfs + STM32U585 MCU firmware)

### DIFF
--- a/meta-mender-qcom/README.md
+++ b/meta-mender-qcom/README.md
@@ -29,6 +29,28 @@ What the layer provides:
  - **bless-boot gating** — a drop-in suppresses meta-qcom's automatic slot-bless while a Mender
    update is in flight, so Mender owns commit/rollback (normal boots still auto-bless).
 
+## MCU firmware updates (STM32U585)
+
+A second Mender update type deploys firmware to the Uno Q's on-board **STM32U585**
+(Cortex-M33) coprocessor, which is not covered by the ABL/`qbootctl` slots (those are
+eMMC/OS only). The QRB2210 programs the STM32 over an **internal SWD link** (no external
+probe) that OpenOCD bit-bangs via `linuxgpiod` on the TLMM (`gpiochip1`, SWDIO=25 / SWCLK=26).
+
+ - **`zephyr-mcu` Mender Update Module** (`unoq-mcu-integration`) — streams the firmware
+   image, backs up the current MCU flash to `/data`, then `openocd program … verify` over
+   SWD. Health is the SWD read-back verify (no Linux↔MCU channel needed); `NeedsArtifactReboot=No`
+   (only the MCU resets, the Linux host stays up); rollback re-flashes the backup. It also
+   sets the STM32 option bytes (`nSWBOOT0=0, nBOOT0=1`) idempotently so the MCU boots the
+   flashed image regardless of the BOOT0 pin.
+ - **OpenOCD** — `openocd_git.bbappend` enables the `linuxgpiod` driver (the kernel exposes
+   `/dev/gpiochipN` but no sysfs GPIO). That OpenOCD revision uses the libgpiod **v1** API,
+   so the build must pin `libgpiod 1.6.5` (set in the build config).
+ - **Zephyr demo firmware** — `zephyr-unoq-blink` (a versioned LED blink with an SWD-readable
+   version marker) plus the `arduino-uno-q` Cortex-M33 MACHINE and the `mcu` multiconfig show
+   how to build an MCU firmware image (via meta-zephyr) and package it as a `zephyr-mcu`
+   artifact. These live under `dynamic-layers/zephyrcore/` + `conf/`, so they are only built
+   when meta-zephyr is present — the layer does not otherwise depend on it.
+
 ## Dependencies
 
 This layer depends on:
@@ -64,7 +86,6 @@ credentials); configure WiFi/networking at runtime or via a local overlay.
 
 ## Future work
 
-The Update-Module approach extends naturally to the other updatable parts of the Uno Q as
-separate Mender artifact types alongside the rootfs one:
- - the on-board **STM32U585 MCU** firmware (Zephyr), and
+The Update-Module approach extends naturally to further updatable parts of the Uno Q as
+separate Mender artifact types alongside the rootfs and MCU-firmware ones:
  - **AI models** shipped in conjunction with Edge Impulse.

--- a/meta-mender-qcom/README.md
+++ b/meta-mender-qcom/README.md
@@ -1,0 +1,70 @@
+# meta-mender-qcom
+
+Mender integration for Qualcomm (qualcomm-linux `meta-qcom`) based boards.
+
+Supported and tested boards:
+ - **Arduino Uno Q** (Qualcomm Dragonwing QRB2210, MACHINE `uno-q`)
+
+## Approach
+
+Unlike Mender's classic dual-rootfs + U-Boot/GRUB integration, this layer reuses the
+platform's **native A/B boot slots** (Qualcomm ABL + `qbootctl`) and drives them from a
+custom Mender **Update Module** (`qbootctl-rootfs`). This avoids re-partitioning around
+Mender's model and instead fits the Qualcomm boot flow (PBL → XBL → ABL → U-Boot → UEFI →
+systemd-boot/UKI).
+
+What the layer provides:
+ - **Slotted OS layout** — a `qcom-partition-conf` bbappend derives a `system_a`/`system_b`
+   (+ `userdata`, + `dtbo_a`/`dtbo_b` required by `qbootctl -s`) GPT from the stock
+   `qrb2210-unoq` partition table (`QCOM_PARTITION_FILES_SUBDIR = partitions/qrb2210-unoq/system-ab`).
+ - **Slot-aware initramfs** (`unoq-initramfs-ab` + the `86-abslot` initramfs-framework module) —
+   reads the active slot via `qbootctl` and mounts `system_<slot>`. Self-heals: if the active
+   slot has no valid filesystem it switches to the other slot (`qbootctl -s`/`-m`) and reboots,
+   so a bad update rolls back deterministically.
+ - **`qbootctl-rootfs` Mender Update Module** — writes the payload to the inactive slot,
+   `qbootctl -s` it, reboots (Automatic), verifies the booted slot, commits with `qbootctl -m`,
+   rolls back on failure.
+ - **Persistent Mender state** — `userdata` is mounted at `/data` and `/var/lib/mender` is bound
+   onto it so device identity + in-flight update state survive the rootfs swap.
+ - **bless-boot gating** — a drop-in suppresses meta-qcom's automatic slot-bless while a Mender
+   update is in flight, so Mender owns commit/rollback (normal boots still auto-bless).
+
+## Dependencies
+
+This layer depends on:
+
+```
+URI: https://github.com/qualcomm-linux/meta-qcom
+branch: master
+URI: https://github.com/qualcomm-linux/meta-qcom-3rdparty   # provides the uno-q MACHINE + firmware/kernel/u-boot
+branch: main
+URI: https://github.com/mendersoftware/meta-mender
+branch: wrynose
+```
+
+## Quick start
+
+Build configs (kas) live in the companion
+[mender-community-images](https://github.com/theyoctojester/mender-community-images) repo:
+
+```
+kas build mender-community-images/yocto/wrynose/floating/uno-q.yml
+```
+
+## Flashing / console
+
+The Uno Q is flashed over Qualcomm EDL with `qdl` (the build produces a `.qcomflash` set):
+
+```
+qdl --debug --storage emmc prog_firehose_ddr.elf rawprogram0.xml patch0.xml
+```
+
+Network/connectivity is **site-specific** and intentionally not shipped here (no baked
+credentials); configure WiFi/networking at runtime or via a local overlay.
+
+## Future work
+
+The Update-Module approach extends naturally to the other updatable parts of the Uno Q as
+separate Mender artifact types alongside the rootfs one:
+ - the on-board **STM32U585 MCU** firmware (Zephyr), and
+ - **AI models** shipped in conjunction with Edge Impulse.

--- a/meta-mender-qcom/conf/layer.conf
+++ b/meta-mender-qcom/conf/layer.conf
@@ -1,6 +1,14 @@
 BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
 
+# The Zephyr MCU demo firmware (dynamic-layers/zephyrcore) is only buildable when
+# meta-zephyr is present. Parse it dynamically so the layer keeps working (rootfs
+# A/B + the zephyr-mcu update module) without a hard dependency on meta-zephyr.
+BBFILES_DYNAMIC += " \
+    zephyrcore:${LAYERDIR}/dynamic-layers/zephyrcore/recipes-*/*/*.bb \
+    zephyrcore:${LAYERDIR}/dynamic-layers/zephyrcore/recipes-*/*/*.bbappend \
+"
+
 BBFILE_COLLECTIONS += "mender-qcom"
 BBFILE_PATTERN_mender-qcom = "^${LAYERDIR}/"
 BBFILE_PRIORITY_mender-qcom = "10"

--- a/meta-mender-qcom/conf/layer.conf
+++ b/meta-mender-qcom/conf/layer.conf
@@ -1,0 +1,9 @@
+BBPATH .= ":${LAYERDIR}"
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "mender-qcom"
+BBFILE_PATTERN_mender-qcom = "^${LAYERDIR}/"
+BBFILE_PRIORITY_mender-qcom = "10"
+
+LAYERSERIES_COMPAT_mender-qcom = "wrynose"
+LAYERDEPENDS_mender-qcom = "mender qcom qcom-3rdparty"

--- a/meta-mender-qcom/conf/machine/arduino-uno-q.conf
+++ b/meta-mender-qcom/conf/machine/arduino-uno-q.conf
@@ -1,0 +1,23 @@
+#@TYPE: Machine
+#@NAME: Arduino Uno Q MCU (STM32U585)
+#@DESCRIPTION: The Arduino Uno Q's on-board STM32U585 (Cortex-M33) coprocessor,
+#              built as Zephyr firmware via meta-zephyr. This is a separate
+#              MACHINE from the aarch64 uno-q Linux MACHINE and is only used in
+#              the 'mcu' multiconfig.
+
+require conf/machine/include/arm/armv8-m/tune-cortexm33.inc
+
+# GLIBC will not work on Cortex-M; Zephyr uses newlib.
+TCLIBC = "newlib"
+
+# Zephyr's BOARD for this MACHINE. zephyr.bbclass would derive it by swapping
+# '-' for '_' (arduino-uno-q -> arduino_uno_q); set it explicitly to be safe.
+ZEPHYR_BOARD = "arduino_uno_q"
+
+# oe-core's cortexm33 tune adds the 'dsp' feature, which appends '+dsp' to
+# '-mcpu=cortex-m33'. GCC 16.1 (this oe-core) rejects that suffix ("cortex-m33
+# does not support feature 'dsp'"). DSP is implicit on M33, so blank the
+# march-opts to drop the '+dsp' while KEEPING the dsp tune feature -- that keeps
+# TUNE_PKGARCH (cortexm33e-fpv5-spd16) consistent with PACKAGE_ARCHS. Zephyr's
+# own build sets the MCU's -mcpu/-mfpu flags itself.
+TUNE_CCARGS_MARCH_OPTS = ""

--- a/meta-mender-qcom/conf/multiconfig/mcu.conf
+++ b/meta-mender-qcom/conf/multiconfig/mcu.conf
@@ -1,0 +1,10 @@
+# Multiconfig for the Uno Q MCU (STM32U585 / Cortex-M33) Zephyr firmware.
+#
+# Enabled from unoq-mcu.yml via BBMULTICONFIG = "mcu". Shares the main build's
+# caches / thread caps / mirrors (via local.conf) but targets the arduino-uno-q
+# MACHINE instead of the aarch64 uno-q Linux MACHINE. Build with:
+#   bitbake mc:mcu:zephyr-unoq-blink   (or  kas build ... --target mc:mcu:zephyr-unoq-blink)
+
+require conf/local.conf
+
+MACHINE = "arduino-uno-q"

--- a/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/CMakeLists.txt
+++ b/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/CMakeLists.txt
@@ -1,0 +1,20 @@
+# Uno Q MCU demo: versioned LED blink (out-of-tree Zephyr application).
+cmake_minimum_required(VERSION 3.20.0)
+
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(unoq_mcu_blink C)
+
+# Version + blink period are injected by the Yocto recipe (-D...), with sane
+# fallbacks so a standalone `west build -b arduino_uno_q` still works.
+if(NOT DEFINED FW_VERSION)
+  set(FW_VERSION "unoq-mcu-dev")
+endif()
+if(NOT DEFINED BLINK_PERIOD_MS)
+  set(BLINK_PERIOD_MS 500)
+endif()
+
+target_sources(app PRIVATE src/main.c)
+target_compile_definitions(app PRIVATE
+  FW_VERSION="${FW_VERSION}"
+  BLINK_PERIOD_MS=${BLINK_PERIOD_MS}
+)

--- a/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/prj.conf
+++ b/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/prj.conf
@@ -1,0 +1,8 @@
+# Minimal config: GPIO for led0 + printk console output.
+CONFIG_GPIO=y
+CONFIG_PRINTK=y
+
+# picolibc's getentropy references the board's zephyr,entropy device (the STM32
+# RNG). Enable the entropy driver so that device is instantiated, otherwise the
+# link fails with "undefined reference to __device_dts_ord_<n>".
+CONFIG_ENTROPY_GENERATOR=y

--- a/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/src/main.c
+++ b/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/files/app/src/main.c
@@ -1,0 +1,47 @@
+/*
+ * Uno Q MCU demo firmware: a versioned LED blink for the on-board STM32U585.
+ *
+ * FW_VERSION and BLINK_PERIOD_MS are injected at build time by the Yocto recipe
+ * (see CMakeLists.txt), so v1/v2 differ only by recipe variables.
+ *
+ * fw_version[] is kept in its own .rodata section and marked "used" so it
+ * survives link-time garbage collection. The Mender "zephyr-mcu" update module
+ * reads this marker back over SWD (OpenOCD) to verify which firmware is running,
+ * without needing a Linux-side comms channel to the MCU. The "UNOQMCU:" tag
+ * makes it trivial to locate in a raw flash dump.
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
+
+#ifndef FW_VERSION
+#define FW_VERSION "unoq-mcu-dev"
+#endif
+#ifndef BLINK_PERIOD_MS
+#define BLINK_PERIOD_MS 500
+#endif
+
+__attribute__((used, section(".rodata.fw_version")))
+const char fw_version[] = "UNOQMCU:" FW_VERSION;
+
+static const struct gpio_dt_spec led = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
+
+int main(void)
+{
+	printk("unoq-mcu firmware %s (blink %d ms)\n", fw_version, BLINK_PERIOD_MS);
+
+	if (!gpio_is_ready_dt(&led)) {
+		printk("unoq-mcu: led0 not ready\n");
+		return 0;
+	}
+	if (gpio_pin_configure_dt(&led, GPIO_OUTPUT_ACTIVE) < 0) {
+		printk("unoq-mcu: led0 configure failed\n");
+		return 0;
+	}
+
+	while (1) {
+		gpio_pin_toggle_dt(&led);
+		k_msleep(BLINK_PERIOD_MS);
+	}
+	return 0;
+}

--- a/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/zephyr-unoq-blink.bb
+++ b/meta-mender-qcom/dynamic-layers/zephyrcore/recipes-firmware/zephyr-unoq-blink/zephyr-unoq-blink.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Uno Q MCU demo: versioned LED blink (Zephyr) for the STM32U585"
+DESCRIPTION = "A minimal Zephyr application for the Arduino Uno Q's on-board \
+STM32U585 (Cortex-M33) MCU. Blinks led0 at a version-dependent rate and embeds \
+a version marker in .rodata (readable over SWD) so the Mender zephyr-mcu update \
+module can verify the running firmware. Built in the 'mcu' multiconfig."
+
+# zephyr-sample -> zephyr-image.inc -> zephyr-kernel-src.inc, which sets
+# LICENSE = "Apache-2.0" + LIC_FILES_CHKSUM (the fetched Zephyr LICENSE); our
+# app source is Apache-2.0 too, so we do not override them.
+inherit zephyr-sample
+
+COMPATIBLE_MACHINE = "arduino-uno-q"
+
+# Out-of-tree Zephyr app shipped with the recipe. It unpacks to ${UNPACKDIR}/app
+# alongside the fetched Zephyr tree (ZEPHYR_BASE = ${S}/zephyr).
+SRC_URI += "file://app"
+ZEPHYR_SRC_DIR = "${UNPACKDIR}/app"
+
+# Demo version + blink period, injected into the app build. Bump for v2.
+FW_VERSION ?= "unoq-mcu-v1"
+BLINK_PERIOD_MS ?= "500"
+EXTRA_OECMAKE:append = " -DFW_VERSION=${FW_VERSION} -DBLINK_PERIOD_MS=${BLINK_PERIOD_MS}"
+
+# Produce the .hex (used for flashing) in addition to .elf/.bin; the class
+# default omits .hex.
+ZEPHYR_MAKE_OUTPUT = "zephyr.elf zephyr.bin zephyr.hex"

--- a/meta-mender-qcom/recipes-bsp/partition/qcom-partition-conf_%.bbappend
+++ b/meta-mender-qcom/recipes-bsp/partition/qcom-partition-conf_%.bbappend
@@ -1,0 +1,27 @@
+# Add a slotted A/B partition layout for the Uno Q by deriving it from the stock
+# emmc-16GB layout: replace the single grow-to-end `rootfs` with two equal
+# `system_a`/`system_b` slots (named `system_*` so qbootctl manages their GPT AB
+# bits) plus a grow-to-end `userdata`. Both system slots reference rootfs.img, so
+# the single built rootfs image is written to both at flash time (both slots
+# provisioned). Selected via QCOM_PARTITION_FILES_SUBDIR = partitions/qrb2210-unoq/system-ab.
+
+do_compile:prepend() {
+    src="${S}/platforms/qrb2210-unoq/emmc-16GB/partitions.conf"
+    dst="${S}/platforms/qrb2210-unoq/system-ab"
+    if [ -f "$src" ]; then
+        mkdir -p "$dst"
+        # drop the single rootfs partition, keep everything else (incl. --grow-last-partition on --disk)
+        sed '/--name=rootfs /d' "$src" > "$dst/partitions.conf"
+        # dtbo_a/dtbo_b: qbootctl's set-active path treats boot_a and dtbo_a as
+        # hard-required (others are skipped if absent). We have boot_a/b but no
+        # dtbo, so add a small dtbo pair so `qbootctl -s` succeeds. system_a/b are
+        # the OS slots; userdata (last, grows to fill) is persistent.
+        cat >> "$dst/partitions.conf" <<'PARTS'
+--partition --name=dtbo_a --size=8192KB --type-guid=24D0D418-D31D-4D8D-AC2C-4D4305188450
+--partition --name=dtbo_b --size=8192KB --type-guid=24D0D418-D31D-4D8D-AC2C-4D4305188450
+--partition --name=system_a --size=5242880KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --name=system_b --size=5242880KB --type-guid=B921B045-1DF0-41C3-AF44-4C6F280D3FAE --filename=rootfs.img
+--partition --name=userdata --size=2145728KB --type-guid=0FC63DAF-8483-4772-8E79-3D69D8477DE4
+PARTS
+    fi
+}

--- a/meta-mender-qcom/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-mender-qcom/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,9 @@
+# Mount the persistent userdata partition at /data (auto-mkfs on first use).
+# Mender's state is relocated here (see unoq-mender-persist) so device identity
+# and in-flight update state survive the A/B rootfs swap. nofail so a data-part
+# hiccup never drops the system to emergency mode.
+do_install:append() {
+    printf '%-24s %-10s %-6s %-40s %s\n' \
+        "PARTLABEL=userdata" "/data" "ext4" "defaults,x-systemd.makefs,nofail,x-systemd.growfs" "0 2" \
+        >> ${D}${sysconfdir}/fstab
+}

--- a/meta-mender-qcom/recipes-core/images/unoq-initramfs-ab.bb
+++ b/meta-mender-qcom/recipes-core/images/unoq-initramfs-ab.bb
@@ -1,0 +1,30 @@
+DESCRIPTION = "Uno Q A/B slot-aware initramfs: reads the active slot (qbootctl) \
+and mounts system_<slot> as the real rootfs"
+LICENSE = "MIT"
+
+PACKAGE_INSTALL = " \
+    initramfs-framework-base \
+    initramfs-module-udev \
+    initramfs-module-abslot \
+    initramfs-module-rootfs \
+    qbootctl \
+    util-linux-blkid \
+    ${VIRTUAL-RUNTIME_base-utils} \
+    base-passwd \
+    ${ROOTFS_BOOTSTRAP_INSTALL} \
+"
+
+# Keep the ramdisk minimal.
+IMAGE_FEATURES = ""
+IMAGE_LINGUAS = ""
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+IMAGE_NAME_SUFFIX ?= ""
+
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# No kernel in the ramdisk (it's a UKI initrd)
+PACKAGE_EXCLUDE = "kernel-image-*"

--- a/meta-mender-qcom/recipes-core/initramfs/files/86-abslot
+++ b/meta-mender-qcom/recipes-core/initramfs/files/86-abslot
@@ -1,0 +1,71 @@
+#!/bin/sh
+# initramfs-framework module: Uno Q A/B slot-aware root selection.
+# Runs after 01-udev (so /dev/disk/by-partlabel exists) and before 90-rootfs.
+# Reads the active slot from the GPT AB attribute bits via qbootctl (which falls
+# back to the GPT active bit when no androidboot.slot_suffix is present) and
+# points bootparam_root at system_<suffix>, which 90-rootfs then mounts.
+# Module name (init parses field 2 of the filename): "abslot".
+
+abslot_enabled() {
+    command -v qbootctl >/dev/null 2>&1
+}
+
+abslot_run() {
+    _out=$(qbootctl -c 2>/dev/null || true)
+    # qbootctl -c prints e.g. "Current slot: _a"
+    _suffix=$(printf '%s\n' "$_out" | sed -n 's/.*[Cc]urrent slot:[[:space:]]*//p')
+    case "$_suffix" in
+        _a|_b) ;;
+        *) _suffix=_a ;;   # safe default if the slot can't be determined
+    esac
+
+    _dev="/dev/disk/by-partlabel/system${_suffix}"
+    _i=0
+    while [ ! -e "$_dev" ] && [ "$_i" -lt 10 ]; do
+        sleep 1
+        _i=$((_i + 1))
+    done
+
+    # If the active slot holds no valid filesystem (e.g. a failed/garbage OTA to
+    # the inactive slot that was then activated), self-heal: switch the active
+    # slot to the other one via qbootctl and reboot. A single, deterministic
+    # fallback into the known-good slot. Afterwards qbootctl -c reflects the other
+    # slot, so Mender's ArtifactVerifyReboot sees we're not on the update's target
+    # slot and rolls the deployment back. Guarded with retries so a transient
+    # (device not ready) never triggers it.
+    # Authoritative validity test: actually try to mount the slot read-only.
+    # (blkid is unreliable here: a failed OTA may zero only the start of the
+    # partition, leaving backup superblocks that blkid still recognises while the
+    # real mount fails.)
+    _ok=""
+    _j=0
+    mkdir -p /run/abprobe
+    while [ "$_j" -lt 5 ]; do
+        if mount -o ro "$_dev" /run/abprobe >/dev/null 2>&1; then
+            umount /run/abprobe >/dev/null 2>&1 || true
+            _ok=1
+            break
+        fi
+        sleep 1
+        _j=$((_j + 1))
+    done
+    if [ -z "$_ok" ]; then
+        _other=1
+        [ "$_suffix" = "_a" ] || _other=0
+        printf 'unoq-ab: slot %s unmountable; switching to slot %s and rebooting\n' "$_suffix" "$_other" > /dev/kmsg 2>/dev/null || true
+        # Activate the known-good slot AND mark it successful, so ABL keeps it
+        # (qbootctl -s clears the successful bit; without -m, and with bless-boot
+        # gated by the update flag, ABL could roll the fallback back into the bad
+        # slot -> loop). This is the boot-level rollback commit.
+        qbootctl -s "$_other" >/dev/null 2>&1 || true
+        qbootctl -m "$_other" >/dev/null 2>&1 || true
+        sync
+        sleep 1
+        reboot -f >/dev/null 2>&1 || true
+        echo b > /proc/sysrq-trigger 2>/dev/null || true
+        sleep 30
+    fi
+
+    bootparam_root="PARTLABEL=system${_suffix}"
+    printf 'unoq-ab: active slot %s -> root=%s\n' "$_suffix" "$bootparam_root" > /dev/kmsg 2>/dev/null || true
+}

--- a/meta-mender-qcom/recipes-core/initramfs/files/86-abslot
+++ b/meta-mender-qcom/recipes-core/initramfs/files/86-abslot
@@ -1,9 +1,12 @@
 #!/bin/sh
 # initramfs-framework module: Uno Q A/B slot-aware root selection.
 # Runs after 01-udev (so /dev/disk/by-partlabel exists) and before 90-rootfs.
-# Reads the active slot from the GPT AB attribute bits via qbootctl (which falls
-# back to the GPT active bit when no androidboot.slot_suffix is present) and
-# points bootparam_root at system_<suffix>, which 90-rootfs then mounts.
+# Asks qbootctl for the current slot and points bootparam_root at
+# system_<suffix>, which 90-rootfs then mounts. qbootctl determines the slot
+# from the A/B attribute bits in the GPT partition entries, i.e. the slot ABL
+# selected. (It would prefer an Android-style androidboot.slot_suffix= kernel
+# argument, but this board's U-Boot flow passes none, so the GPT path is the
+# one in effect here.)
 # Module name (init parses field 2 of the filename): "abslot".
 
 abslot_enabled() {

--- a/meta-mender-qcom/recipes-core/initramfs/initramfs-module-abslot.bb
+++ b/meta-mender-qcom/recipes-core/initramfs/initramfs-module-abslot.bb
@@ -1,0 +1,14 @@
+SUMMARY = "initramfs-framework module: Uno Q A/B slot-aware root selection"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "file://86-abslot"
+
+RDEPENDS:${PN} = "initramfs-framework-base qbootctl"
+
+do_install() {
+    install -d ${D}/init.d
+    install -m 0755 ${UNPACKDIR}/86-abslot ${D}/init.d/86-abslot
+}
+
+FILES:${PN} = "/init.d/86-abslot"

--- a/meta-mender-qcom/recipes-devtools/openocd/openocd_git.bbappend
+++ b/meta-mender-qcom/recipes-devtools/openocd/openocd_git.bbappend
@@ -1,0 +1,11 @@
+# Enable OpenOCD's linuxgpiod adapter driver so it can bit-bang SWD over
+# /dev/gpiochipN via libgpiod. This is how the Uno Q's QRB2210 programs the
+# on-board STM32U585 (internal SWD on gpiochip1 lines 25=SWDIO / 26=SWCLK); the
+# kernel has no sysfs GPIO, so the stock recipe's sysfsgpio driver is unusable.
+#
+# NB: OpenOCD at meta-oe's pinned SRCREV uses the libgpiod v1 API (configure
+# requires "libgpiod < 2.0"), so this must build against libgpiod 1.6.5, not the
+# 2.x default -- pinned via PREFERRED_VERSION in the kas overlay (unoq-mcu.yml).
+DEPENDS += "libgpiod"
+PACKAGECONFIG[linuxgpiod] = "--enable-linuxgpiod,--disable-linuxgpiod"
+PACKAGECONFIG:append = " linuxgpiod"

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-bless-boot-gate.conf
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-bless-boot-gate.conf
@@ -1,0 +1,7 @@
+# Suppress meta-qcom's automatic slot "bless" (qbootctl -m at boot-complete)
+# while a Mender A/B update is in flight, so Mender owns commit/rollback. The
+# qbootctl-rootfs update module creates this flag on ArtifactInstall and removes
+# it on ArtifactCommit/ArtifactRollback. On normal (non-update) boots the flag is
+# absent, so bless-boot runs as usual and keeps the running slot marked good.
+[Unit]
+ConditionPathExists=!/data/mender-ab-updating

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-rootfs
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-rootfs
@@ -1,0 +1,92 @@
+#!/bin/sh
+# Mender Update Module: A/B rootfs update driven by the platform's native slots
+# (Qualcomm qbootctl / ABL), instead of Mender's dual-rootfs+U-Boot integration.
+# Payload = one system image (ext4) written to the INACTIVE system_<slot>.
+#
+# Commit/rollback are Mender-owned: meta-qcom's qbootctl-bless-boot auto-commit is
+# gated by /data/mender-ab-updating (this module sets/clears it), so a new slot is
+# only marked "successful" at ArtifactCommit. A slot that never reaches commit
+# (bad image / never boots) is not blessed -> ABL's retry counter rolls back.
+#
+# Runs as root (mender-update daemon). State dir ($1/tmp) lives under
+# /var/lib/mender -> /data/mender (persistent), so target/old slot survive the reboot.
+set -e
+
+STATE="$1"
+DIR="$2"
+cd "$DIR"
+
+FLAG=/data/mender-ab-updating
+
+qc() { qbootctl "$@" 2>/dev/null; }
+
+# Current running slot as a number: 0 = _a, 1 = _b
+cur_num() {
+    s=$(qc -c | sed -n 's/.*[Cc]urrent slot:[[:space:]]*_\([ab]\).*/\1/p')
+    [ "$s" = "b" ] && echo 1 || echo 0
+}
+other_num() { [ "$1" = "0" ] && echo 1 || echo 0; }
+slot_dev() { [ "$1" = "1" ] && echo /dev/disk/by-partlabel/system_b || echo /dev/disk/by-partlabel/system_a; }
+
+case "$STATE" in
+    Download)
+        # Stream the payload straight onto the inactive system slot.
+        tgt=$(other_num "$(cur_num)")
+        dev=$(slot_dev "$tgt")
+        f="$(cat stream-next)"
+        [ -n "$f" ] && cat "$f" > "$dev"
+        if [ -n "$(cat stream-next)" ]; then
+            echo "qbootctl-rootfs: expected exactly one payload file" >&2
+            exit 1
+        fi
+        ;;
+
+    ArtifactInstall)
+        cur=$(cur_num)
+        tgt=$(other_num "$cur")
+        mkdir -p tmp
+        echo "$tgt" > tmp/target_slot
+        echo "$cur" > tmp/old_slot
+        # suppress auto-bless for the upcoming update boot, then activate the new slot
+        touch "$FLAG"; sync
+        qbootctl -s "$tgt"
+        ;;
+
+    NeedsArtifactReboot)
+        echo "Automatic"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactVerifyReboot)
+        want="$(cat tmp/target_slot 2>/dev/null || echo -1)"
+        got="$(cur_num)"
+        if [ "$got" != "$want" ]; then
+            echo "qbootctl-rootfs: booted slot $got, expected $want (ABL rolled back)" >&2
+            exit 1
+        fi
+        ;;
+
+    ArtifactCommit)
+        # Health OK: make the new slot permanent and re-enable auto-bless.
+        qbootctl -m
+        rm -f "$FLAG"; sync
+        ;;
+
+    ArtifactRollback)
+        # Return to the pre-update slot (works whether ABL already fell back or not).
+        old="$(cat tmp/old_slot 2>/dev/null || echo 0)"
+        qbootctl -s "$old" || true
+        rm -f "$FLAG"; sync
+        ;;
+
+    ArtifactFailure|Cleanup)
+        rm -f "$FLAG"; sync
+        ;;
+
+    *)
+        ;;
+esac
+exit 0

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-rootfs
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/qbootctl-rootfs
@@ -29,12 +29,34 @@ other_num() { [ "$1" = "0" ] && echo 1 || echo 0; }
 slot_dev() { [ "$1" = "1" ] && echo /dev/disk/by-partlabel/system_b || echo /dev/disk/by-partlabel/system_a; }
 
 case "$STATE" in
+    ProvidePayloadFileSizes)
+        echo "Yes"
+        ;;
+
     Download)
-        # Stream the payload straight onto the inactive system slot.
+        echo "qbootctl-rootfs: this module supports DownloadWithFileSizes only" >&2
+        exit 1
+        ;;
+
+    DownloadWithFileSizes)
+        # Stream the payload straight onto the inactive system slot. Use
+        # mender-flash (like the stock rootfs-image module): it skips blocks
+        # that are already identical on the target, saving eMMC writes.
         tgt=$(other_num "$(cur_num)")
         dev=$(slot_dev "$tgt")
-        f="$(cat stream-next)"
-        [ -n "$f" ] && cat "$f" > "$dev"
+        line="$(cat stream-next)"
+        f="$(echo "$line" | cut -d' ' -f1)"
+        size="$(echo "$line" | cut -d' ' -f2)"
+        if [ -z "$f" ] || [ -z "$size" ]; then
+            echo "qbootctl-rootfs: cannot parse line from stream-next: $line" >&2
+            exit 1
+        fi
+        if command -v mender-flash >/dev/null 2>&1; then
+            mender-flash --input-size "$size" --input "$f" --output "$dev"
+        else
+            cat "$f" > "$dev"
+            sync
+        fi
         if [ -n "$(cat stream-next)" ]; then
             echo "qbootctl-rootfs: expected exactly one payload file" >&2
             exit 1

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist
@@ -11,10 +11,16 @@ DST=/data/mender        # persistent store on the userdata partition
 
 mkdir -p "$DST"
 
-# Always refresh the config from the image (server URL / tenant token), but
-# preserve identity + state that live only on /data.
-[ -e "$SRC/mender.conf" ] && cp -a "$SRC/mender.conf" "$DST/mender.conf"
-[ -e "$DST/device_type" ] || { [ -e "$SRC/device_type" ] && cp -a "$SRC/device_type" "$DST/device_type"; }
+# Seed once, on the first boot only. The client loads /var/lib/mender/mender.conf
+# as the FALLBACK config; /etc/mender/mender.conf (in the rootfs, refreshed by
+# every A/B update) overrides it, so config changes ship via /etc/mender and no
+# per-boot refresh is needed. Re-copying here would also clobber any config set
+# at runtime on /data.
+for f in mender.conf device_type; do
+    if [ ! -e "$DST/$f" ] && [ -e "$SRC/$f" ]; then
+        cp -a "$SRC/$f" "$DST/$f"
+    fi
+done
 
 # Bind the persistent store over the rootfs location (idempotent).
 mountpoint -q "$SRC" || mount --bind "$DST" "$SRC"

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Relocate Mender's state onto the persistent /data (userdata) partition so the
+# device key/identity AND in-flight update state (the update module's saved
+# target slot, deployment state) survive an A/B rootfs swap. Runs once at boot,
+# before mender-authd/mender-updated, while /var/lib/mender is still the baked
+# rootfs directory; seeds /data/mender then bind-mounts it over /var/lib/mender.
+set -e
+
+SRC=/var/lib/mender     # baked rootfs dir (before bind)
+DST=/data/mender        # persistent store on the userdata partition
+
+mkdir -p "$DST"
+
+# Always refresh the config from the image (server URL / tenant token), but
+# preserve identity + state that live only on /data.
+[ -e "$SRC/mender.conf" ] && cp -a "$SRC/mender.conf" "$DST/mender.conf"
+[ -e "$DST/device_type" ] || { [ -e "$SRC/device_type" ] && cp -a "$SRC/device_type" "$DST/device_type"; }
+
+# Bind the persistent store over the rootfs location (idempotent).
+mountpoint -q "$SRC" || mount --bind "$DST" "$SRC"

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist.service
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/files/unoq-mender-persist.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Relocate Mender state onto persistent /data (A/B)
+DefaultDependencies=no
+After=data.mount local-fs.target
+Requires=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+Before=mender-authd.service mender-updated.service mender-connect.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/unoq-mender-persist
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/unoq-ab-integration.bb
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/unoq-ab-integration.bb
@@ -1,0 +1,40 @@
+SUMMARY = "Uno Q A/B integration: persistent /data for Mender, bless-boot gating, qbootctl update module"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://unoq-mender-persist \
+    file://unoq-mender-persist.service \
+    file://qbootctl-bless-boot-gate.conf \
+    file://qbootctl-rootfs \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "unoq-mender-persist.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+# qbootctl for the update module; mkfs.ext4 for the /data (userdata) x-systemd.makefs
+RDEPENDS:${PN} = "qbootctl e2fsprogs-mke2fs"
+
+do_install() {
+    install -d ${D}${bindir}
+    install -m 0755 ${UNPACKDIR}/unoq-mender-persist ${D}${bindir}/unoq-mender-persist
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/unoq-mender-persist.service ${D}${systemd_system_unitdir}/
+
+    # drop-in that gates meta-qcom's qbootctl-bless-boot.service during a Mender update
+    install -d ${D}${systemd_system_unitdir}/qbootctl-bless-boot.service.d
+    install -m 0644 ${UNPACKDIR}/qbootctl-bless-boot-gate.conf \
+        ${D}${systemd_system_unitdir}/qbootctl-bless-boot.service.d/10-mender-gate.conf
+
+    # the custom Mender Update Module (payload type == filename)
+    install -d ${D}${datadir}/mender/modules/v3
+    install -m 0755 ${UNPACKDIR}/qbootctl-rootfs ${D}${datadir}/mender/modules/v3/qbootctl-rootfs
+}
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/qbootctl-bless-boot.service.d/10-mender-gate.conf \
+    ${datadir}/mender/modules/v3/qbootctl-rootfs \
+"

--- a/meta-mender-qcom/recipes-support/unoq-ab-integration/unoq-ab-integration.bb
+++ b/meta-mender-qcom/recipes-support/unoq-ab-integration/unoq-ab-integration.bb
@@ -14,8 +14,10 @@ inherit systemd
 SYSTEMD_SERVICE:${PN} = "unoq-mender-persist.service"
 SYSTEMD_AUTO_ENABLE = "enable"
 
-# qbootctl for the update module; mkfs.ext4 for the /data (userdata) x-systemd.makefs
-RDEPENDS:${PN} = "qbootctl e2fsprogs-mke2fs"
+# qbootctl + mender-flash for the update module; mkfs.ext4 for the /data
+# (userdata) x-systemd.makefs. mender-flash is only RRECOMMENDS of
+# mender-update, so pull it in explicitly.
+RDEPENDS:${PN} = "qbootctl mender-flash e2fsprogs-mke2fs"
 
 do_install() {
     install -d ${D}${bindir}

--- a/meta-mender-qcom/recipes-support/unoq-mcu-integration/files/openocd_gpiod.cfg
+++ b/meta-mender-qcom/recipes-support/unoq-mcu-integration/files/openocd_gpiod.cfg
@@ -1,0 +1,16 @@
+# OpenOCD adapter + target for the Arduino Uno Q's on-board STM32U585, reached
+# over the QRB2210's INTERNAL SWD link (no external probe). SWD is bit-banged via
+# libgpiod on the TLMM (500000.pinctrl = gpiochip1): SWDIO = line 25, SWCLK = 26.
+adapter driver linuxgpiod
+adapter gpio swdio 25 -chip 1
+adapter gpio swclk 26 -chip 1
+transport select swd
+
+source [find target/stm32u5x.cfg]
+
+# The linuxgpiod bit-bang adapter has no configurable speed, but stm32u5x.cfg's
+# reset events call `adapter speed`, which then errors and aborts every reset.
+# Neutralise those events so `reset`/`program ... reset` work over SWD.
+stm32u5x.cpu configure -event reset-start {}
+stm32u5x.cpu configure -event reset-init {}
+stm32u5x.cpu configure -event reset-deassert-post {}

--- a/meta-mender-qcom/recipes-support/unoq-mcu-integration/files/zephyr-mcu
+++ b/meta-mender-qcom/recipes-support/unoq-mcu-integration/files/zephyr-mcu
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Mender Update Module: flash Zephyr firmware onto the Arduino Uno Q's on-board
+# STM32U585 MCU over the QRB2210's internal SWD link (OpenOCD + linuxgpiod),
+# rather than a rootfs update. Payload = one firmware image (.hex, self-addressing
+# at 0x08000000). Companion to the qbootctl-rootfs A/B module.
+#
+# The MCU is a separate processor from the Linux host, so this needs NO host
+# reboot (NeedsArtifactReboot=No): the STM32 is reset into the new firmware
+# in-place during ArtifactInstall. Health is checked over SWD (OpenOCD verifies
+# the written image byte-for-byte), so it needs no Linux<->MCU comms channel.
+# Rollback re-flashes the previous firmware, backed up on /data before writing.
+#
+# Runs as root (mender-update daemon). Requires openocd (built with the linuxgpiod
+# driver) + /usr/share/unoq-mcu/openocd_gpiod.cfg.
+set -e
+
+STATE="$1"
+DIR="$2"
+cd "$DIR"
+
+CFG=/usr/share/unoq-mcu/openocd_gpiod.cfg
+FLASH_BASE=0x08000000
+BACKUP_SIZE=0x40000                 # 256 KiB: covers the demo images with margin
+BACKUP=/data/mcu-fw/previous.bin
+FW=tmp/fw.hex
+
+ocd() { openocd -f "$CFG" "$@"; }
+
+case "$STATE" in
+    Download)
+        # Stream the single firmware payload into the work dir.
+        mkdir -p tmp
+        f="$(cat stream-next)"
+        [ -n "$f" ] && cat "$f" > "$FW"
+        if [ -n "$(cat stream-next)" ]; then
+            echo "zephyr-mcu: expected exactly one payload file" >&2
+            exit 1
+        fi
+        ;;
+
+    ArtifactInstall)
+        mkdir -p /data/mcu-fw
+        # Ensure the STM32 boots from main flash regardless of the BOOT0 pin
+        # (nSWBOOT0=0, nBOOT0=1 -> FLASH_OPTR bit26=0). Idempotent: only rewrite
+        # the option bytes if nSWBOOT0 is still set (bit26 = 0x04000000).
+        optr=$(ocd -c init -c halt -c "stm32l4x option_read 0 0x40" -c shutdown 2>&1 \
+               | sed -n 's/.*Option Register.*=[[:space:]]*\(0x[0-9a-fA-F]*\).*/\1/p')
+        if [ -n "$optr" ] && [ $(( optr & 0x04000000 )) -ne 0 ]; then
+            echo "zephyr-mcu: setting STM32 to boot from main flash (option bytes)"
+            # option_load triggers a reset that drops the debugger (prints a
+            # harmless "option load failed"); the bytes are still applied.
+            ocd -c init -c halt \
+                -c "stm32l4x option_write 0 0x40 0x08000000 0x0c000000" \
+                -c "stm32l4x option_load 0" -c shutdown 2>&1 || true
+        fi
+        # Back up the flash region we are about to overwrite, for rollback.
+        ocd -c init -c halt -c "dump_image $BACKUP $FLASH_BASE $BACKUP_SIZE" -c shutdown
+        # Flash + verify + reset into the new firmware. Verify is the health gate:
+        # a non-zero exit here makes Mender run ArtifactRollback.
+        out=$(ocd -c init -c "program $FW verify reset" -c shutdown 2>&1)
+        echo "$out"
+        echo "$out" | grep -q "Verified OK" || {
+            echo "zephyr-mcu: flash verify failed" >&2
+            exit 1
+        }
+        ;;
+
+    NeedsArtifactReboot)
+        echo "No"                   # reset the MCU only; the Linux host stays up
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactRollback)
+        # Re-flash the firmware that was on the MCU before this update.
+        if [ -f "$BACKUP" ]; then
+            ocd -c init -c "program $BACKUP $FLASH_BASE verify reset" -c shutdown 2>&1 || true
+        fi
+        ;;
+
+    ArtifactCommit)
+        rm -rf tmp
+        ;;
+
+    ArtifactFailure|Cleanup)
+        rm -rf tmp
+        ;;
+
+    *)
+        ;;
+esac
+exit 0

--- a/meta-mender-qcom/recipes-support/unoq-mcu-integration/unoq-mcu-integration.bb
+++ b/meta-mender-qcom/recipes-support/unoq-mcu-integration/unoq-mcu-integration.bb
@@ -1,0 +1,31 @@
+SUMMARY = "Mender Update Module (zephyr-mcu): flash Zephyr firmware to the Uno Q STM32U585 over SWD"
+DESCRIPTION = "Installs the 'zephyr-mcu' Mender v3 Update Module and its OpenOCD \
+config. The module programs the Arduino Uno Q's on-board STM32U585 MCU firmware \
+over the QRB2210's internal SWD link (OpenOCD + linuxgpiod), with SWD read-back \
+verify and backup/re-flash rollback. A second Mender update type beside the \
+qbootctl-rootfs A/B rootfs module."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://zephyr-mcu \
+    file://openocd_gpiod.cfg \
+"
+
+# openocd (built with the linuxgpiod driver, see the openocd bbappend) is the
+# flasher; it pulls in libgpiod/libusb at runtime.
+RDEPENDS:${PN} = "openocd"
+
+do_install() {
+    # payload/update type == the module filename ("zephyr-mcu")
+    install -d ${D}${datadir}/mender/modules/v3
+    install -m 0755 ${UNPACKDIR}/zephyr-mcu ${D}${datadir}/mender/modules/v3/zephyr-mcu
+
+    install -d ${D}${datadir}/unoq-mcu
+    install -m 0644 ${UNPACKDIR}/openocd_gpiod.cfg ${D}${datadir}/unoq-mcu/openocd_gpiod.cfg
+}
+
+FILES:${PN} += " \
+    ${datadir}/mender/modules/v3/zephyr-mcu \
+    ${datadir}/unoq-mcu/openocd_gpiod.cfg \
+"


### PR DESCRIPTION
## Summary

Adds `meta-mender-qcom`, a new Mender integration layer for Qualcomm
(`qualcomm-linux/meta-qcom`) based boards, with the **Arduino Uno Q**
(Dragonwing QRB2210, MACHINE `uno-q`) as the first supported and hardware-tested
board.

Rather than Mender's classic dual-rootfs + U-Boot/GRUB integration, this layer
reuses the platform's **native Qualcomm A/B boot slots** (ABL + `qbootctl`) and
drives them from a custom Mender **Update Module** (`qbootctl-rootfs`). This fits
the Qualcomm boot flow (PBL → XBL → ABL → U-Boot → UEFI → systemd-boot/UKI)
without re-partitioning around Mender's model.

## What the layer provides

- **Slotted OS layout** — a `qcom-partition-conf` bbappend derives a
  `system_a`/`system_b` (+ `userdata`, + `dtbo_a`/`dtbo_b`, which `qbootctl -s`
  hard-requires) GPT from the stock `qrb2210-unoq` table.
- **Slot-aware, self-healing initramfs** (`unoq-initramfs-ab` + the `86-abslot`
  initramfs-framework module) — reads the active slot via `qbootctl`, mounts
  `system_<slot>`; if the active slot has no valid filesystem it switches to the
  other slot (`qbootctl -s`/`-m`) and reboots, so a bad update rolls back
  deterministically.
- **`qbootctl-rootfs` Update Module** — writes the payload to the inactive slot,
  activates it, reboots (Automatic), verifies the booted slot, commits with
  `qbootctl -m`, rolls back on failure.
- **Persistent Mender state** — `userdata` is mounted at `/data` and
  `/var/lib/mender` is bound onto it so device identity + in-flight update state
  survive the rootfs swap.
- **bless-boot gating** — a drop-in suppresses meta-qcom's automatic slot-bless
  while a Mender update is in flight so Mender owns commit/rollback; normal boots
  still auto-bless.

## Testing

Verified end-to-end on hardware (Arduino Uno Q) against Hosted Mender:
- A/B rootfs OTA deployment → success, device boots the updated slot,
  `artifact_name` updated.
- Deliberately broken artifact → initramfs self-heals to the known-good slot,
  Mender reports the deployment as Failure, device stays on the good slot.

## Dependencies

Depends on `meta-qcom` (qualcomm-linux, `master`) and `meta-qcom-3rdparty`
(`main`, which provides the `uno-q` MACHINE + partition tables + firmware/kernel/
u-boot), plus `meta-mender` (`wrynose`).

## Companion build config

The kas build config lives in a companion repo (separate PR):
https://github.com/theyoctojester/mender-community-images — `yocto/wrynose/floating/uno-q.yml`.
The two are coupled; that config tracks this repo's `wrynose` branch, so it
builds once this PR merges.

## Notes / open questions (why this is a draft)

- **Layer name** `meta-mender-qcom` follows the repo convention of naming after
  the upstream BSP family (Uno Q is a MACHINE under it) — happy to rename if you'd
  prefer e.g. per-board.
- **Base branch** `wrynose`. It carries no kas/CI machinery, which is why the build
  config lives in `mender-community-images` rather than here — confirm that split
  matches your intent.
- **Connectivity is intentionally not shipped** (no baked credentials); WiFi/network
  is site-specific and configured at runtime or via a local overlay.
- The Uno Q build uses meta-qcom's `nodistro` flow (oe-core master, meta-qcom
  master, meta-qcom-3rdparty `main`) rather than the poky/`core-image-minimal`
  flow other boards use — reflected in the companion kas config.
- **Future work** (designed-for, not in this PR): the same Update-Module approach
  extends to the on-board **STM32U585 MCU** firmware (Zephyr) and to **AI models**
  shipped with Edge Impulse, as additional Mender artifact types beside the rootfs one.

