### PR TITLE
feat(tegra): add the Tegra-native update scheme as its own layer

### DIFF
--- a/meta-mender-tegra/README.md
+++ b/meta-mender-tegra/README.md
@@ -46,6 +46,11 @@ release.
   The classic update scheme: Mender's stock `rootfs-image` update module, driven
   through this layer's state scripts and the `fw_printenv`/`fw_setenv` shims.
 
+- `meta-mender-tegra-native`
+  The Tegra-native update scheme: a `tegra-rootfs-image` update module driving
+  `nvbootctrl`, the BSP partlabels and the UEFI capsule directly, with none of
+  those adapters.
+
 - `meta-mender-tegra-jetpack7`
   Jetpack 7 specific parts, matching the `wrynose` branch of `meta-tegra`.
 
@@ -62,9 +67,18 @@ BBLAYERS += "\
 INHERIT += "tegra-mender-classic"
 ```
 
-`tegra-mender-common` is never inherited directly. The scheme class pulls it in,
-and on its own it would configure no scheme at all, so the common layer refuses
-that at parse time.
+For the native scheme, substitute `meta-mender-tegra-native` and
+`INHERIT += "tegra-mender-native"`.
+
+Two things are refused at parse time. Inheriting `tegra-mender-common` directly:
+the scheme class pulls it in, and on its own it would configure no scheme at all.
+And two scheme layers at once: the bbappends of both would apply whichever class
+was inherited, yielding an image whose slot verification belongs to the other
+scheme.
+
+The schemes are mutually exclusive on the device as well. Neither can install the
+other's artifact, so there is no migration path; see
+[meta-mender-tegra-native/README.md](meta-mender-tegra-native/README.md).
 
 ## Quick start
 
@@ -119,6 +133,22 @@ systems. `meta-mender-tegra-classic` supplies the adapters it needs on Tegra:
 
 This is the scheme every published Tegra build uses and the one verified on
 hardware.
+
+## The native update scheme
+
+`meta-mender-tegra-native` replaces that stack with a single update module,
+`tegra-rootfs-image`, calling the BSP directly: `nvbootctrl -t rootfs` for slot
+state and verification, `/dev/disk/by-partlabel/APP{,_b}` for the partitions,
+`mender-flash` for the write, the UEFI capsule for the switch. The capsule ships
+inside the artifact, so nothing has to mount the freshly written slot.
+
+The artifact keeps the canonical `.mender` name and still provides
+`rootfs-image.version`, so the upload and the server side are unchanged. Only the
+payload type inside differs; `mender-artifact read` tells the two apart.
+
+Verification window, why `nv_update_verifier` is disabled rather than removed, and
+the scheme's limitations:
+[meta-mender-tegra-native/README.md](meta-mender-tegra-native/README.md).
 
 ## Shell portability
 

--- a/meta-mender-tegra/meta-mender-tegra-native/README.md
+++ b/meta-mender-tegra/meta-mender-tegra-native/README.md
@@ -1,9 +1,106 @@
-This layer holds the Tegra-native update scheme: a `tegra-rootfs-image` update
-module that drives `nvbootctrl`, the BSP partlabels and the UEFI capsule
-directly, instead of Mender's stock `rootfs-image` module and the adapters that
-one needs on Tegra.
+# meta-mender-tegra-native
 
-It is one of two mutually exclusive scheme layers, and selecting it means adding
-it to `BBLAYERS` and inheriting `tegra-mender-native`.
+The Tegra-native update scheme: a `tegra-rootfs-image` update module that talks to
+the BSP directly, in place of Mender's stock `rootfs-image` module and the adapters
+that one needs on Tegra.
 
-See ../README.md for more details and other layers.
+It uses `nvbootctrl -t rootfs` for slot queries and verification, `mender-flash`
+for the write and `oe4t-set-uefi-OSIndications` to arm the capsule. Which device a
+partition label means, and which ESP the capsule belongs on, come from
+`meta-mender-tegra-common`'s `disk-helpers.sh`, sourced at runtime and shared with
+the classic scheme. `libubootenv-fake`, the Mender
+state scripts, `mender-update-verifier` and the `RootfsPartA`/`RootfsPartB` entries
+in `mender.conf` are neither needed nor installed.
+
+One of two mutually exclusive scheme layers. Select it by adding it to `BBLAYERS`
+alongside `meta-mender-tegra-common` and a Jetpack layer, plus:
+
+```
+INHERIT += "tegra-mender-native"
+```
+
+Inheriting `tegra-mender-common` directly, or having both scheme layers in
+`BBLAYERS`, is refused at parse time. See ../README.md for the layer set as a whole.
+
+## What the build produces
+
+One `.mender` file under the usual name, in a deploy directory that looks like the
+classic scheme's. Inside it the payload type is `tegra-rootfs-image` and there are
+two payload files, the rootfs `.ext4` and `tegra-bl.cap`. Carrying the capsule in
+the artifact is what removes the classic `switch-rootfs` mount of the freshly
+written slot.
+
+`rootfs-image.version` is still provided and `rootfs-image.*` still cleared, so
+inventory and deployment logic look unchanged to the server. The file name does not
+say which scheme built it; `mender-artifact read` does, via the payload type.
+
+The stock `rootfs-image` module is deliberately left in the image. Without
+`libubootenv-fake` it fails immediately on the missing `fw_printenv`, which is the
+loud failure wanted if an ordinary `rootfs-image` artifact reaches a device on this
+scheme.
+
+## Slot verification
+
+`RootfsRetryCountMax` is 1 on this platform, so a slot that is never verified does
+not survive a boot. Something has to run `nvbootctrl verify` on an ordinary boot,
+and stand down while an update awaits its verdict, or the new slot is marked good
+before Mender commits and the A/B rollback is gone.
+
+The classic scheme keys that window off `upgrade_available` in the u-boot
+environment. There is no u-boot environment here, so meta-tegra's
+`nv_update_verifier` is left disabled and `tegra-rootfs-verify.service` takes over.
+The update module writes `/var/lib/mender/tegra-update-pending` naming the slot the
+update aims at, and the verifier stands down only while that slot is the one
+running, so a marker left by an interrupted deployment cannot condemn an unrelated
+slot.
+
+`nv_update_verifier` is disabled, not removed. It arrives through
+`MACHINE_EXTRA_RDEPENDS` in meta-tegra's `tegra-common.inc`, so it is in the image
+either way, and masking it instead breaks the rootfs build in
+`tegra-redundant-boot`'s postinstall.
+
+## Moving a device between schemes
+
+There is no migration path. Update modules are dispatched by the running rootfs, so
+neither scheme can install the other's artifact. Both failures are immediate and
+leave the slots untouched: a `rootfs-image` artifact on a native device dies on the
+missing `fw_printenv`, a `tegra-rootfs-image` artifact on a classic device dies
+because there is no such module under `/usr/share/mender/modules/v3`. Changing
+scheme means reflashing, or writing the other scheme's rootfs into the inactive slot
+out of band and letting the capsule switch to it.
+
+Before the split a classic image could also carry `tegra-rootfs-update-module` and
+migrate over two deployments. The module recipe now lives in this layer and a build
+cannot have both scheme layers, so that route is closed.
+
+Changes to the module itself take effect one deployment later than you might
+expect, since the states up to the reboot run from the old rootfs and everything
+after it from the new one. The pending marker crosses that boundary, so a deployment
+that upgrades the module is written by one revision and read by the next. A marker
+the new verifier cannot attribute to the running slot is treated as stale and the
+slot is verified, so that one deployment runs without the deferral. Mender's own
+rollback is unaffected; what is skipped for that boot is the firmware's automatic
+fallback.
+
+## Known limitations
+
+- **Every rootfs update reflashes the bootloader.** The capsule is bundled in every
+  artifact and armed unconditionally, so each deployment writes the inactive boot
+  chain even when the firmware is byte for byte what is already there, roughly
+  11 MB of QSPI per update on an Orin NX. The classic scheme arms the capsule the
+  same way, so this is inherited behaviour rather than a regression. The place to
+  fix it is the module's `ArtifactInstall`, comparing the capsule against the
+  installed firmware version and skipping the arming, except that arming the capsule
+  is also what performs the slot switch, so the two cannot simply be separated.
+
+- **Rollback does not roll back firmware.** The capsule has already updated the
+  other boot chain by the time a rollback happens, so the standby chain carries the
+  new firmware next to a rootfs that failed its commit, and that slot is still
+  flagged bootable: the module flags the target unbootable only while it is being
+  written. If the active chain later fails to boot, the firmware falls back to a
+  rootfs and firmware pair that was never validated together, running an artifact
+  the server never recorded as installed. The classic scheme behaves the same way.
+
+- **The unbootable-rootfs fallback gap** applies as it does to the classic scheme.
+  A/B recovers a rootfs that boots but never commits, not one that fails to boot,
+  and a rootfs that panics is never condemned at all.

--- a/meta-mender-tegra/meta-mender-tegra-native/README.md
+++ b/meta-mender-tegra/meta-mender-tegra-native/README.md
@@ -1,0 +1,9 @@
+This layer holds the Tegra-native update scheme: a `tegra-rootfs-image` update
+module that drives `nvbootctrl`, the BSP partlabels and the UEFI capsule
+directly, instead of Mender's stock `rootfs-image` module and the adapters that
+one needs on Tegra.
+
+It is one of two mutually exclusive scheme layers, and selecting it means adding
+it to `BBLAYERS` and inheriting `tegra-mender-native`.
+
+See ../README.md for more details and other layers.

--- a/meta-mender-tegra/meta-mender-tegra-native/classes-global/tegra-mender-native.bbclass
+++ b/meta-mender-tegra/meta-mender-tegra-native/classes-global/tegra-mender-native.bbclass
@@ -1,0 +1,83 @@
+# The Tegra-native update scheme.
+#
+# A tegra-rootfs-image update module that drives nvbootctrl, the BSP partlabels
+# and the UEFI capsule directly, in place of Mender's stock rootfs-image module
+# and the adapters meta-mender-tegra-classic has to supply for it. The artifact
+# it emits carries the tegra-rootfs-image payload type and the capsule alongside
+# the rootfs, and keeps the canonical .mender name, since only the payload type
+# inside it differs.
+#
+# This is the entry point for a native build. Inherit it instead of
+# tegra-mender-common, which it pulls in itself:
+#
+#   INHERIT += "tegra-mender-native"
+
+inherit tegra-mender-common
+
+TEGRA_MENDER_SCHEME = "native"
+
+IMAGE_CLASSES += "image_types_mender_tegra_native"
+
+# This class is inherited build-wide, so the appends below reach every image
+# recipe in the build, not just the OS image. meta-tegra's helper images must be
+# excluded from both, or:
+#
+#   - the initramfs images deadlock, because the native artifact depends on the
+#     UEFI capsule and meta-tegra builds the capsule from the initramfs:
+#       tegra-uefi-capsules:do_compile -> tegra-minimal-initramfs:do_image_complete
+#         -> do_image_tegra_mender_native -> tegra-uefi-capsules:do_deploy
+#   - the initramfs also gains the update module and its runtime dependencies
+#     (mender-flash, tegra-redundant-boot-base, setup-nv-boot-control), which it
+#     has no use for, and which then grow the capsule built from it, and so the
+#     payload of every artifact.
+#   - tegra-espimage otherwise emits a meaningless update artifact holding the
+#     ESP contents.
+#
+# The skip list is matched as a substring of the image name. That is blunt: an
+# image whose name merely contains "initramfs" is skipped too. It is preferred to
+# naming meta-tegra's helper images exactly, which breaks silently whenever one
+# is renamed. The failure modes are asymmetric, which is what settles it: a false
+# skip means a missing artifact, which is noticed immediately, while a false
+# include means a dependency loop or a bloated capsule, which is not.
+TEGRA_MENDER_NATIVE_SKIP_IMAGES ?= "initramfs espimage"
+
+def tegra_mender_native_enabled(d):
+    name = d.getVar('IMAGE_BASENAME') or d.getVar('PN') or ''
+    for skip in (d.getVar('TEGRA_MENDER_NATIVE_SKIP_IMAGES') or '').split():
+        if skip in name:
+            return False
+    return True
+
+# The stock rootfs-image module is left in the image on purpose rather than
+# surgically deleted. Under this scheme libubootenv-fake is not installed, so it
+# fails immediately on the missing fw_printenv instead of running through a
+# no-op fw_setenv and silently doing nothing. That is the loud failure we want
+# if someone deploys an ordinary rootfs-image artifact here.
+IMAGE_INSTALL:append:tegra = "${@' tegra-rootfs-update-module' if tegra_mender_native_enabled(d) else ''}"
+
+# Swap the stock "mender" artifact for the module-image one. This has to be an
+# :append:tegra plus a :remove:tegra, not a plain +=, because the tegra kas
+# configurations set IMAGE_FSTYPES:tegra outright and that replaces anything
+# appended to the unoverridden variable.
+#
+# The removal is not just tidiness. Both types write the artifact under the
+# canonical .mender name, so leaving both in IMAGE_FSTYPES has the two do_image
+# tasks writing the same path in IMGDEPLOYDIR, and whichever finishes last wins.
+# A legacy artifact under the expected name is exactly the kind of thing that is
+# only noticed on the device, so the check below refuses to build instead.
+IMAGE_FSTYPES:append:tegra = "${@' tegra-mender-native' if tegra_mender_native_enabled(d) else ''}"
+IMAGE_FSTYPES:remove:tegra = "mender"
+
+# The :remove above makes this unreachable in an untouched configuration, since
+# :remove wins over any assignment or append whatever the parse order. It is here
+# for the configuration that overrides IMAGE_FSTYPES:remove:tegra itself, which
+# puts "mender" back and is otherwise silent.
+python () {
+    fstypes = (d.getVar('IMAGE_FSTYPES') or '').split()
+    if 'tegra-mender-native' in fstypes and 'mender' in fstypes:
+        bb.fatal('IMAGE_FSTYPES contains both "mender" and "tegra-mender-native". '
+                 'Both write the artifact under the same .mender name, so the two '
+                 'do_image tasks would write one path and whichever finished last '
+                 'would win. Take "mender" back out, or inherit '
+                 'tegra-mender-classic instead.')
+}

--- a/meta-mender-tegra/meta-mender-tegra-native/classes-recipe/image_types_mender_tegra_native.bbclass
+++ b/meta-mender-tegra/meta-mender-tegra-native/classes-recipe/image_types_mender_tegra_native.bbclass
@@ -1,0 +1,75 @@
+# Builds a Mender artifact for the tegra-rootfs-image update module.
+#
+# Unlike the stock "mender" image type this emits a module-image artifact with a
+# payload type of tegra-rootfs-image, carrying two files: the rootfs and the
+# UEFI capsule. Carrying the capsule in the artifact is what lets the module
+# stage it without mounting the freshly written slot, which is what the
+# switch-rootfs state script has to do today.
+#
+# The file itself keeps the canonical .mender extension. Only the payload type
+# inside it differs, this is still an ordinary Mender artifact, and naming it
+# anything else would break every script and upload step that expects one.
+#
+# Modelled on meta-mender's mender-artifact-uefi-capsule.bbclass, which does the
+# same shape of thing for -T uefi-capsule, and likewise writes a .mender file
+# from an image type not called "mender".
+
+inherit image_types_mender_tegra
+
+TEGRA_NATIVE_ARTIFACT_TYPE ?= "tegra-rootfs-image"
+
+# The capsule that tegra-uefi-capsules built for this machine.
+TEGRA_NATIVE_CAPSULE ?= "${DEPLOY_DIR_IMAGE}/tegra-bl.cap"
+
+do_image_tegra_mender_native[depends] += " \
+    mender-artifact-native:do_populate_sysroot \
+    tegra-uefi-capsules:do_deploy \
+"
+
+IMAGE_TYPEDEP:tegra-mender-native = "${ARTIFACTIMG_FSTYPE}"
+
+# Same name the stock "mender" type gives its artifact, which is the point.
+TEGRA_NATIVE_ARTIFACT ?= "${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.mender"
+
+IMAGE_CMD:tegra-mender-native () {
+    if [ ! -e "${TEGRA_NATIVE_CAPSULE}" ]; then
+        bbfatal "TEGRA_NATIVE_CAPSULE (${TEGRA_NATIVE_CAPSULE}) does not exist. The" \
+                "tegra-rootfs-image module needs the capsule in the artifact, since" \
+                "applying it is what switches the boot slot."
+    fi
+
+    extra_args=""
+    for dev in ${MENDER_DEVICE_TYPES_COMPATIBLE}; do
+        extra_args="$extra_args -c $dev"
+    done
+    if [ -n "${MENDER_ARTIFACT_SIGNING_KEY}" ]; then
+        extra_args="$extra_args -k ${MENDER_ARTIFACT_SIGNING_KEY}"
+    fi
+
+    # Provide rootfs-image.version, the same key the stock rootfs-image module
+    # provides, so inventory and the server's already-installed check are
+    # unchanged by switching schemes. --software-filesystem alone will not do:
+    # it composes <filesystem>.<type>.version, which would yield
+    # rootfs-image.tegra-rootfs-image.version. Set it explicitly instead.
+    mender-artifact write module-image \
+        -n ${MENDER_ARTIFACT_NAME} \
+        -T ${TEGRA_NATIVE_ARTIFACT_TYPE} \
+        $extra_args \
+        -f ${IMGDEPLOYDIR}/${IMAGE_NAME}${IMAGE_NAME_SUFFIX}.${ARTIFACTIMG_FSTYPE} \
+        -f ${TEGRA_NATIVE_CAPSULE} \
+        --no-default-software-version \
+        --no-default-clears-provides \
+        --provides rootfs-image.version:${MENDER_ARTIFACT_NAME} \
+        --clears-provides "rootfs-image.*" \
+        -o ${IMGDEPLOYDIR}/${TEGRA_NATIVE_ARTIFACT}
+
+    # create_symlinks in image.bbclass makes the stable, timestamp-free symlink
+    # for each type in IMAGE_FSTYPES, but it looks for <IMAGE_NAME>.<type> and
+    # this type is not called "mender". It logs "Skipping symlink, source does
+    # not exist" and moves on, so make the same relative symlink here. Without it
+    # the artifact is only reachable under its timestamped name, which the stock
+    # scheme does not ask of anyone.
+    if [ -n "${IMAGE_LINK_NAME}" ]; then
+        ln -sf ${TEGRA_NATIVE_ARTIFACT} ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.mender
+    fi
+}

--- a/meta-mender-tegra/meta-mender-tegra-native/conf/layer.conf
+++ b/meta-mender-tegra/meta-mender-tegra-native/conf/layer.conf
@@ -1,0 +1,12 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+# We have recipes-* directories, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+		${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-mender-tegra-native"
+BBFILE_PATTERN_meta-mender-tegra-native = "^${LAYERDIR}/"
+BBFILE_PRIORITY_meta-mender-tegra-native = "10"
+LAYERVERSION_meta-mender-tegra-native = "1"
+LAYERSERIES_COMPAT_meta-mender-tegra-native = "wrynose"
+LAYERDEPENDS_meta-mender-tegra-native = "tegra meta-mender-tegra-common"

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-bsp/tegra-binaries/tegra-redundant-boot_%.bbappend
@@ -1,0 +1,17 @@
+# meta-tegra's nv_update_verifier.service runs "nvbootctrl verify" on every boot.
+# Under this scheme that is exactly the wrong thing: verifying the running slot is
+# what the update module does in ArtifactCommit, once Mender has decided the
+# deployment succeeded. A unit that does it unconditionally at boot marks the new
+# slot good before the client has committed, and with RootfsRetryCountMax at 1
+# there is then nothing left to roll back to.
+#
+# The unit stays installed and is only left disabled, for two reasons. Masking it
+# breaks the rootfs build in tegra-redundant-boot's own postinstall, and the
+# package is not ours to leave out anyway: it arrives through
+# MACHINE_EXTRA_RDEPENDS in meta-tegra's tegra-common.inc, so dropping this
+# bbappend would enable the unit, not remove it.
+#
+# tegra-rootfs-verify, from tegra-rootfs-update-module, takes over the job: it
+# marks the running slot good on an ordinary boot and stands down while the module
+# has an update awaiting its verdict.
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/mender-client/mender_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/mender-client/mender_%.bbappend
@@ -1,0 +1,9 @@
+# Applying the UEFI capsule is what switches the boot slot, so the capsule
+# package belongs in the image. The common layer appends what both schemes need;
+# :append fragments from both layers merge.
+#
+# Note that the module does not read the on-device copy under
+# /opt/nvidia/UpdateCapsule: it takes the capsule from the artifact payload. What
+# it needs at runtime, mender-flash and the nvbootctrl and OsIndications helpers,
+# the module recipe depends on itself.
+RDEPENDS:mender-update:append:tegra = " tegra-uefi-capsules"

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-image
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-image
@@ -1,0 +1,383 @@
+#!/bin/sh
+# Mender update module for Tegra A/B rootfs updates.
+#
+# Must parse and run under busybox ash: this layer targets images such as
+# core-image-minimal where /bin/sh is busybox and bash is not installed. Do not
+# use 'var+=' to append - ash parses that as a command name, so it fails
+# silently and leaves the variable empty.
+#
+# Unlike the stock rootfs-image module this talks to the BSP directly:
+#
+#   nvbootctrl -t rootfs        which slot is running, and slot verification
+#   /dev/disk/by-partlabel/APP  the rootfs partitions, named by the BSP layout
+#   mender-flash                sparse-aware write to the passive slot
+#   oe4t-set-uefi-OSIndications arm the staged UEFI capsule
+#
+# There is no fw_printenv/fw_setenv, no upgrade_available, no parsing of
+# RootfsPartA/B out of mender.conf, and no Mender state scripts.
+#
+# Slot switching is performed by the UEFI capsule, not by nvbootctrl. Applying a
+# capsule writes firmware into the *inactive* boot chain and then makes that
+# chain active, and rootfs slots are paired to bootloader slots, so the rootfs
+# follows. Calling set-active-boot-slot as well would make the capsule target
+# the wrong chain, so it is used only to undo a switch during rollback.
+
+set -ue
+
+STATE="$1"
+FILES="$2"
+
+# Overridable only so the module can be exercised off-target; the defaults are
+# what runs on the device.
+ESP_MOUNT="${TEGRA_ESP_MOUNT:-/boot/efi}"
+ESP_CAPSULE_DIR="${TEGRA_ESP_CAPSULE_DIR:-${ESP_MOUNT}/EFI/UpdateCapsule}"
+UEFI_COMMON_FUNC="${TEGRA_UEFI_COMMON_FUNC:-/usr/bin/uefi_common.func}"
+PARTLABEL_DIR="${TEGRA_PARTLABEL_DIR:-/dev/disk/by-partlabel}"
+PROC_MOUNTS="${TEGRA_PROC_MOUNTS:-/proc/mounts}"
+SYS_BLOCK="${TEGRA_SYS_BLOCK:-/sys/class/block}"
+ESP_CAPSULE="${ESP_CAPSULE_DIR}/TEGRA_BL.Cap"
+CAPSULE_STASH="${FILES}/tmp/tegra-bl.cap"
+ORIG_SLOT_FILE="${FILES}/tmp/orig-slot"
+# Persistent, and deliberately not under $FILES: tegra-rootfs-verify reads it on
+# the next boot to decide whether the running slot may be marked good yet.
+UPDATE_PENDING="${TEGRA_UPDATE_PENDING:-/var/lib/mender/tegra-update-pending}"
+ROOTFS_STATUS_GUID="781e084c-a330-417c-b678-38e696380cb9"
+EFI_GLOBAL_GUID="8be4df61-93ca-11d2-aa0d-00e098032b8c"
+
+# Disk and ESP detection, shared with the classic scheme and installed by
+# meta-mender-tegra-common. Reads the four variables set above.
+TEGRA_LOG_PREFIX="tegra-rootfs-image[$STATE]"
+. "${TEGRA_DISK_HELPERS:-/usr/share/tegra-mender/disk-helpers.sh}"
+
+# Progress goes to stderr, which mender folds into the deployment log. Without
+# this a module that dies mid-state leaves nothing behind saying how far it got,
+# and the deployment log is the only evidence available once a bad update has
+# made the device unreachable.
+log() {
+    echo "tegra-rootfs-image[$STATE]: $*" 1>&2
+}
+
+# Slot number (0/1) -> that slot's rootfs device, resolved on the booted disk.
+slot_device() {
+    case "$1" in
+        0) _lbl="APP" ;;
+        1) _lbl="APP_b" ;;
+        *) echo "unexpected rootfs slot '$1'" 1>&2; return 1 ;;
+    esac
+    tegra_partlabel_dev "$_lbl"
+}
+
+# Device the root filesystem is actually mounted from, canonicalised the same
+# way, so it can be compared with slot_device output.
+root_device() {
+    _r=$(while read -r dev mnt _rest; do
+             [ "$mnt" = "/" ] && { echo "$dev"; break; }
+         done < "$PROC_MOUNTS")
+    readlink -f "$_r"
+}
+
+# Never write to the slot we are running from. nvbootctrl and the mounted root
+# must agree about which slot is active; if they do not, the slot bookkeeping is
+# wrong and writing would destroy the running system mid-update. Fail the
+# deployment instead. The stock rootfs-image module guards the same way, via
+# check_device_matches_root.
+assert_slot_mapping_sane() {
+    _act=$(slot_device "$(current_slot)")
+    _pas=$(slot_device "$(passive_slot)")
+    _root=$(root_device)
+
+    if [ -z "$_root" ]; then
+        log "FATAL: cannot determine the root device from $PROC_MOUNTS"
+        return 1
+    fi
+    if [ "$_act" != "$_root" ]; then
+        log "FATAL: nvbootctrl says the active slot is $_act but / is mounted from $_root"
+        return 1
+    fi
+    if [ "$_pas" = "$_root" ]; then
+        log "FATAL: computed passive slot $_pas is the mounted root; refusing to write"
+        return 1
+    fi
+    log "slot mapping sane: active $_act, passive $_pas"
+    return 0
+}
+
+slot_letter() {
+    case "$1" in
+        0) echo "A" ;;
+        1) echo "B" ;;
+        *) echo "unexpected rootfs slot '$1'" 1>&2; return 1 ;;
+    esac
+}
+
+current_slot() {
+    nvbootctrl -t rootfs get-current-slot
+}
+
+passive_slot() {
+    if [ "$(current_slot)" = "0" ]; then echo 1; else echo 0; fi
+}
+
+# Write a slot's RootfsStatusSlot{A,B} efivar. 0x00 is a normal, bootable slot;
+# 0xff tells UEFI the slot is unusable, so it boots the partner instead.
+set_rootfs_status() {
+    _slot="$1"
+    _val="$2"
+    _rc=0
+    # uefi_common.func predates any use of 'set -u'. set_efi_var reads a fourth
+    # positional argument (write_once) and $RUNTIME_DIRECTORY, and neither is
+    # guaranteed to be set when we call it. Relax nounset around the call rather
+    # than patching the BSP, and pass the fourth argument explicitly: empty means
+    # "not write-once", which is what we want since the status must be
+    # overwritten every time.
+    set +u
+    . "$UEFI_COMMON_FUNC"
+    set_efi_var "RootfsStatusSlot$(slot_letter "$_slot")" "$ROOTFS_STATUS_GUID" \
+        "$_val" "" || _rc=$?
+    set -u
+    return "$_rc"
+}
+
+# The passive slot may still be flagged unbootable, either from an earlier failed
+# update or from the write below. UEFI refuses to boot it until this is cleared.
+clear_unbootable() {
+    set_rootfs_status "$1" "\x00\x00\x00\x00"
+}
+
+mark_unbootable() {
+    set_rootfs_status "$1" "\xff\x00\x00\x00"
+}
+
+# Undo "arm the capsule". Deleting the staged file is not enough on its own:
+# OsIndications still asks the firmware to run a capsule update on the next
+# boot, and an aborted update must not leave that request standing.
+disarm_capsule() {
+    _rc=0
+    set +u
+    . "$UEFI_COMMON_FUNC"
+    set_efi_var "OsIndications" "$EFI_GLOBAL_GUID" \
+        "\x00\x00\x00\x00\x00\x00\x00\x00" "" || _rc=$?
+    set -u
+    return "$_rc"
+}
+
+case "$STATE" in
+    ProvidePayloadFileSizes)
+        echo "Yes"
+        ;;
+
+    Download)
+        echo "This module supports DownloadWithFileSizes only" 1>&2
+        exit 1
+        ;;
+
+    DownloadWithFileSizes)
+        assert_slot_mapping_sane || exit 1
+        target="$(passive_slot)"
+        target_dev="$(slot_device "$target")"
+
+        # From the first byte written until ArtifactInstall clears this again,
+        # the slot holds a torn filesystem. Leaving it flagged bootable would let
+        # UEFI fall back onto a half-written rootfs if the running slot failed
+        # during the download.
+        log "flagging slot $target unbootable while it is being written"
+        mark_unbootable "$target"
+
+        got_rootfs=0
+        got_capsule=0
+        while true; do
+            line="$(cat stream-next)"
+            [ -n "$line" ] || break
+
+            # "<path> <size>"; the path's basename identifies the payload.
+            path="$(echo "$line" | cut -d' ' -f1)"
+            size="$(echo "$line" | cut -d' ' -f2)"
+            if [ -z "$path" ] || [ -z "$size" ]; then
+                echo "Cannot parse line from stream-next, got: $line" 1>&2
+                exit 1
+            fi
+
+            # Match both payloads explicitly. A catch-all that treats "not a
+            # capsule" as "the rootfs" would flash a stray file straight onto
+            # the partition, and would let a second rootfs payload silently
+            # overwrite the first.
+            case "$(basename "$path")" in
+                *.cap)
+                    if [ "$got_capsule" = 1 ]; then
+                        echo "Artifact carries more than one .cap payload" 1>&2
+                        exit 1
+                    fi
+                    log "stashing capsule ($size bytes)"
+                    mkdir -p "${FILES}/tmp"
+                    cat "$path" > "$CAPSULE_STASH"
+                    got_capsule=1
+                    ;;
+                *.ext4)
+                    if [ "$got_rootfs" = 1 ]; then
+                        echo "Artifact carries more than one rootfs payload" 1>&2
+                        exit 1
+                    fi
+                    log "writing rootfs ($size bytes) to $target_dev"
+                    mender-flash --input-size "$size" --input "$path" \
+                        --output "$target_dev"
+                    log "rootfs write finished"
+                    got_rootfs=1
+                    ;;
+                *)
+                    echo "Unexpected payload '$(basename "$path")': this module" \
+                         "takes exactly one .ext4 rootfs and one .cap capsule" 1>&2
+                    exit 1
+                    ;;
+            esac
+        done
+
+        if [ "$got_rootfs" != 1 ]; then
+            echo "Artifact contained no rootfs payload" 1>&2
+            exit 1
+        fi
+        if [ "$got_capsule" != 1 ]; then
+            echo "Artifact contained no .cap payload; the slot switch is" \
+                 "performed by the UEFI capsule, so it is required" 1>&2
+            exit 1
+        fi
+        sync
+        ;;
+
+    ArtifactInstall)
+        # Remember where we came from, so rollback after the reboot knows which
+        # slot to go back to. $FILES/tmp survives the reboot.
+        assert_slot_mapping_sane || exit 1
+        _cur="$(current_slot)"
+        _passive="$(passive_slot)"
+        log "current slot $_cur, arming slot $_passive"
+        echo "$_cur" > "${ORIG_SLOT_FILE}.tmp"
+        mv "${ORIG_SLOT_FILE}.tmp" "$ORIG_SLOT_FILE"
+        sync
+
+        log "clearing any unbootable flag on slot $_passive"
+        clear_unbootable "$_passive"
+
+        # UEFI reads the capsule from the medium it booted, so anywhere else
+        # arms nothing. Fatal here, a capsule is about to be written.
+        if ! tegra_ensure_esp_mounted; then
+            log "FATAL: no usable ESP at $ESP_MOUNT; the capsule would land on the rootfs"
+            exit 1
+        fi
+
+        log "staging capsule to $ESP_CAPSULE"
+        mkdir -p "$ESP_CAPSULE_DIR"
+        cp "$CAPSULE_STASH" "$ESP_CAPSULE"
+        sync
+
+        # Hold off tegra-rootfs-verify until this update has a verdict. Without
+        # this the next boot marks the new slot good before mender commits, and
+        # the rollback is gone.
+        #
+        # The marker names the slot the update is aiming at, and the verifier
+        # only stands down while that slot is the one running. A marker that
+        # outlives its deployment then cannot silently stop verification of some
+        # unrelated slot forever, which with RootfsRetryCountMax=1 would condemn
+        # it after a single boot.
+        log "marking update pending ($UPDATE_PENDING), target slot $_passive"
+        echo "$_passive" > "${UPDATE_PENDING}.tmp"
+        mv "${UPDATE_PENDING}.tmp" "$UPDATE_PENDING"
+        sync
+
+        log "arming OsIndications"
+        oe4t-set-uefi-OSIndications
+        log "done; the capsule will switch the boot chain on the next reboot"
+        ;;
+
+    NeedsArtifactReboot)
+        echo "Automatic"
+        ;;
+
+    SupportsRollback)
+        echo "Yes"
+        ;;
+
+    ArtifactVerifyReboot)
+        # The capsule should have switched us to the other slot.
+        [ -f "$ORIG_SLOT_FILE" ] || { echo "missing $ORIG_SLOT_FILE" 1>&2; exit 1; }
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" = "$orig" ]; then
+            log "still on slot $orig after reboot; the capsule did not switch the boot chain"
+            exit 1
+        fi
+        log "booted slot $cur as expected (was $orig)"
+        # The boot chain switched, but that is only half of the claim. Confirm
+        # that / really is this slot's partition before the commit blesses the
+        # pairing; otherwise a chain that switched without the rootfs following
+        # goes unnoticed until the next update writes over the running system.
+        assert_slot_mapping_sane || exit 1
+        ;;
+
+    ArtifactCommit)
+        # Marks the running bootloader and rootfs slot good, and resets the
+        # rootfs retry counter. Without this UEFI reverts on a later boot.
+        log "verifying slot $(current_slot)"
+        nvbootctrl verify
+        rm -f "$UPDATE_PENDING"
+        sync
+        log "slot verified, update no longer pending"
+        ;;
+
+    ArtifactRollback)
+        # Remove a staged-but-unapplied capsule unconditionally, before anything
+        # else can fail. Leaving it behind is the dangerous outcome: the next
+        # reboot would switch to the slot being abandoned.
+        if [ -e "$ESP_CAPSULE" ]; then
+            log "removing staged capsule $ESP_CAPSULE"
+            rm -f "$ESP_CAPSULE"
+            sync
+        else
+            log "no staged capsule to remove"
+        fi
+        log "disarming OsIndications"
+        disarm_capsule || log "WARNING: could not clear OsIndications"
+        rm -f "$UPDATE_PENDING"
+        sync
+
+        if [ ! -f "$ORIG_SLOT_FILE" ]; then
+            log "no recorded original slot; nothing further to undo"
+            exit 0
+        fi
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" != "$orig" ]; then
+            # The capsule already applied and we booted the new slot. Send the
+            # boot chain back; the rootfs slot is paired to it and follows.
+            log "on slot $cur, returning to $orig"
+            nvbootctrl set-active-boot-slot "$orig"
+        else
+            log "still on the original slot $orig, no switch to undo"
+        fi
+        ;;
+
+    ArtifactVerifyRollbackReboot)
+        [ -f "$ORIG_SLOT_FILE" ] || { echo "missing $ORIG_SLOT_FILE" 1>&2; exit 1; }
+        orig="$(cat "$ORIG_SLOT_FILE")"
+        cur="$(current_slot)"
+        if [ "$cur" != "$orig" ]; then
+            log "FATAL: rollback aimed at slot $orig but booted slot $cur"
+            exit 1
+        fi
+        log "back on slot $orig after rollback"
+        ;;
+
+    ArtifactFailure)
+        ;;
+
+    Cleanup)
+        rm -f "$CAPSULE_STASH"
+        # Whatever happened above, mender is done with this deployment, so
+        # nothing is awaiting a verdict any more. Dropping the marker here as
+        # well covers the paths that reach ArtifactInstall but never reach
+        # ArtifactCommit or ArtifactRollback, such as an aborted deployment.
+        rm -f "$UPDATE_PENDING"
+        sync
+        log "cleaned up"
+        ;;
+esac
+exit 0

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Keep the running Tegra rootfs slot marked good.
+#
+# Must parse and run under busybox ash; see the update module for the details.
+#
+# UEFI condemns a rootfs slot whose retry counter runs out, and this platform
+# sets RootfsRetryCountMax to 1, so a slot that is never verified does not
+# survive. Something has to run "nvbootctrl verify" on an ordinary boot.
+#
+# It must not run while an update is awaiting its verdict. Verifying the newly
+# booted slot before mender has committed would mark it good and throw away the
+# A/B rollback, which is the whole point of the redundant layout. The stock
+# integration keys that window off mender's upgrade_available in the u-boot
+# environment; the native scheme has no u-boot environment, so the update module
+# drops a marker instead, for exactly the same window.
+# The marker names the slot the update is aiming at, and standing down only
+# applies while that slot is the one running. A marker is not proof that an
+# update is still live: a deployment interrupted between ArtifactInstall and its
+# verdict leaves one behind. Treating any marker as "never verify" would then
+# stop verification for good, and a slot that is never verified does not survive
+# a boot, so the stale marker would condemn the very slot it was left on.
+set -u
+
+PENDING="${TEGRA_UPDATE_PENDING:-/var/lib/mender/tegra-update-pending}"
+NVBOOTCTRL="${TEGRA_NVBOOTCTRL:-nvbootctrl}"
+
+if [ -e "$PENDING" ]; then
+    target="$(cat "$PENDING" 2>/dev/null || true)"
+    current="$("$NVBOOTCTRL" -t rootfs get-current-slot 2>/dev/null || true)"
+    if [ -n "$target" ] && [ "$target" = "$current" ]; then
+        echo "tegra-rootfs-verify: update pending on slot $current, leaving it unverified" 1>&2
+        exit 0
+    fi
+    # Running a slot the marker is not about. Either the switch has not happened
+    # yet, or a rollback already brought us back. Either way this slot is not the
+    # one awaiting a verdict and still has to be kept good. The marker is left in
+    # place, so the real window is still honoured if the switch happens later.
+    echo "tegra-rootfs-verify: pending marker names slot ${target:-none}," \
+         "running slot ${current:-unknown}; verifying anyway" 1>&2
+fi
+
+echo "tegra-rootfs-verify: marking the running slot good" 1>&2
+exec "$NVBOOTCTRL" verify

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify.service
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/files/tegra-rootfs-verify.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Mark the running Tegra rootfs slot good
+# nvbootctrl needs the BSP's boot control setup to have run.
+After=nvstartup.service
+# Settle the slot state before mender can start a new deployment or commit one.
+Before=mender-updated.service
+ConditionPathExists=/usr/sbin/nvbootctrl
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/tegra-rootfs-verify
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/tegra-rootfs-update-module_1.0.bb
+++ b/meta-mender-tegra/meta-mender-tegra-native/recipes-mender/tegra-rootfs-update-module/tegra-rootfs-update-module_1.0.bb
@@ -1,0 +1,48 @@
+SUMMARY = "Tegra-native Mender update module for A/B rootfs updates"
+DESCRIPTION = "Mender update module for Tegra A/B rootfs updates, using the BSP's \
+own tooling (nvbootctrl, partlabels, UEFI capsule) instead of the u-boot \
+environment shims the stock rootfs-image module needs."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "\
+    file://tegra-rootfs-image \
+    file://tegra-rootfs-verify \
+    file://tegra-rootfs-verify.service \
+"
+
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+# nvbootctrl comes from tegra-redundant-boot-base; uefi_common.func,
+# oe4t-set-uefi-OSIndications and the ESP mount come from setup-nv-boot-control;
+# mender-flash does the sparse-aware write to the passive slot;
+# tegra-mender-helpers carries the disk and ESP detection the module sources at
+# runtime, shared with the classic scheme.
+RDEPENDS:${PN} = "mender-flash tegra-redundant-boot-base setup-nv-boot-control tegra-mender-helpers"
+
+inherit systemd
+SYSTEMD_SERVICE:${PN} = "tegra-rootfs-verify.service"
+
+do_install() {
+    install -d ${D}${datadir}/mender/modules/v3
+    install -m 0755 ${S}/tegra-rootfs-image ${D}${datadir}/mender/modules/v3/tegra-rootfs-image
+
+    # Replaces the disabled nv_update_verifier: keeps the running slot marked
+    # good on an ordinary boot, and stays out of the way while the update module
+    # has an update awaiting its verdict.
+    install -d ${D}${sbindir}
+    install -m 0755 ${S}/tegra-rootfs-verify ${D}${sbindir}/tegra-rootfs-verify
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/tegra-rootfs-verify.service ${D}${systemd_system_unitdir}/
+}
+
+# Only the module needs listing. The default FILES:${PN} already covers
+# ${sbindir}/*, and systemd.bbclass appends the unit and its preset, but the
+# default reaches only ${datadir}/${BPN}, not ${datadir} as a whole.
+FILES:${PN} += "${datadir}/mender/modules/v3/tegra-rootfs-image"
+
+# Shell scripts, so the content is architecture independent, but allarch and
+# COMPATIBLE_MACHINE do not mix. Machine-specific packages it is.
+PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
Rebased onto `wrynose` now that #529 and #534 have landed, so the diff is three commits and nothing else. Replaces #528.

Mender's stock `rootfs-image` module is written for u-boot and GRUB systems, and on Tegra it only works through adapters `meta-mender-tegra-classic` maintains. `libubootenv-fake` fakes `fw_printenv`/`fw_setenv`, where `fw_setenv mender_boot_part` is a no-op, so the module cannot switch slots at all. Three state scripts do the real work outside the module, one of them mounting the freshly written slot just to copy a UEFI capsule out of it. And the module parses `RootfsPartA`/`RootfsPartB` out of `mender.conf` to find partitions the BSP already names.

Everything needed is available natively, so `tegra-rootfs-image` talks to the BSP directly:

```
nvbootctrl -t rootfs        which slot runs, and slot verification
/dev/disk/by-partlabel/APP  the rootfs partitions, named by the BSP layout
mender-flash                sparse-aware write to the passive slot
the UEFI capsule            the slot switch itself
```

Which device a label actually means, and which ESP the capsule belongs on, come from #534's `disk-helpers.sh`, sourced at runtime out of the rootfs since unlike a state script the module lives there. So the module carries no copy of that logic itself.

The capsule travels in the artifact alongside the rootfs, which is what removes the need to mount the freshly written slot just to fetch one. The artifact keeps the canonical `.mender` name and still provides `rootfs-image.version`, so nothing about uploading or deploying changes; only the payload type inside it differs, and `mender-artifact read` is how you tell the two apart.

`tegra-rootfs-verify` replaces the BSP's `nv_update_verifier`, which this scheme cannot use: that one keys the verification window off `upgrade_available` in a u-boot environment there is no longer any shim for. The replacement keys it off a marker naming the slot an update is aiming at, and stands down only while that slot is the one running, so a marker that outlives its deployment cannot disarm verification permanently. With `RootfsRetryCountMax` at 1 on this platform, a slot that is never verified does not survive a boot, so something has to run `nvbootctrl verify` on an ordinary boot and stand down while an update awaits its verdict.

Note that `nv_update_verifier` is disabled rather than removed. It arrives through `MACHINE_EXTRA_RDEPENDS` in meta-tegra's `tegra-common.inc` so it is in the image either way, and masking it breaks `tegra-redundant-boot`'s postinstall during the rootfs build. One thing only the split could reveal: before it, the classic layer's `FILESEXTRAPATHS` shadowed meta-tegra's unit with a shell wrapper, so a native build got the wrapper. With the classic layer gone the unit is meta-tegra's own and its `ExecStart` is `nvbootctrl verify` on every boot, which would mark a new slot good before Mender commits and spend the rollback window. So disabling it is load-bearing under the split, for a different reason than #528 gave.

The stock `rootfs-image` module is deliberately left in the image. Without `libubootenv-fake` it fails immediately on the missing `fw_printenv`, which is the loud failure you want if an ordinary `rootfs-image` artifact reaches a device running this scheme. That cuts both ways and there is no migration path: update modules are dispatched by the running rootfs, so a `tegra-rootfs-image` artifact on a classic device dies on the missing module under `/usr/share/mender/modules/v3`, and neither failure touches the slots. `meta-mender-tegra-native/README.md` says so, along with the scheme's limitations: every rootfs update reflashes the bootloader, a rollback does not roll back firmware, and the unbootable-rootfs gap that A/B does not cover.

Exercised on an Orin NX 8GB on NVMe and on an Orin Nano 8GB devkit with a microSD and an NVMe both fitted: the happy path in both slot directions, the post-reboot rollback in both directions, the pre-reboot rollback, and deployments against the other disk's ESP. Both directions matter, since UEFI treats the two slots asymmetrically. The Orin NX was then RCM flashed with this scheme's `tegraflash-tar` and took an update over the air, so flash, boot, update and commit are covered as one chain. Re-run on the Orin Nano after this rebase, with the classic scheme resolving against `wrynose` and only the native layer coming from the fork.

Build configurations are in [mender-community-images](https://github.com/TheYoctoJester/mender-community-images) under `tegra/jetpack7/native/`, for both Orin NX modules and both Orin Nano devkit variants. Only the 8GB modules have hardware coverage. The recovery system that builds on this scheme is held back for a separate pull request.