### PR TITLE
meta-mender-qcom: name the emitted artifact .mender

### DIFF
--- a/meta-mender-qcom/README.md
+++ b/meta-mender-qcom/README.md
@@ -80,16 +80,17 @@ Update Module alongside the flashable image set, enable the layer's image type:
 
 ```
 IMAGE_CLASSES += "image_types_mender_qcom"
-IMAGE_FSTYPES += "mender-qbootctl"
+IMAGE_FSTYPES += "mender"
 ```
 
 This wraps the rootfs filesystem image via `mender-artifact write module-image
 -T qbootctl-rootfs`, named from `MENDER_ARTIFACT_NAME` and targeting
 `MENDER_DEVICE_TYPES_COMPATIBLE`; `MENDER_ARTIFACT_SIGNING_KEY` and
-`MENDER_ARTIFACT_EXTRA_ARGS` are honored. The deployed
-`<image>.mender-qbootctl` file is a regular Mender artifact (only the
-extension differs, to avoid clashing with meta-mender's dual-rootfs `mender`
-image type). The same artifact can of course also be created manually:
+`MENDER_ARTIFACT_EXTRA_ARGS` are honored, producing a regular
+`<image>.mender` file. On meta-qcom machines this replaces meta-mender's
+dual-rootfs `mender` image type (via a `qcom` MACHINEOVERRIDE-qualified
+definition), which does not apply to the qbootctl A/B layout. The same
+artifact can of course also be created manually:
 
 ```
 mender-artifact write module-image -T qbootctl-rootfs \

--- a/meta-mender-qcom/classes-recipe/image_types_mender_qcom.bbclass
+++ b/meta-mender-qcom/classes-recipe/image_types_mender_qcom.bbclass
@@ -4,17 +4,21 @@
 #
 # Usage (build configuration):
 #   IMAGE_CLASSES += "image_types_mender_qcom"
-#   IMAGE_FSTYPES += "mender-qbootctl"
+#   IMAGE_FSTYPES += "mender"
 #
-# The type name is deliberately NOT "mender": meta-mender-core registers its
-# own "mender" image type (rootfs-image artifacts for the dual-rootfs layout)
-# unconditionally via mender-setup, and that writer does not apply to the
-# qbootctl A/B integration. The produced file is a regular Mender artifact;
-# only the filename extension differs.
+# meta-mender-core registers its own "mender" image type unconditionally via
+# mender-setup (rootfs-image artifacts for the dual-rootfs layout), and its
+# class parses after the ones listed in the build configuration. The
+# definitions below are therefore qualified with the "qcom" MACHINEOVERRIDE
+# (set by meta-qcom's qcom-common.inc for every machine of the BSP): an
+# override-qualified assignment takes precedence over an unqualified one
+# regardless of parse order, so on meta-qcom machines the "mender" image type
+# produces a qbootctl-rootfs module-image artifact instead of the dual-rootfs
+# one, which does not apply to the qbootctl A/B integration.
 
 inherit image_types
 
-IMAGE_TYPES += "mender-qbootctl"
+IMAGE_TYPES += "mender"
 
 # Filesystem image type used as the artifact payload.
 MENDER_QBOOTCTL_ARTIFACT_FSTYPE ??= "ext4"
@@ -25,9 +29,9 @@ MENDER_ARTIFACT_EXTRA_ARGS ?= ""
 # The key used to sign the artifact, if any.
 MENDER_ARTIFACT_SIGNING_KEY ?= ""
 
-do_image_mender_qbootctl[depends] += "mender-artifact-native:do_populate_sysroot"
+do_image_mender[depends] += "mender-artifact-native:do_populate_sysroot"
 
-IMAGE_CMD:mender-qbootctl () {
+IMAGE_CMD:mender:qcom () {
     if [ -z "${MENDER_ARTIFACT_NAME}" ]; then
         bbfatal "Need to define MENDER_ARTIFACT_NAME variable."
     fi
@@ -51,8 +55,8 @@ IMAGE_CMD:mender-qbootctl () {
         $extra_args \
         -f ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.${MENDER_QBOOTCTL_ARTIFACT_FSTYPE} \
         ${MENDER_ARTIFACT_EXTRA_ARGS} \
-        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender-qbootctl
+        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender
 }
 
 # The payload filesystem image must be generated first.
-IMAGE_TYPEDEP:mender-qbootctl = "${MENDER_QBOOTCTL_ARTIFACT_FSTYPE}"
+IMAGE_TYPEDEP:mender:qcom = "${MENDER_QBOOTCTL_ARTIFACT_FSTYPE}"


### PR DESCRIPTION
Follow-up to #519. The `.mender-qbootctl` extension was confusing — the emitted file is a regular Mender artifact and should look like one.

The naming conflict that motivated the suffix is resolved with override precedence instead: the image type definitions are now qualified with the `qcom` MACHINEOVERRIDE (set by meta-qcom's `qcom-common.inc` for every machine of the BSP). An override-qualified `IMAGE_CMD:mender:qcom` takes precedence over the unqualified dual-rootfs writer from meta-mender-core's `mender-artifactimg` regardless of class parse order, so the type can safely be called `mender` and the build emits `<image>.mender`. On non-qcom machines the class changes nothing.

Opt-in becomes:

```
IMAGE_CLASSES += "image_types_mender_qcom"
IMAGE_FSTYPES += "mender"
```

Verified on a uno-q core-image-base build: deploy directory contains `core-image-base-uno-q.mender` (plus versioned file and symlink as usual), and `mender-artifact read` confirms update type `qbootctl-rootfs` with compatible type `uno-q` — i.e. the qcom-qualified writer was selected, not the dual-rootfs one. Payload construction is unchanged from what was OTA-verified on hardware in #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)