### PR TITLE
meta-mender-tegra: follow up cleanups to the Jetpack 7 integration

### DIFF
--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -27,8 +27,8 @@ repos:
 
   meta-mender:
     url: https://github.com/mendersoftware/meta-mender.git
-    # branch: main
-    commit: 9bba2bdc412d48d7cd98e5f2533c15a5665c2a4a
+    # branch: wrynose
+    commit: acc45e431e1aa6360a78c182a8c2578bd43af990
 
     layers:
       meta-mender-core:

--- a/kas/include/mender-base.yml
+++ b/kas/include/mender-base.yml
@@ -13,7 +13,7 @@ repos:
 
   bitbake:
     url: https://git.openembedded.org/bitbake.git
-    # branch: wrynose
+    # branch: 2.18
     commit: acfe02fa38b5da9e6a36c6cedcf91d4fcbefbfbd
     layers:
       bitbake: disabled

--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -44,7 +44,7 @@ revision: HEAD
 
 - `meta-mender-tegra-jetpack7`
   Holds Jetpack release 7 specific parts of the Mender integration for Tegra.
-  This correlates with the `wip-l4t-r39.2.0` branch of `meta-tegra`.
+  This correlates with the `wrynose` branch of `meta-tegra`.
 
 ## Quick start
 
@@ -56,19 +56,9 @@ for the most up to date instructions on starting out with mender and tegra.
 
 The following configuration files for building using the `kas` tool are provided:
 
-### Jetpack 5
+### Jetpack 7
 
-- [jetson-agx-orin-devkit.yml](../kas/tegra/jetpack5/jetson-agx-orin-devkit.yml)
-- [jetson-agx-xavier-devkit.yml](../kas/tegra/jetpack5/jetson-agx-xavier-devkit.yml)
-- [jetson-orin-16gb-nx-p3786.yml](../kas/tegra/jetpack6/jetson-orin-16gb-nx-p3786.yml)
-- [jetson-orin-nano-devkit.yml](../kas/tegra/jetpack5/jetson-orin-nano-devkit.yml)
-
-### Jetpack 6
-
-- [jetson-agx-orin-devkit-64.yml](../kas/tegra/jetpack6/jetson-agx-orin-devkit-64.yml)
-- [jetson-agx-orin-devkit.yml](../kas/tegra/jetpack6/jetson-agx-orin-devkit.yml)
-- [jetson-orin-16gb-nx-p3786.yml](../kas/tegra/jetpack6/jetson-orin-16gb-nx-p3786.yml)
-- [jetson-orin-nano-devkit.yml](../kas/tegra/jetpack6/jetson-orin-nano-devkit.yml)
+- [jetson-agx-thor-devkit.yaml](../kas/tegra/jetpack7/jetson-agx-thor-devkit.yaml)
 
 ### Jetson Orin NX
 


### PR DESCRIPTION
Follow up cleanups to #516, split out so they do not hold up the integration itself.

- The Jetpack 7 layer was documented as correlating with meta-tegra's
  `wip-l4t-r39.2.0` branch. The pins moved to `wrynose` during review.

- The kas section of `meta-mender-tegra/README.md` listed eight Jetpack 5 and 6
  configurations that do not exist here, so every link was dead, while
  `kas/tegra/jetpack7/jetson-agx-thor-devkit.yaml` went unlisted.

- The bitbake branch comment named a `wrynose` branch that bitbake does not
  have. The pinned commit is on `2.18` and is unchanged.

- The meta-mender pin was a `master` commit, not an ancestor of meta-mender's
  `wrynose` branch. It now points at the current wrynose head.
  `LAYERSERIES_COMPAT_mender` is `wrynose` on both, and the `meta-mender-core`
  delta is just the addition of mender-artifact 4.4.1.

Verified with a `core-image-minimal` build for `jetson-agx-thor-devkit` on the
repointed pin: no errors, and the rootfs, dataimg and .mender artifact are
unchanged in size against the previous pin.

Not addressed here, since it is an integration question rather than a cleanup:
`mender-growfs-data` is enabled in `kas/include/tegra-base.yml`, but on the
stock t264 layout `UDA` sits ahead of `APP`/`APP_b` with the free space only
after them, so `/data` stays at 400 MiB.

(Claude Code was involved in the analysis and writing here as well.)
