### PR TITLE
fix(tegra): make the layer's shipped shell scripts run without bash

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -73,6 +73,32 @@ To solve this issue we create a new [custom partition layout](recipes-bsp/tegra-
 
 It is possible to auto-grow the UDA partition to fill remaining space with [this](https://gist.github.com/rishabnayak/a734d2720f43b8908e59564c14fa52e9) bbappend in a layer above `meta-mender-tegra`. It sets the UDA allocation attribute to `0x808`, removes partition id numbers, and moves the UDA partition to right before the `secondary_gpt` partition following [Nvidia documentation](https://docs.nvidia.com/jetson/archives/r35.6.0/DeveloperGuide/AR/BootArchitecture/PartitionConfiguration.html#partition-child-elements).
 
+## Shell portability
+
+This layer installs shell scripts onto the target: the Mender state scripts, the
+`fw_printenv`/`fw_setenv` shims, the update verifiers and the machine-id helper.
+They run on images such as `core-image-minimal`, where `/bin/sh` is busybox ash
+and bash is not installed at all, so they must not use bash-only syntax.
+
+busybox ash accepts more than POSIX does. `local`, `source`, `[[ ]]`, the
+`function` keyword, `${var:offset:length}` and `${#var}` all work. What does not:
+
+- herestrings (`<<<`)
+- C-style `for (( ; ; ))` loops
+- `var+=value` appending. This one is the dangerous case: ash parses it as a
+  command name rather than an assignment, so it does not fail the script, it
+  just leaves the variable empty.
+- a `#!/bin/bash` interpreter line
+
+Check a script before committing it:
+
+```
+busybox ash -n path/to/script
+```
+
+Note that this only catches parse errors. `var+=value` parses fine and fails at
+runtime, so grep for it as well.
+
 ## Acknowlegements
 
 Special thanks to [Matt Madison](https://github.com/madisongh) for his contributions to

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/files/efi_systemd_machine_id.sh
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/files/efi_systemd_machine_id.sh
@@ -1,63 +1,71 @@
 #!/bin/sh
+# Must parse and run under busybox ash: this layer targets images such as
+# core-image-minimal where /bin/sh is busybox and bash is not installed.
+# In particular, do not use 'var+=' to append - ash parses that as a command
+# name rather than an assignment, so it fails silently and leaves the variable
+# empty instead of erroring out.
 
-function to_unicode() {
+to_unicode() {
 	local in="$1"
-	local out
+	local out=""
+	local i=0
+	local char
 
-	for (( i=0; i<${#in}; i++)); do
+	while [ "$i" -lt "${#in}" ]; do
 		char=${in:i:1}
-		out+="$char"
-		out+="\x00"
+		out="$out$char\x00"
+		i=$((i + 1))
 	done
 	echo -n "$out"
 }
 
 
-function fill_to_size() {
+fill_to_size() {
 	local size="$2"
-	local out="$1"	
+	local out="$1"
 	local fill_size=$(( $size - (${#out}*2/5) ))
+	local i
 
 	for i in $(seq $fill_size)
 	do
-		out+="\x00"
+		out="$out\x00"
 	done
 
 	echo -n "$out"
 }
 
 
-function write_efivar() {
-	local readonly varname="781e084c-a330-417c-b678-38e696380cb9-KernelCommandLine"
-	local readonly total_size=514
-	local readonly attr_size=4
-	local readonly data_size=$(( $total_size - $attr_size))
+write_efivar() {
+	local varname="781e084c-a330-417c-b678-38e696380cb9-KernelCommandLine"
+	local total_size=514
+	local attr_size=4
+	local data_size=$(( $total_size - $attr_size))
 	local in="$1"
 
 	#printf "\nin=$in\n"
-	local out="$(to_unicode "$in")"	
+	local out="$(to_unicode "$in")"
 	out="$(fill_to_size "$out" $data_size)"
 
 	local f=$(mktemp)
 	printf "$out" > $f
-	efivar -n $varname -f $f -w 
+	efivar -n $varname -f $f -w
 	rm ${f}
 }
 
-function read_efivar() {
-	local readonly varname="/sys/firmware/efi/efivars/KernelCommandLine-781e084c-a330-417c-b678-38e696380cb9"
-	local var=$(cat $varname | tail -c +5 | tr -d '[\000]')
+read_efivar() {
+	local varname="/sys/firmware/efi/efivars/KernelCommandLine-781e084c-a330-417c-b678-38e696380cb9"
+	local var=$(cat $varname | tail -c +5 | tr -d '\000')
 
 	echo -n "$var"
 }
 
 
-function read_efi_machine_id() {
+read_efi_machine_id() {
 	local var=$(read_efivar)
 	local id
-	
+
 	for i in $var; do
-		case $i in 
+		case $i in
 			systemd.machine_id=*)
 				id="${i#*=}"
 				;;
@@ -69,32 +77,32 @@ function read_efi_machine_id() {
 }
 
 
-function write_efi_machine_id() {
+write_efi_machine_id() {
 	local id="$1"
 	local var=$(read_efivar)
-	local out_var
+	local out_var=""
 	local sep=""
 	local id_mod=false
 
 	for i in $var; do
-		out_var+="$sep"
-		case $i in 
+		out_var="$out_var$sep"
+		case $i in
 			systemd.machine_id=*)
-				out_var+="systemd.machine_id=$id"
+				out_var="${out_var}systemd.machine_id=$id"
 				id_mod=true
 				;;
 			*)
-				out_var+="$i"
+				out_var="$out_var$i"
 				;;
 		esac
 		sep=" "
 	done
-	
+
 	if [ "$id_mod" = false ] ; then
-		out_var+="${sep}systemd.machine_id=$id"
+		out_var="${out_var}${sep}systemd.machine_id=$id"
 	fi
 
-	write_efivar "$out_var"	
+	write_efivar "$out_var"
 }
 
 
@@ -106,23 +114,15 @@ while getopts "rw:" opt; do
 	printf "$(read_efi_machine_id)\n"
       ;;
     w )
-	write_efi_machine_id $OPTARG 
+	write_efi_machine_id $OPTARG
       ;;
-    \? ) 
+    \? )
 	echo "$usage";exit 2
       ;;
   esac
 done
 
 
-if [ $OPTIND -eq 1 ]; then 
-	echo "$usage"; exit 1 
+if [ $OPTIND -eq 1 ]; then
+	echo "$usage"; exit 1
 fi
-
-
-
-
-
-
-
-

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-update-verifier/files/mender-update-verifier.sh
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-update-verifier/files/mender-update-verifier.sh
@@ -1,33 +1,32 @@
 #!/bin/sh
+# Must parse and run under busybox ash: this layer targets images such as
+# core-image-minimal where /bin/sh is busybox and bash is not installed.
 
-
-function read_efivar() {
+read_efivar() {
 	local AB="AB"
 	local slot="Slot${AB:$1:1}"
 	local varname="/sys/firmware/efi/efivars/RootfsStatus${slot}-781e084c-a330-417c-b678-38e696380cb9"
-	local var=$(cat $varname | tail -c +5 | tr -d '[\000]')
+	local var=$(cat $varname | tail -c +5 | tr -d '\000')
 
 	echo -n "$var"
 }
 
 
-
-function get_bootable_status() {
+get_bootable_status() {
 	local status="$(read_efivar "${1}")"
 	local size="${#status}"
 	return $size
 }
 
 
-function set_update_status() {
+set_update_status() {
 	get_bootable_status 0
 	local slot0=$?
 	get_bootable_status 1
 	local slot1=$?
-	if [[ "$slot0" -ne 0 || "$slot1" -ne 0 ]]; then
-		fw_setenv -s <<< upgrade_available=0
-	fi	
+	if [ "$slot0" -ne 0 ] || [ "$slot1" -ne 0 ]; then
+		fw_setenv upgrade_available 0
+	fi
 }
 
 set_update_status
-

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
@@ -1,4 +1,6 @@
-#!/bin/bash
+#!/bin/sh
+# Must parse and run under busybox ash: this layer targets images such as
+# core-image-minimal where /bin/sh is busybox and bash is not installed.
 
 CAPTARGET="/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"
 


### PR DESCRIPTION
Three scripts that this layer installs onto the target declare `#!/bin/sh` (or
`#!/bin/bash`) but are written for bash, and nothing in the layer depends on
bash. On `core-image-minimal`, which is the image the layer README's own quick
start tells people to build, `/bin/sh` is busybox ash and bash is not installed
at all, so none of the three work.

| script | construct | result |
|---|---|---|
| `mender-update-verifier.sh:28` | `fw_setenv -s <<< upgrade_available=0` | `syntax error: unexpected redirection` |
| `efi_systemd_machine_id.sh:7` | `for (( i=0; i<${#in}; i++))` | `syntax error: bad for loop variable` |
| `abort-blupdate:1` | `#!/bin/bash` | cannot exec, exit 127 |

This has been invisible because the images that were actually booted on hardware
so far used `core-image-base`, which pulls bash in and points `/bin/sh` at it.
Thor's `core-image-minimal` manifest contains `mender-update-verifier` and
`busybox` but no bash, so on that configuration the verifier has never run.

`efi_systemd_machine_id.sh` also uses `out+="$char"` to build the kernel command
line. ash does not treat that as an assignment; it parses it as a command name,
prints `not found` on stderr and leaves the variable empty. Had the script
parsed, it would have written an empty `KernelCommandLine` efivar rather than
failing. That one is not caught by `busybox ash -n`.

## Why it matters

`abort-blupdate` is `ArtifactRollback_Leave_50_abort-blupdate`. Its only job is
to delete `/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap`. That matters when
`ArtifactInstall_Leave` fails after `ArtifactInstall_Leave_50_switch-rootfs` has
already staged the capsule: if the capsule is not removed, the next reboot
applies it and the bootloader switches to the slot mender just decided to
abandon.

Reproduced on an Orin NX 8GB (`p3768-0000-p3767-0001`, Jetpack 7,
mender-update 5.1.0) running `core-image-minimal`, with a deliberate
`ArtifactInstall_Leave_60_fail` state script:

```
Running State Script: /var/lib/mender/scripts/ArtifactRollback_Leave_50_abort-blupdate
error: Received error: (NonZero exit code error: Received error code: 1)
       when running the State Script scripts ArtifactRollbackLeave
Calling `reboot` command and waiting for system to restart.
```

The deployment was reported to the server as `failure`, and `mender-update
show-artifact` still named the old artifact, but the board came back on the
other slot:

| | before | after |
|---|---|---|
| bootloader slot | A | **B** |
| rootfs | `/dev/nvme0n1p1` | `/dev/nvme0n1p2` |
| deployment status | | `failure` |
| `mender-update show-artifact` | `onx-min-unfixed-1` | `onx-min-unfixed-1` |

So mender's record and the hardware disagree after a failed install. In this
test the payload was byte identical, so nothing broke. With a genuinely bad
image, the device would be running the rejected rootfs while the server shows a
clean rollback.

## The fix

Make the three scripts run under busybox ash as well as bash, rather than adding
a bash dependency, which would make bash a hard requirement of every Tegra image
and defeat the purpose of `core-image-minimal`. `abort-blupdate` is already
`#!/usr/bin/env sh` on the `scarthgap` branch; `wrynose` is the outlier.

Also included, all drive by:

- `[[ ]]` becomes two POSIX tests, and the bash `function` keyword goes, for
  consistency with the rest of the layer.
- `tr -d '[\000]'` becomes `tr -d '\000'` in both scripts that read efivars. The
  brackets are literal to `tr`, so the old form also stripped `[` and `]` from
  the value.
- Five `local readonly x=...` declarations lose the `readonly` token. `local`
  does not accept it as an option, so it only ever declared an extra local named
  `readonly` and made nothing read only.

The `efi_systemd_machine_id.sh` rewrite is behaviour preserving: `to_unicode`,
`fill_to_size`, `read_efi_machine_id` and `write_efi_machine_id` produce byte
identical output to the original when both are run under bash, for the
machine-id-present and machine-id-absent paths, and the rewrite gives the same
results under busybox ash 1.37.0.

## Verification

Seven deployments on the Orin NX 8GB, all on `core-image-minimal` with
`kernel-module-r8168` added for the Realtek NIC. Every image was confirmed to
contain busybox and no bash. Broken artifacts are `mender-artifact` repacks of
the corresponding build's `.ext4`, so the payload is identical and the injected
state script is the only variable.

| # | scenario | before the fix | after the fix |
|---|---|---|---|
| 1 / 3 | plain update, commit | deployment `success`, but `mender-update-verifier` left `failed`, `status=2` | `success`, verifier `status=0/SUCCESS` |
| 2 / 4 | `ArtifactInstall_Leave` fails after the capsule is staged | `abort-blupdate` errors, capsule survives, board moves A to B | `abort-blupdate` runs clean, capsule removed, board stays on A |
| 5 | `ArtifactCommit_Enter` fails after reboot | not run | rollback clean, back on the original slot, deployment `failure` |
| 6 | rootfs with no init at all | not run | UEFI marks `RootfsStatusSlotB=0xff` and reverts, verifier `success`, deployment `failure` |
| 7 | restore | | both slots hold a good image again |

The machine-id helper was also checked directly on the target. Before the fix,
running it under the image's own `/bin/sh` gives the line 7 syntax error and its
caller `mender-set-systemd-machine-id.sh` swallows that and still exits 0. After
the fix it returns the correct id and the caller genuinely succeeds.

Two observations from the runs that are not addressed here and want their own
look:

- With the unbootable rootfs in slot B, the bootloader chain failure check does
  not fail over. `Total boot-chains: 2 Active-chain: 1|B - BR-BCT based
  selection` stays put across repeated boots, because UEFI itself starts fine
  and only the kernel panics. Recovery came from the rootfs A/B mechanism, and
  needed considerably more boot attempts than the three seen when the broken
  slot was A. The panic also halts rather than rebooting, so the attempts had to
  be driven by power cycling.
- Cutting power resets the RTC to 1970, which breaks TLS and stalls the
  deployment status upload until timesyncd catches up.

The same two script defects exist on `scarthgap` and want a follow up there.

(Claude Code was involved in the analysis and writing here as well.)
