### PR TITLE
meta-mender-qcom: fix stale kas config names in comments

### DIFF
--- a/meta-mender-qcom/conf/multiconfig/mcu.conf
+++ b/meta-mender-qcom/conf/multiconfig/mcu.conf
@@ -1,6 +1,6 @@
 # Multiconfig for the Uno Q MCU (STM32U585 / Cortex-M33) Zephyr firmware.
 #
-# Enabled from unoq-mcu.yml via BBMULTICONFIG = "mcu". Shares the main build's
+# Enabled from uno-q-mcu-firmware.yml via BBMULTICONFIG = "mcu". Shares the main build's
 # caches / thread caps / mirrors (via local.conf) but targets the arduino-uno-q
 # MACHINE instead of the aarch64 uno-q Linux MACHINE. Build with:
 #   bitbake mc:mcu:zephyr-unoq-blink   (or  kas build ... --target mc:mcu:zephyr-unoq-blink)

--- a/meta-mender-qcom/recipes-devtools/openocd/openocd_git.bbappend
+++ b/meta-mender-qcom/recipes-devtools/openocd/openocd_git.bbappend
@@ -5,7 +5,7 @@
 #
 # NB: OpenOCD at meta-oe's pinned SRCREV uses the libgpiod v1 API (configure
 # requires "libgpiod < 2.0"), so this must build against libgpiod 1.6.5, not the
-# 2.x default -- pinned via PREFERRED_VERSION in the kas overlay (unoq-mcu.yml).
+# 2.x default -- pinned via PREFERRED_VERSION in the kas configuration (uno-q.yml).
 DEPENDS += "libgpiod"
 PACKAGECONFIG[linuxgpiod] = "--enable-linuxgpiod,--disable-linuxgpiod"
 PACKAGECONFIG:append = " linuxgpiod"


### PR DESCRIPTION
Two comments still reference `unoq-mcu.yml`, a pre-upstreaming overlay name that never existed here: the libgpiod pin lives in `uno-q.yml` and the mcu multiconfig is enabled by `uno-q-mcu-firmware.yml` (both in `mender-community-images`). Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)