### PR TITLE
fix(tegra): the Orin Nano devkit card is mmcblk0

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/classes-global/tegra-mender-setup.bbclass
+++ b/meta-mender-tegra/meta-mender-tegra-common/classes-global/tegra-mender-setup.bbclass
@@ -58,10 +58,13 @@ MENDER_ROOTFS_PART_B_NUMBER_DEFAULT:tegra264 = "2"
 # the inactive slot. TNSPEC_BOOTDEV is the BSP's own statement of where the
 # rootfs lives, so take the device from it.
 MENDER_STORAGE_DEVICE_DEFAULT:tegra = "${@'/dev/nvme0n1' if (d.getVar('TNSPEC_BOOTDEV') or '').startswith('nvme') else '/dev/mmcblk0'}"
-# The SD-card Orin Nano devkit enumerates its card as mmcblk1.
-MENDER_STORAGE_DEVICE_DEFAULT:jetson-orin-nano-devkit = "/dev/mmcblk1"
-# The NVMe variant of that devkit would otherwise inherit the line above,
-# because jetson-orin-nano-devkit is in its MACHINEOVERRIDES.
+# The SD-card Orin Nano devkit keeps the mmcblk0 default: an Orin Nano module has
+# no eMMC, so sdmmc1 is the only MMC controller and the card takes index 0. Naming
+# it mmcblk1 fails in a way nothing at build time catches, and that is not obvious
+# on the board either: the rootfs mounts, the network comes up and answers ARP, and
+# then boot stalls before sshd on a /data mount that can never succeed.
+# State the NVMe variant explicitly rather than leaning on TNSPEC_BOOTDEV, since it
+# shares MACHINEOVERRIDES with the SD one.
 MENDER_STORAGE_DEVICE_DEFAULT:jetson-orin-nano-devkit-nvme = "/dev/nvme0n1"
 
 # A/B rootfs updates need the redundant flash layout. In practice it is already


### PR DESCRIPTION
The SD-card Orin Nano devkit override says mmcblk1. On real hardware the card is mmcblk0, so drop the override and let the tegra default apply.

An Orin Nano module has no eMMC, which means sdmmc1 is the only MMC controller on the board and takes index 0. Verified on a p3767-0005 devkit: `lsblk` shows one MMC device, the 57.6 GB card, as mmcblk0.

The reason this is worth a fix rather than a footnote is how it fails. With mmcblk1 the board looks alive and is not: the rootfs mounts, DHCP completes, it answers ARP, and then boot stalls before sshd waiting on a /data mount that can never succeed. Nothing at build time catches it, and from the outside it reads as a network problem.

Verified by parsing the published SD configuration with this change and no local override: `MENDER_STORAGE_DEVICE="/dev/mmcblk0"`, `MENDER_DATA_PART="/dev/mmcblk0p15"`. With that value the board boots from the card at mmcblk0p1 with /data on p15, and a full A/B deployment installs, switches slots and commits, on both the classic and the Tegra-native update scheme.

Note that this is independent of #529 and #530: the line came in with e2ebdd3, which is already on wrynose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)