### PR TITLE
meta-mender-qcom: emit qbootctl-rootfs artifacts from the build

### DIFF
--- a/meta-mender-qcom/README.md
+++ b/meta-mender-qcom/README.md
@@ -73,6 +73,29 @@ Build configs (kas) live in the companion
 kas build mender-community-images/yocto/wrynose/floating/uno-q.yml
 ```
 
+## Rootfs update artifacts
+
+To have the build emit a deployable Mender artifact for the `qbootctl-rootfs`
+Update Module alongside the flashable image set, enable the layer's image type:
+
+```
+IMAGE_CLASSES += "image_types_mender_qcom"
+IMAGE_FSTYPES += "mender-qbootctl"
+```
+
+This wraps the rootfs filesystem image via `mender-artifact write module-image
+-T qbootctl-rootfs`, named from `MENDER_ARTIFACT_NAME` and targeting
+`MENDER_DEVICE_TYPES_COMPATIBLE`; `MENDER_ARTIFACT_SIGNING_KEY` and
+`MENDER_ARTIFACT_EXTRA_ARGS` are honored. The deployed
+`<image>.mender-qbootctl` file is a regular Mender artifact (only the
+extension differs, to avoid clashing with meta-mender's dual-rootfs `mender`
+image type). The same artifact can of course also be created manually:
+
+```
+mender-artifact write module-image -T qbootctl-rootfs \
+    -n <artifact name> -t <device type> -f <rootfs>.ext4 -o <artifact>.mender
+```
+
 ## Flashing / console
 
 The Uno Q is flashed over Qualcomm EDL with `qdl` (the build produces a `.qcomflash` set):

--- a/meta-mender-qcom/classes-recipe/image_types_mender_qcom.bbclass
+++ b/meta-mender-qcom/classes-recipe/image_types_mender_qcom.bbclass
@@ -1,0 +1,58 @@
+# Image type that wraps the generated rootfs filesystem image in a Mender
+# artifact for the qbootctl-rootfs Update Module, so the build directly emits
+# a deployable artifact alongside the flashable image set.
+#
+# Usage (build configuration):
+#   IMAGE_CLASSES += "image_types_mender_qcom"
+#   IMAGE_FSTYPES += "mender-qbootctl"
+#
+# The type name is deliberately NOT "mender": meta-mender-core registers its
+# own "mender" image type (rootfs-image artifacts for the dual-rootfs layout)
+# unconditionally via mender-setup, and that writer does not apply to the
+# qbootctl A/B integration. The produced file is a regular Mender artifact;
+# only the filename extension differs.
+
+inherit image_types
+
+IMAGE_TYPES += "mender-qbootctl"
+
+# Filesystem image type used as the artifact payload.
+MENDER_QBOOTCTL_ARTIFACT_FSTYPE ??= "ext4"
+
+# Extra arguments that should be passed to mender-artifact.
+MENDER_ARTIFACT_EXTRA_ARGS ?= ""
+
+# The key used to sign the artifact, if any.
+MENDER_ARTIFACT_SIGNING_KEY ?= ""
+
+do_image_mender_qbootctl[depends] += "mender-artifact-native:do_populate_sysroot"
+
+IMAGE_CMD:mender-qbootctl () {
+    if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
+        bbfatal "Need to define MENDER_ARTIFACT_NAME variable."
+    fi
+    if [ -z "${MENDER_DEVICE_TYPES_COMPATIBLE}" ]; then
+        bbfatal "MENDER_DEVICE_TYPES_COMPATIBLE variable cannot be empty."
+    fi
+
+    extra_args=
+
+    for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
+        extra_args="$extra_args -t $dev"
+    done
+
+    if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then
+        extra_args="$extra_args -k ${MENDER_ARTIFACT_SIGNING_KEY}"
+    fi
+
+    mender-artifact write module-image \
+        -T qbootctl-rootfs \
+        -n ${MENDER_ARTIFACT_NAME} \
+        $extra_args \
+        -f ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${MENDER_QBOOTCTL_ARTIFACT_FSTYPE} \
+        ${MENDER_ARTIFACT_EXTRA_ARGS} \
+        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender-qbootctl
+}
+
+# The payload filesystem image must be generated first.
+IMAGE_TYPEDEP:mender-qbootctl = "${MENDER_QBOOTCTL_ARTIFACT_FSTYPE}"


### PR DESCRIPTION
## What

Adds an opt-in image type so builds directly emit a deployable Mender artifact for the `qbootctl-rootfs` Update Module alongside the flashable `qcomflash` set, instead of requiring a manual `mender-artifact` invocation:

```
IMAGE_CLASSES += "image_types_mender_qcom"
IMAGE_FSTYPES += "mender-qbootctl"
```

The class wraps the generated rootfs filesystem image via `mender-artifact write module-image -T qbootctl-rootfs` and follows the established meta-mender variables: `MENDER_ARTIFACT_NAME`, `MENDER_DEVICE_TYPES_COMPATIBLE`, `MENDER_ARTIFACT_SIGNING_KEY`, `MENDER_ARTIFACT_EXTRA_ARGS`.

The type is deliberately **not** named `mender`: meta-mender-core registers that image type unconditionally via `mender-setup` (even in client-only setups like this integration), and its `rootfs-image` writer does not apply to the qbootctl A/B layout. The produced `.mender-qbootctl` file is a regular Mender artifact; only the extension differs.

## Verification

On an Arduino Uno Q `core-image-base` build (wrynose):

- the deploy directory gains `core-image-base-uno-q.mender-qbootctl`; `mender-artifact read` shows update type `qbootctl-rootfs`, compatible type `uno-q`, and the `rootfs-image.qbootctl-rootfs.version` provides — identical structure to the manually created artifacts verified during #517.
- end-to-end on hardware against Hosted Mender: uploaded the build-emitted artifact as-is, deployed it to a Uno Q, deployment finished with **success** — payload streamed to the inactive slot, reboot into `system_b`, verified and committed, device reports the new artifact name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)