### PR TITLE
meta-mender-qcom: give the mcu multiconfig its own TMPDIR

### DIFF
--- a/meta-mender-qcom/conf/multiconfig/mcu.conf
+++ b/meta-mender-qcom/conf/multiconfig/mcu.conf
@@ -4,7 +4,19 @@
 # caches / thread caps / mirrors (via local.conf) but targets the arduino-uno-q
 # MACHINE instead of the aarch64 uno-q Linux MACHINE. Build with:
 #   bitbake mc:mcu:zephyr-unoq-blink   (or  kas build ... --target mc:mcu:zephyr-unoq-blink)
+# The firmware deploys to ${TOPDIR}/tmp-mcu/deploy/images/arduino-uno-q/.
 
 require conf/local.conf
 
 MACHINE = "arduino-uno-q"
+
+# This multiconfig must not share TMPDIR with the default (uno-q Linux)
+# configuration. Its native task hashes differ from the default config's
+# (newlib/Cortex-M toolchain), so both configurations end up building the
+# same native recipes in the same tmp/work/x86_64-linux workdir. When one
+# variant is restored from sstate while the other executes for real, the
+# workdir is incomplete and do_configure fails, e.g.:
+#   mc:mcu:p11-kit-native do_configure:
+#     Cannot find specified native file: .../p11-kit-native/0.26.2/meson.native
+# A warm sstate cache masks the problem; cold builds hit it reliably.
+TMPDIR = "${TOPDIR}/tmp-mcu"


### PR DESCRIPTION
## Summary

Follow-up to #517. The `mcu` multiconfig (STM32U585 Zephyr firmware) currently shares TMPDIR with the default uno-q Linux configuration. That is unsafe: the mcu config's native task hashes differ from the default config's (newlib/Cortex-M toolchain), so both configurations build the same native recipes in the same `tmp/work/x86_64-linux` workdir. When one variant is restored from sstate while the other executes for real, the workdir is incomplete and `do_configure` fails:

```
mc:mcu:p11-kit-native do_configure: meson setup failed
ERROR: Cannot find specified native file: .../p11-kit-native/0.26.2/meson.native
```

A warm sstate cache masks the problem, which is why interactive builds tend to pass — cold CI builds hit it reliably (observed on a scheduled builder doing a fresh `core-image-base` + `mc:mcu:zephyr-unoq-blink` build).

## Change

`conf/multiconfig/mcu.conf` sets `TMPDIR = "${TOPDIR}/tmp-mcu"`, so the two configurations cannot collide. DL_DIR and SSTATE_DIR remain shared via `local.conf`. The firmware then deploys to `tmp-mcu/deploy/images/arduino-uno-q/` (noted in the file header).

## Testing

- Cold CI build of `core-image-base` + `mc:mcu:zephyr-unoq-blink` (kas, wrynose) failed reproducibly with the collision above and passes with the equivalent TMPDIR split applied via the build config overlay; `zephyr-unoq-blink-arduino-uno-q.hex` is produced in `tmp-mcu/deploy/images/arduino-uno-q/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)