### PR TITLE
feat(tegra): add an opt-in Tegra-native rootfs update module

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -73,6 +73,106 @@ To solve this issue we create a new [custom partition layout](recipes-bsp/tegra-
 
 It is possible to auto-grow the UDA partition to fill remaining space with [this](https://gist.github.com/rishabnayak/a734d2720f43b8908e59564c14fa52e9) bbappend in a layer above `meta-mender-tegra`. It sets the UDA allocation attribute to `0x808`, removes partition id numbers, and moves the UDA partition to right before the `secondary_gpt` partition following [Nvidia documentation](https://docs.nvidia.com/jetson/archives/r35.6.0/DeveloperGuide/AR/BootArchitecture/PartitionConfiguration.html#partition-child-elements).
 
+## Tegra-native update scheme (opt in)
+
+By default this layer drives Mender's stock `rootfs-image` update module. That module
+is written for u-boot and GRUB systems, so on Tegra it only works through a stack of
+adapters: `libubootenv-fake` provides `fw_printenv`/`fw_setenv` (where
+`fw_setenv mender_boot_part` is a no-op), three Mender state scripts perform the
+actual slot switch outside the module, and `mender-update-verifier` exists to undo
+state the shims cannot express.
+
+Setting
+
+```
+TEGRA_MENDER_NATIVE_UPDATE = "1"
+```
+
+selects an alternative that talks to the BSP directly. It uses `nvbootctrl -t rootfs`
+for slot queries and verification, `/dev/disk/by-partlabel/APP{,_b}` for the
+partitions, `mender-flash` for the write, and `oe4t-set-uefi-OSIndications` to arm the
+capsule. None of the shims, state scripts or `mender.conf` partition entries are
+needed, and none are installed.
+
+### What changes
+
+The image builds a `.tegra-mender-native` artifact instead of a `.mender` one. It
+carries the payload type `tegra-rootfs-image` and two payload files, the rootfs
+`.ext4` and `tegra-bl.cap`. Shipping the capsule inside the artifact is what removes
+the worst of the glue, since the legacy `switch-rootfs` state script has to mount the
+freshly written slot just to fetch it.
+
+The artifact still provides `rootfs-image.version` and clears `rootfs-image.*`, so
+inventory and deployment logic look unchanged to the server.
+
+Note that the payload type is what selects the module, so the two schemes cannot be
+mixed within one artifact. The stock `rootfs-image` module is deliberately left in the
+image: without `libubootenv-fake` it fails immediately on the missing `fw_printenv`,
+which is the loud failure you want if an ordinary `rootfs-image` artifact is deployed
+to a device running this scheme.
+
+### Slot verification
+
+This platform sets `RootfsRetryCountMax` to 1, so a slot that is never verified does
+not survive a boot. Something has to run `nvbootctrl verify` on an ordinary boot, and
+it must stand down while an update is awaiting its verdict, or the new slot is marked
+good before Mender commits and the A/B rollback is gone.
+
+The legacy scheme keys that window off `upgrade_available` in the u-boot environment.
+The native scheme has no u-boot environment, so meta-tegra's `nv_update_verifier` is
+disabled and replaced by `tegra-rootfs-verify.service`. The update module writes
+`/var/lib/mender/tegra-update-pending` naming the slot the update is aiming at, and
+the verifier stands down only while that slot is the one running. A marker left behind
+by an interrupted deployment therefore cannot stop verification of some unrelated slot
+forever, which would condemn it.
+
+### Migrating an existing device
+
+Update modules are dispatched by the running rootfs, so a device on the legacy scheme
+has no `tegra-rootfs-image` module yet and cannot install a native artifact. Migration
+takes two deployments: first a legacy `.mender` artifact built from an image that
+already contains `tegra-rootfs-update-module`, then the native artifact. The same
+applies to changes to the module itself, which take effect one deployment later than
+you might expect.
+
+Note that this splits a single deployment across two revisions of the module: the
+states up to the reboot run from the old rootfs, and everything after it from the new
+one. The pending marker crosses that boundary, so a deployment that upgrades the
+module is written by one revision and read by the next. A marker the new verifier
+cannot attribute to the running slot is treated as stale and the slot is verified, so
+such a deployment runs without the deferral. Mender's own rollback is unaffected;
+what is skipped for that one boot is the firmware's automatic fallback.
+
+### Known limitations
+
+**Every rootfs update reflashes the bootloader.** The capsule is bundled in every
+artifact and armed unconditionally, so each deployment writes the inactive boot chain
+even when the firmware is byte for byte what is already there. On an Orin NX that is
+roughly 11 MB of QSPI written per update. This matches the legacy scheme, which arms
+the capsule the same way, so it is inherited behaviour rather than a regression. If
+that write is unwanted, the place to fix it is the module's `ArtifactInstall`, which
+could compare the capsule against the installed firmware version and skip arming when
+they agree. Nothing in the current design depends on the capsule being applied when
+the firmware has not changed, other than the slot switch itself, which is precisely
+what the capsule performs, so the two cannot simply be separated.
+
+**Rollback does not roll back firmware.** The capsule has already updated the other
+boot chain by the time a rollback happens, so a rolled-back device carries the new
+firmware on its standby chain. This also matches the legacy scheme.
+
+That has a consequence worth stating plainly. After a rolled-back update the standby
+chain holds the new firmware alongside a rootfs that failed its commit, and that slot
+is still flagged bootable. The module flags the target unbootable only while it is
+being written, and clears the flag once the write completes, so a slot that was written
+successfully but never committed remains a valid fallback target. If the active chain
+later fails to boot, the firmware falls back to a rootfs and firmware pair that was
+never validated together. Mender does not know about that slot either, so the device
+would come up reporting an artifact the server never recorded as installed.
+
+**The unbootable-rootfs fallback gap** applies here as it does to the legacy scheme.
+A/B recovers a rootfs that boots but never commits. It does not recover one that fails
+to boot, and a rootfs that panics is never condemned at all.
+
 ## Shell portability
 
 This layer installs shell scripts onto the target: the Mender state scripts, the

--- a/meta-mender-tegra/meta-mender-tegra-common/classes-global/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/meta-mender-tegra-common/classes-global/tegra-mender-setup.bbclass
@@ -15,11 +15,69 @@ def tegra_mender_image_rootfs_size(d):
     calc_rootfs_size = (calc_rootfs_size * 95) // 100
     return calc_rootfs_size - eval(d.getVar('IMAGE_ROOTFS_EXTRA_SPACE'))
 
+# Opt in to the Tegra-native update scheme: a tegra-rootfs-image update module
+# that drives nvbootctrl, the BSP partlabels and the UEFI capsule directly,
+# instead of the stock rootfs-image module plus this layer's state scripts and
+# fw_printenv/fw_setenv shims.
+#
+# The two schemes are mutually exclusive. Off by default: the state-script path
+# is the one that has been verified on hardware.
+TEGRA_MENDER_NATIVE_UPDATE ??= "0"
+
 # meta-tegra and tegraflash requirements
 # meta-tegra renamed the flashable image type "tegraflash" -> "tegraflash-tar"
 # in the JetPack 7 / wrynose era; track that rename here.
 IMAGE_CLASSES += "image_types_mender_tegra"
+IMAGE_CLASSES += "${@'image_types_mender_tegra_native' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')) else ''}"
 IMAGE_FSTYPES += "tegraflash-tar"
+
+# Native scheme: install the module and emit the module-image artifact.
+#
+# This class is inherited build-wide (INHERIT += "tegra-mender-setup"), so both
+# of the appends below reach every image recipe in the build, not just the OS
+# image. meta-tegra's helper images must be excluded from both, or:
+#
+#   - the initramfs images deadlock, because the native artifact depends on the
+#     UEFI capsule and meta-tegra builds the capsule from the initramfs:
+#       tegra-uefi-capsules:do_compile -> tegra-minimal-initramfs:do_image_complete
+#         -> do_image_tegra_mender_native -> tegra-uefi-capsules:do_deploy
+#   - the initramfs also gains the update module and its runtime dependencies
+#     (mender-flash, tegra-redundant-boot-base, setup-nv-boot-control), which it
+#     has no use for, and which then grow the capsule built from it, and so the
+#     payload of every artifact.
+#   - tegra-espimage otherwise emits a meaningless update artifact holding the
+#     ESP contents.
+#
+# The skip list is matched as a substring of the image name. That is blunt: an
+# image whose name merely contains "initramfs" is skipped too. It is preferred to
+# naming meta-tegra's helper images exactly, which breaks silently whenever one
+# is renamed. The failure modes are asymmetric, which is what settles it: a false
+# skip means a missing artifact, which is noticed immediately, while a false
+# include means a dependency loop or a bloated capsule, which is not.
+TEGRA_MENDER_NATIVE_SKIP_IMAGES ?= "initramfs espimage"
+
+def tegra_mender_native_enabled(d):
+    if not bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')):
+        return False
+    name = d.getVar('IMAGE_BASENAME') or d.getVar('PN') or ''
+    for skip in (d.getVar('TEGRA_MENDER_NATIVE_SKIP_IMAGES') or '').split():
+        if skip in name:
+            return False
+    return True
+
+# The stock rootfs-image module is left in the image on purpose rather than
+# surgically deleted. Under this scheme libubootenv-fake is not installed, so it
+# fails immediately on the missing fw_printenv instead of running through a
+# no-op fw_setenv and silently doing nothing. That is the loud failure we want
+# if someone deploys an ordinary rootfs-image artifact here.
+IMAGE_INSTALL:append:tegra = "${@' tegra-rootfs-update-module' if tegra_mender_native_enabled(d) else ''}"
+
+# Swap the stock "mender" artifact for the module-image one. This has to be an
+# :append:tegra plus a :remove:tegra, not a plain +=, because the tegra kas
+# configurations set IMAGE_FSTYPES:tegra outright and that replaces anything
+# appended to the unoverridden variable.
+IMAGE_FSTYPES:append:tegra = "${@' tegra-mender-native' if tegra_mender_native_enabled(d) else ''}"
+IMAGE_FSTYPES:remove:tegra = "${@'mender' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')) else ''}"
 
 ARTIFACTIMG_FSTYPE = "ext4"
 # Generate dataimg for use with the tegraflash-tar package
@@ -133,8 +191,11 @@ def tegra_mender_calc_total_size(d):
 MENDER_IMAGE_ROOTFS_SIZE_DEFAULT = "${@tegra_mender_image_rootfs_size(d)}"
 MENDER_STORAGE_TOTAL_SIZE_MB_DEFAULT:tegra = "${@tegra_mender_calc_total_size(d)}"
 
+# The state scripts exist only to work around the stock rootfs-image module not
+# being able to drive Tegra. The native module does that work itself, so they
+# are not built or bundled into the artifact when it is selected.
 _MENDER_IMAGE_DEPS_EXTRA = ""
-_MENDER_IMAGE_DEPS_EXTRA:tegra = "tegra-state-scripts:do_deploy"
+_MENDER_IMAGE_DEPS_EXTRA:tegra = "${@'' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')) else 'tegra-state-scripts:do_deploy'}"
 do_image_mender[depends] += "${_MENDER_IMAGE_DEPS_EXTRA}"
 
 # mender-setup-image adds kernel-image and kernel-devicetree to

--- a/meta-mender-tegra/meta-mender-tegra-common/classes-recipe/image_types_mender_tegra_native.bbclass
+++ b/meta-mender-tegra/meta-mender-tegra-common/classes-recipe/image_types_mender_tegra_native.bbclass
@@ -1,0 +1,57 @@
+# Builds a Mender artifact for the tegra-rootfs-image update module.
+#
+# Unlike the stock "mender" image type this emits a module-image artifact with a
+# payload type of tegra-rootfs-image, carrying two files: the rootfs and the
+# UEFI capsule. Carrying the capsule in the artifact is what lets the module
+# stage it without mounting the freshly written slot, which is what the
+# switch-rootfs state script has to do today.
+#
+# Modelled on meta-mender's mender-artifact-uefi-capsule.bbclass, which does the
+# same shape of thing for -T uefi-capsule.
+
+inherit image_types_mender_tegra
+
+TEGRA_NATIVE_ARTIFACT_TYPE ?= "tegra-rootfs-image"
+
+# The capsule that tegra-uefi-capsules built for this machine.
+TEGRA_NATIVE_CAPSULE ?= "${DEPLOY_DIR_IMAGE}/tegra-bl.cap"
+
+do_image_tegra_mender_native[depends] += " \
+    mender-artifact-native:do_populate_sysroot \
+    tegra-uefi-capsules:do_deploy \
+"
+
+IMAGE_TYPEDEP:tegra-mender-native = "${ARTIFACTIMG_FSTYPE}"
+
+IMAGE_CMD:tegra-mender-native () {
+    if [ ! -e "${TEGRA_NATIVE_CAPSULE}" ]; then
+        bbfatal "TEGRA_NATIVE_CAPSULE (${TEGRA_NATIVE_CAPSULE}) does not exist. The" \
+                "tegra-rootfs-image module needs the capsule in the artifact, since" \
+                "applying it is what switches the boot slot."
+    fi
+
+    extra_args=""
+    for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
+        extra_args="$extra_args -c $dev"
+    done
+    if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then
+        extra_args="$extra_args -k ${MENDER_ARTIFACT_SIGNING_KEY}"
+    fi
+
+    # Provide rootfs-image.version, the same key the stock rootfs-image module
+    # provides, so inventory and the server's already-installed check are
+    # unchanged by switching schemes. --software-filesystem alone will not do:
+    # it composes <filesystem>.<type>.version, which would yield
+    # rootfs-image.tegra-rootfs-image.version. Set it explicitly instead.
+    mender-artifact write module-image \
+        -n ${MENDER_ARTIFACT_NAME} \
+        -T ${TEGRA_NATIVE_ARTIFACT_TYPE} \
+        $extra_args \
+        -f ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${ARTIFACTIMG_FSTYPE} \
+        -f ${TEGRA_NATIVE_CAPSULE} \
+        --no-default-software-version \
+        --no-default-clears-provides \
+        --provides rootfs-image.version:${MENDER_ARTIFACT_NAME} \
+        --clears-provides "rootfs-image.*" \
+        -o ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.tegra-mender-native
+}

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
@@ -8,3 +8,16 @@ do_install:append() {
     install -d ${D}/${sbindir}
     install -m 0755 ${S}/nv_update_verifier.sh ${D}/${sbindir}/nv_update_verifier
 }
+
+# nv_update_verifier reads "fw_printenv upgrade_available" to decide whether an
+# update is in flight. The Tegra-native update scheme does not install
+# libubootenv-fake, so fw_printenv does not exist, the value comes back empty,
+# and empty never equals "0". The script then takes its "upgrade in progress"
+# branch on every boot and runs "systemctl reboot -f" the second time it boots
+# the same slot, which is an infinite reboot loop.
+#
+# Leave the unit installed but do not enable it. Its two jobs are covered:
+# marking the running slot good is done by the update module in ArtifactCommit,
+# and forcing reboots to drain the UEFI retry counter is something UEFI already
+# does on its own for an unverified slot.
+SYSTEMD_AUTO_ENABLE:${PN} = "${@'disable' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')) else 'enable'}"

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/mender-tegra.inc
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/mender-tegra.inc
@@ -1,4 +1,8 @@
-EXTRADEPS:tegra = "tegra-uefi-capsules libubootenv-fake mender-update-verifier tegra-redundant-boot"
+# Under the native scheme the update module talks to nvbootctrl directly, so the
+# fw_printenv/fw_setenv shims and the verifier that patches up their limitations
+# are not pulled in. The capsule and tegra-redundant-boot are still needed:
+# applying the capsule is what switches the boot slot.
+EXTRADEPS:tegra = "${@'tegra-uefi-capsules tegra-redundant-boot' if bb.utils.to_boolean(d.getVar('TEGRA_MENDER_NATIVE_UPDATE')) else 'tegra-uefi-capsules libubootenv-fake mender-update-verifier tegra-redundant-boot'}"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:remove:mender-persist-systemd-machine-id = " \

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-image
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-image
@@ -1,0 +1,379 @@
+#!/bin/sh
+# Mender update module for Tegra A/B rootfs updates.
+#
+# Must parse and run under busybox ash: this layer targets images such as
+# core-image-minimal where /bin/sh is busybox and bash is not installed. Do not
+# use 'var+=' to append - ash parses that as a command name, so it fails
+# silently and leaves the variable empty.
+#
+# Unlike the stock rootfs-image module this talks to the BSP directly:
+#
+#   nvbootctrl -t rootfs        which slot is running, and slot verification
+#   /dev/disk/by-partlabel/APP  the rootfs partitions, named by the BSP layout
+#   mender-flash                sparse-aware write to the passive slot
+#   oe4t-set-uefi-OSIndications arm the staged UEFI capsule
+#
+# There is no fw_printenv/fw_setenv, no upgrade_available, no parsing of
+# RootfsPartA/B out of mender.conf, and no Mender state scripts.
+#
+# Slot switching is performed by the UEFI capsule, not by nvbootctrl. Applying a
+# capsule writes firmware into the *inactive* boot chain and then makes that
+# chain active, and rootfs slots are paired to bootloader slots, so the rootfs
+# follows. Calling set-active-boot-slot as well would make the capsule target
+# the wrong chain, so it is used only to undo a switch during rollback.
+
+set -ue
+
+STATE="$1"
+FILES="$2"
+
+# Overridable only so the module can be exercised off-target; the defaults are
+# what runs on the device.
+ESP_MOUNT="${TEGRA_ESP_MOUNT:-/boot/efi}"
+ESP_CAPSULE_DIR="${TEGRA_ESP_CAPSULE_DIR:-${ESP_MOUNT}/EFI/UpdateCapsule}"
+UEFI_COMMON_FUNC="${TEGRA_UEFI_COMMON_FUNC:-/usr/bin/uefi_common.func}"
+PARTLABEL_DIR="${TEGRA_PARTLABEL_DIR:-/dev/disk/by-partlabel}"
+PROC_MOUNTS="${TEGRA_PROC_MOUNTS:-/proc/mounts}"
+ESP_CAPSULE="${ESP_CAPSULE_DIR}/TEGRA_BL.Cap"
+CAPSULE_STASH="${FILES}/tmp/tegra-bl.cap"
+ORIG_SLOT_FILE="${FILES}/tmp/orig-slot"
+# Persistent, and deliberately not under $FILES: tegra-rootfs-verify reads it on
+# the next boot to decide whether the running slot may be marked good yet.
+UPDATE_PENDING="${TEGRA_UPDATE_PENDING:-/var/lib/mender/tegra-update-pending}"
+ROOTFS_STATUS_GUID="781e084c-a330-417c-b678-38e696380cb9"
+EFI_GLOBAL_GUID="8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+# Progress goes to stderr, which mender folds into the deployment log. Without
+# this a module that dies mid-state leaves nothing behind saying how far it got,
+# and the deployment log is the only evidence available once a bad update has
+# made the device unreachable.
+log() {
+    echo "tegra-rootfs-image[$STATE]: $*" 1>&2
+}
+
+# Slot number (0/1) -> the real device node for that slot's rootfs. The BSP
+# names the partitions, but the symlink is resolved before use: the stock
+# rootfs-image module does the same before handing a path to mender-flash.
+slot_device() {
+    case "$1" in
+        0) _lbl="${PARTLABEL_DIR}/APP" ;;
+        1) _lbl="${PARTLABEL_DIR}/APP_b" ;;
+        *) echo "unexpected rootfs slot '$1'" 1>&2; return 1 ;;
+    esac
+    readlink -f "$_lbl"
+}
+
+# Device the root filesystem is actually mounted from, canonicalised the same
+# way, so it can be compared with slot_device output.
+root_device() {
+    _r=$(while read -r dev mnt _rest; do
+             [ "$mnt" = "/" ] && { echo "$dev"; break; }
+         done < "$PROC_MOUNTS")
+    readlink -f "$_r"
+}
+
+# Never write to the slot we are running from. nvbootctrl and the mounted root
+# must agree about which slot is active; if they do not, the slot bookkeeping is
+# wrong and writing would destroy the running system mid-update. Fail the
+# deployment instead. The stock rootfs-image module guards the same way, via
+# check_device_matches_root.
+assert_slot_mapping_sane() {
+    _act=$(slot_device "$(current_slot)")
+    _pas=$(slot_device "$(passive_slot)")
+    _root=$(root_device)
+
+    if [ -z "$_root" ]; then
+        log "FATAL: cannot determine the root device from $PROC_MOUNTS"
+        return 1
+    fi
+    if [ "$_act" != "$_root" ]; then
+        log "FATAL: nvbootctrl says the active slot is $_act but / is mounted from $_root"
+        return 1
+    fi
+    if [ "$_pas" = "$_root" ]; then
+        log "FATAL: computed passive slot $_pas is the mounted root; refusing to write"
+        return 1
+    fi
+    log "slot mapping sane: active $_act, passive $_pas"
+    return 0
+}
+
+slot_letter() {
+    case "$1" in
+        0) echo "A" ;;
+        1) echo "B" ;;
+        *) echo "unexpected rootfs slot '$1'" 1>&2; return 1 ;;
+    esac
+}
+
+current_slot() {
+    nvbootctrl -t rootfs get-current-slot
+}
+
+passive_slot() {
+    if [ "$(current_slot)" = "0" ]; then echo 1; else echo 0; fi
+}
+
+# Write a slot's RootfsStatusSlot{A,B} efivar. 0x00 is a normal, bootable slot;
+# 0xff tells UEFI the slot is unusable, so it boots the partner instead.
+set_rootfs_status() {
+    _slot="$1"
+    _val="$2"
+    _rc=0
+    # uefi_common.func predates any use of 'set -u'. set_efi_var reads a fourth
+    # positional argument (write_once) and $RUNTIME_DIRECTORY, and neither is
+    # guaranteed to be set when we call it. Relax nounset around the call rather
+    # than patching the BSP, and pass the fourth argument explicitly: empty means
+    # "not write-once", which is what we want since the status must be
+    # overwritten every time.
+    set +u
+    . "$UEFI_COMMON_FUNC"
+    set_efi_var "RootfsStatusSlot$(slot_letter "$_slot")" "$ROOTFS_STATUS_GUID" \
+        "$_val" "" || _rc=$?
+    set -u
+    return "$_rc"
+}
+
+# The passive slot may still be flagged unbootable, either from an earlier failed
+# update or from the write below. UEFI refuses to boot it until this is cleared.
+clear_unbootable() {
+    set_rootfs_status "$1" "\x00\x00\x00\x00"
+}
+
+mark_unbootable() {
+    set_rootfs_status "$1" "\xff\x00\x00\x00"
+}
+
+# Undo "arm the capsule". Deleting the staged file is not enough on its own:
+# OsIndications still asks the firmware to run a capsule update on the next
+# boot, and an aborted update must not leave that request standing.
+disarm_capsule() {
+    _rc=0
+    set +u
+    . "$UEFI_COMMON_FUNC"
+    set_efi_var "OsIndications" "$EFI_GLOBAL_GUID" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" "" || _rc=$?
+    set -u
+    return "$_rc"
+}
+
+case "$STATE" in
+    ProvidePayloadFileSizes)
+        echo "Yes"
+        ;;
+
+    Download)
+        echo "This module supports DownloadWithFileSizes only" 1>&2
+        exit 1
+        ;;
+
+    DownloadWithFileSizes)
+        assert_slot_mapping_sane || exit 1
+        target="$(passive_slot)"
+        target_dev="$(slot_device "$target")"
+
+        # From the first byte written until ArtifactInstall clears this again,
+        # the slot holds a torn filesystem. Leaving it flagged bootable would let
+        # UEFI fall back onto a half-written rootfs if the running slot failed
+        # during the download.
+        log "flagging slot $target unbootable while it is being written"
+        mark_unbootable "$target"
+
+        got_rootfs=0
+        got_capsule=0
+        while true; do
+            line="$(cat stream-next)"
+            [ -n "$line" ] || break
+
+            # "<path> <size>"; the path's basename identifies the payload.
+            path="$(echo "$line" | cut -d' ' -f1)"
+            size="$(echo "$line" | cut -d' ' -f2)"
+            if [ -z "$path" ] || [ -z "$size" ]; then
+                echo "Cannot parse line from stream-next, got: $line" 1>&2
+                exit 1
+            fi
+
+            # Match both payloads explicitly. A catch-all that treats "not a
+            # capsule" as "the rootfs" would flash a stray file straight onto
+            # the partition, and would let a second rootfs payload silently
+            # overwrite the first.
+            case "$(basename "$path")" in
+                *.cap)
+                    if [ "$got_capsule" = 1 ]; then
+                        echo "Artifact carries more than one .cap payload" 1>&2
+                        exit 1
+                    fi
+                    log "stashing capsule ($size bytes)"
+                    mkdir -p "${FILES}/tmp"
+                    cat "$path" > "$CAPSULE_STASH"
+                    got_capsule=1
+                    ;;
+                *.ext4)
+                    if [ "$got_rootfs" = 1 ]; then
+                        echo "Artifact carries more than one rootfs payload" 1>&2
+                        exit 1
+                    fi
+                    log "writing rootfs ($size bytes) to $target_dev"
+                    mender-flash --input-size "$size" --input "$path" \
+                        --output "$target_dev"
+                    log "rootfs write finished"
+                    got_rootfs=1
+                    ;;
+                *)
+                    echo "Unexpected payload '$(basename "$path")': this module" \
+                         "takes exactly one .ext4 rootfs and one .cap capsule" 1>&2
+                    exit 1
+                    ;;
+            esac
+        done
+
+        if [ "$got_rootfs" != 1 ]; then
+            echo "Artifact contained no rootfs payload" 1>&2
+            exit 1
+        fi
+        if [ "$got_capsule" != 1 ]; then
+            echo "Artifact contained no .cap payload; the slot switch is" \
+                 "performed by the UEFI capsule, so it is required" 1>&2
+            exit 1
+        fi
+        sync
+        ;;
+
+    ArtifactInstall)
+        # Remember where we came from, so rollback after the reboot knows which
+        # slot to go back to. $FILES/tmp survives the reboot.
+        assert_slot_mapping_sane || exit 1
+        _cur="$(current_slot)"
+        _passive="$(passive_slot)"
+        log "current slot $_cur, arming slot $_passive"
+        echo "$_cur" > "${ORIG_SLOT_FILE}.tmp"
+        mv "${ORIG_SLOT_FILE}.tmp" "$ORIG_SLOT_FILE"
+        sync
+
+        log "clearing any unbootable flag on slot $_passive"
+        clear_unbootable "$_passive"
+
+        # The ESP has to be mounted, or the capsule silently lands on the rootfs
+        # and no switch is armed.
+        if ! grep -q " $ESP_MOUNT " "$PROC_MOUNTS" 2>/dev/null; then
+            log "FATAL: $ESP_MOUNT is not mounted; the capsule would land on the rootfs"
+            exit 1
+        fi
+
+        log "staging capsule to $ESP_CAPSULE"
+        mkdir -p "$ESP_CAPSULE_DIR"
+        cp "$CAPSULE_STASH" "$ESP_CAPSULE"
+        sync
+
+        # Hold off tegra-rootfs-verify until this update has a verdict. Without
+        # this the next boot marks the new slot good before mender commits, and
+        # the rollback is gone.
+        #
+        # The marker names the slot the update is aiming at, and the verifier
+        # only stands down while that slot is the one running. A marker that
+        # outlives its deployment then cannot silently stop verification of some
+        # unrelated slot forever, which with RootfsRetryCountMax=1 would condemn
+        # it after a single boot.
+        log "marking update pending ($UPDATE_PENDING), target slot $_passive"
+        echo "$_passive" > "${UPDATE_PENDING}.tmp"
+        mv "${UPDATE_PENDING}.tmp" "$UPDATE_PENDING"
+        sync
+
+        log "arming OsIndications"
+        oe4t-set-uefi-OSIndications
+        log "done; the capsule will switch the boot chain on the next reboot"
+        ;;
+
+    NeedsArtifactReboot)
+        echo "Automatic"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactVerifyReboot)
+        # The capsule should have switched us to the other slot.
+        [ -f "$ORIG_SLOT_FILE" ] || { echo "missing $ORIG_SLOT_FILE" 1>&2; exit 1; }
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" = "$orig" ]; then
+            log "still on slot $orig after reboot; the capsule did not switch the boot chain"
+            exit 1
+        fi
+        log "booted slot $cur as expected (was $orig)"
+        # The boot chain switched, but that is only half of the claim. Confirm
+        # that / really is this slot's partition before the commit blesses the
+        # pairing; otherwise a chain that switched without the rootfs following
+        # goes unnoticed until the next update writes over the running system.
+        assert_slot_mapping_sane || exit 1
+        ;;
+
+    ArtifactCommit)
+        # Marks the running bootloader and rootfs slot good, and resets the
+        # rootfs retry counter. Without this UEFI reverts on a later boot.
+        log "verifying slot $(current_slot)"
+        nvbootctrl verify
+        rm -f "$UPDATE_PENDING"
+        sync
+        log "slot verified, update no longer pending"
+        ;;
+
+    ArtifactRollback)
+        # Remove a staged-but-unapplied capsule unconditionally, before anything
+        # else can fail. Leaving it behind is the dangerous outcome: the next
+        # reboot would switch to the slot being abandoned.
+        if [ -e "$ESP_CAPSULE" ]; then
+            log "removing staged capsule $ESP_CAPSULE"
+            rm -f "$ESP_CAPSULE"
+            sync
+        else
+            log "no staged capsule to remove"
+        fi
+        log "disarming OsIndications"
+        disarm_capsule || log "WARNING: could not clear OsIndications"
+        rm -f "$UPDATE_PENDING"
+        sync
+
+        if [ ! -f "$ORIG_SLOT_FILE" ]; then
+            log "no recorded original slot; nothing further to undo"
+            exit 0
+        fi
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" != "$orig" ]; then
+            # The capsule already applied and we booted the new slot. Send the
+            # boot chain back; the rootfs slot is paired to it and follows.
+            log "on slot $cur, returning to $orig"
+            nvbootctrl set-active-boot-slot "$orig"
+        else
+            log "still on the original slot $orig, no switch to undo"
+        fi
+        ;;
+
+    ArtifactVerifyRollbackReboot)
+        [ -f "$ORIG_SLOT_FILE" ] || { echo "missing $ORIG_SLOT_FILE" 1>&2; exit 1; }
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" != "$orig" ]; then
+            log "FATAL: rollback aimed at slot $orig but booted slot $cur"
+            exit 1
+        fi
+        log "back on slot $orig after rollback"
+        ;;
+
+    ArtifactFailure)
+        ;;
+
+    Cleanup)
+        rm -f "$CAPSULE_STASH"
+        # Whatever happened above, mender is done with this deployment, so
+        # nothing is awaiting a verdict any more. Dropping the marker here as
+        # well covers the paths that reach ArtifactInstall but never reach
+        # ArtifactCommit or ArtifactRollback, such as an aborted deployment.
+        rm -f "$UPDATE_PENDING"
+        sync
+        log "cleaned up"
+        ;;
+esac
+exit 0

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Keep the running Tegra rootfs slot marked good.
+#
+# Must parse and run under busybox ash; see the update module for the details.
+#
+# UEFI condemns a rootfs slot whose retry counter runs out, and this platform
+# sets RootfsRetryCountMax to 1, so a slot that is never verified does not
+# survive. Something has to run "nvbootctrl verify" on an ordinary boot.
+#
+# It must not run while an update is awaiting its verdict. Verifying the newly
+# booted slot before mender has committed would mark it good and throw away the
+# A/B rollback, which is the whole point of the redundant layout. The stock
+# integration keys that window off mender's upgrade_available in the u-boot
+# environment; the native scheme has no u-boot environment, so the update module
+# drops a marker instead, for exactly the same window.
+# The marker names the slot the update is aiming at, and standing down only
+# applies while that slot is the one running. A marker is not proof that an
+# update is still live: a deployment interrupted between ArtifactInstall and its
+# verdict leaves one behind. Treating any marker as "never verify" would then
+# stop verification for good, and a slot that is never verified does not survive
+# a boot, so the stale marker would condemn the very slot it was left on.
+set -u
+
+PENDING="${TEGRA_UPDATE_PENDING:-/var/lib/mender/tegra-update-pending}"
+NVBOOTCTRL="${TEGRA_NVBOOTCTRL:-nvbootctrl}"
+
+if [ -e "$PENDING" ]; then
+    target="$(cat "$PENDING" 2>/dev/null || true)"
+    current="$("$NVBOOTCTRL" -t rootfs get-current-slot 2>/dev/null || true)"
+    if [ -n "$target" ] && [ "$target" = "$current" ]; then
+        echo "tegra-rootfs-verify: update pending on slot $current, leaving it unverified" 1>&2
+        exit 0
+    fi
+    # Running a slot the marker is not about. Either the switch has not happened
+    # yet, or a rollback already brought us back. Either way this slot is not the
+    # one awaiting a verdict and still has to be kept good. The marker is left in
+    # place, so the real window is still honoured if the switch happens later.
+    echo "tegra-rootfs-verify: pending marker names slot ${target:-none}," \
+         "running slot ${current:-unknown}; verifying anyway" 1>&2
+fi
+
+echo "tegra-rootfs-verify: marking the running slot good" 1>&2
+exec "$NVBOOTCTRL" verify

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify.service
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mark the running Tegra rootfs slot good
+# nvbootctrl needs the BSP's boot control setup to have run.
+After=nvstartup.service
+# Settle the slot state before mender can start a new deployment or commit one.
+Before=mender-updated.service
+ConditionPathExists=/usr/sbin/nvbootctrl
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/tegra-rootfs-verify
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/tegra-rootfs-update-module_1.0.bb
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-rootfs-update-module/tegra-rootfs-update-module_1.0.bb
@@ -1,0 +1,46 @@
+SUMMARY = "Tegra-native Mender update module for A/B rootfs updates"
+DESCRIPTION = "Mender update module for Tegra A/B rootfs updates, using the BSP's \
+own tooling (nvbootctrl, partlabels, UEFI capsule) instead of the u-boot \
+environment shims the stock rootfs-image module needs."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "\
+    file://tegra-rootfs-image \
+    file://tegra-rootfs-verify \
+    file://tegra-rootfs-verify.service \
+"
+
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+# nvbootctrl comes from tegra-redundant-boot-base; uefi_common.func,
+# oe4t-set-uefi-OSIndications and the ESP mount come from setup-nv-boot-control;
+# mender-flash does the sparse-aware write to the passive slot.
+RDEPENDS:${PN} = "mender-flash tegra-redundant-boot-base setup-nv-boot-control"
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "tegra-rootfs-verify.service"
+
+do_install() {
+    install -d ${D}${datadir}/mender/modules/v3
+    install -m 0755 ${S}/tegra-rootfs-image ${D}${datadir}/mender/modules/v3/tegra-rootfs-image
+
+    # Replaces the disabled nv_update_verifier: keeps the running slot marked
+    # good on an ordinary boot, and stays out of the way while the update module
+    # has an update awaiting its verdict.
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/tegra-rootfs-verify ${D}${sbindir}/tegra-rootfs-verify
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/tegra-rootfs-verify.service ${D}${systemd_system_unitdir}/
+}
+
+# Only the module needs listing. The default FILES:${PN} already covers
+# ${sbindir}/*, and systemd.bbclass appends the unit and its preset, but the
+# default reaches only ${datadir}/${BPN}, not ${datadir} as a whole.
+FILES:${PN} += "${datadir}/mender/modules/v3/tegra-rootfs-image"
+
+# Shell scripts, so the content is architecture independent, but allarch and
+# COMPATIBLE_MACHINE do not mix. Machine-specific packages it is.
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Mender's stock `rootfs-image` update module is written for u-boot and GRUB. On
Tegra it only works through a stack of adapters this layer maintains, and every
one of them papers over something the platform does not provide:

| adapter | what it papers over |
|---|---|
| `libubootenv-fake` | there is no u-boot environment, so `fw_setenv mender_boot_part` is a **no-op** and the module cannot switch slots at all |
| `ArtifactInstall_Leave_50_switch-rootfs` | the slot switch itself, done outside the module |
| `ArtifactCommit_Enter_50_verify-slot` | `nvbootctrl verify`, which the module has no way to call |
| `ArtifactRollback_Leave_50_abort-blupdate` | removing a staged capsule the module does not know it staged |
| `mender-update-verifier` | undoing state the shims cannot express |
| `RootfsPartA/B` in `mender.conf` | naming partitions the BSP layout already names `APP` and `APP_b` |

Everything the module needs is available natively, so this adds a Tegra specific
module that talks to the BSP directly: `nvbootctrl -t rootfs` for the running
slot and for verification, `/dev/disk/by-partlabel/APP` for the partitions,
`mender-flash` for the write, `oe4t-set-uefi-OSIndications` to arm the staged
capsule. No `fw_printenv`, no state scripts, no `mender.conf` partition entries,
no `upgrade_available`, and none of them are installed when the scheme is on.

## Opt in

```
TEGRA_MENDER_NATIVE_UPDATE = "1"
```

Off by default, because the existing scheme is verified and stays the default.
The payload type is what selects the module, so the two schemes cannot be mixed
within one artifact.

The image then builds a `.tegra-mender-native` artifact instead of a `.mender`
one, payload type `tegra-rootfs-image`, carrying the rootfs `.ext4` and
`tegra-bl.cap`. Shipping the capsule inside the artifact is what removes the
worst of the glue. It still provides `rootfs-image.version` and clears
`rootfs-image.*`, so nothing changes from the server's point of view.

## Three things worth knowing

**The capsule performs the slot switch, not `nvbootctrl`.** Applying a UEFI
capsule writes firmware into the inactive boot chain and makes it active, and
rootfs slots are paired to bootloader slots, so the rootfs follows.
`set-active-boot-slot` is used only to undo a switch during rollback; calling it
on the install path too would aim the capsule at the wrong chain.

**Slot verification needs a marker.** `RootfsRetryCountMax` is 1 here, so an
unverified slot does not survive a boot and something has to run `nvbootctrl
verify` on ordinary boots. It also has to stand down while an update awaits its
verdict, or the new slot is marked good before Mender commits and the A/B
rollback is gone. meta-tegra's `nv_update_verifier` keys that off
`upgrade_available`, which does not exist here, so it is disabled and
`tegra-rootfs-verify.service` takes over. The module writes a marker naming the
target slot, and the verifier stands down only while that slot is the one
running, so a marker left over from an interrupted deployment cannot condemn a
slot forever.

**Migration takes two deployments.** Modules are dispatched by the running
rootfs, so a device on the legacy scheme has no `tegra-rootfs-image` module yet:
first a legacy `.mender` artifact built from an image that contains the module,
then the native one. Same for later changes to the module itself.

Note that the stock `rootfs-image` module stays in the image on purpose. Without
`libubootenv-fake` it fails on the missing `fw_printenv` before writing
anything, which is the loud failure you want if someone deploys an ordinary
`rootfs-image` artifact here.

Two bits of build wiring look odd and are explained in comments: `IMAGE_FSTYPES`
uses `:append:tegra`, because kas configurations set `IMAGE_FSTYPES:tegra`
outright and a plain `+=` is discarded, and the flag is
`TEGRA_MENDER_NATIVE_UPDATE` rather than `MENDER_TEGRA_*`, because meta-mender
sanity checks `MENDER_` variables against a fixed list a layer cannot extend.

## Verification

Offline, against stubbed `nvbootctrl`, `mender-flash` and
`oe4t-set-uefi-OSIndications`: 42 assertions across 11 scenarios, passing under
busybox ash, dash and bash. Both shipped scripts parse under ash, since this
layer targets images such as `core-image-minimal` where bash is absent, the same
constraint #527 dealt with.

On hardware, a Jetson Orin NX 8GB (`p3768-0000-p3767-0001`, NVMe, JetPack 7,
L4T 39.2.0) running `core-image-minimal`:

| scenario | expected | result |
|---|---|---|
| plain update, commit | lands on the other slot, `nvbootctrl verify` run, no state scripts in the log | pass |
| `ArtifactInstall_Leave` fails after the capsule is staged | capsule removed, `OsIndications` disarmed, slot unchanged | pass |
| `ArtifactCommit_Enter` fails after the reboot | `set-active-boot-slot` back, deployment `failure`, board on the original slot | pass |

All of them in both slot directions. The broken artifacts are repacks of the
same build's `.ext4`, so the injected state script is the only variable.
Rollback issues an explicit `set-active-boot-slot` rather than trusting the
firmware's own fallback, which is why the A/B asymmetry noted in #527 does not
affect these paths.

## Known limitations, also in the README

**Every rootfs update reflashes the bootloader.** The capsule ships in every
artifact and is armed unconditionally, so each deployment writes the inactive
boot chain even when the firmware is identical, roughly 11 MB of QSPI on an Orin
NX. The legacy scheme arms it the same way, so this is inherited rather than a
regression. Fixing it means comparing firmware versions in `ArtifactInstall` and
skipping the arming, but the capsule is also what switches the slot, so the two
do not separate cleanly.

**Rollback does not roll back firmware.** Also true of the legacy scheme. The
part worth stating: the standby slot ends up holding new firmware next to a
rootfs that failed its commit, still flagged bootable, because the module clears
the unbootable flag once the write completes. Should the active chain later fail
to boot, the firmware falls back to a pair that was never validated together.

**The unbootable-rootfs fallback gap** applies exactly as it does to the legacy
scheme. A/B recovers a rootfs that boots but never commits, not one that fails
to boot.

Two nits, neither blocking: `disarm_capsule` zeroes all eight bytes of
`OsIndications` rather than only the capsule delivery bit, safe because nothing
else on this image sets those bits, and `tegra-rootfs-verify.service` uses
`ConditionPathExists=/usr/sbin/nvbootctrl`, so a moved `nvbootctrl` would make
the unit silently succeed and stop verifying.

(Claude Code was involved in the analysis and writing here as well.)
