### PR TITLE
fix(tegra): default EXTRADEPS so non-tegra machines can parse

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/mender-tegra.inc
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/mender-client/mender-tegra.inc
@@ -1,3 +1,4 @@
+EXTRADEPS = ""
 EXTRADEPS:tegra = "tegra-uefi-capsules libubootenv-fake mender-update-verifier tegra-redundant-boot"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"


### PR DESCRIPTION
mender-tegra.inc is pulled in via mender_%.bbappend, which applies to every machine while the layer is in bblayers. EXTRADEPS is only defined with a :tegra override, so on any non-tegra machine (e.g. a qemu VM flavor built from the same layer set) RDEPENDS:mender-update gets the literal string ${EXTRADEPS}, which is unbuildable. Provide an empty default.