### PR TITLE
fix(tegra): propagate the mender data size into the flash layout

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-bsp/tegra-binaries/tegra-storage-layout-base_%.bbappend
@@ -1,12 +1,33 @@
 DEPENDS:append = " tegra-helper-scripts-native"
 PATH =. "${STAGING_BINDIR_NATIVE}/tegra-flash:"
 
+# Size of the data partition in the staged flash layout.
+#
+# NVIDIA's templates hardcode it (400MB UDA on t234) and nothing carries
+# MENDER_DATA_PART_SIZE_MB into the layout, so three values disagree: the
+# layout allocates 400MB, mender's accounting and its flashed ext4 data image
+# follow MENDER_DATA_PART_SIZE_MB (default 128), and the first-boot growfs
+# expands the filesystem to fill the partition -- which makes the default
+# arrangement look coherent by accident. Raising MENDER_DATA_PART_SIZE_MB
+# breaks it: the data image no longer fits the partition it is flashed into.
+#
+# Set empty to keep the template's size, leaving the staged layouts
+# byte-identical to before.
+TEGRA_MENDER_UDA_SIZE_MB ?= "${@d.getVar('MENDER_DATA_PART_SIZE_MB') or ''}"
+
 mender_flash_layout_adjust() {
     local file=$1
     mv ${D}${datadir}/l4t-storage-layout/$file ${WORKDIR}/$file
     nvflashxmlparse -v --rewrite-contents-from=${WORKDIR}/UDA.xml \
-		--output=${D}${datadir}/l4t-storage-layout/$file \
+		--output=${WORKDIR}/$file.contents \
 		${WORKDIR}/$file
+    if [ -s ${WORKDIR}/UDA-size.xml ]; then
+        nvflashxmlparse -v --update-parttype-sizes-from=${WORKDIR}/UDA-size.xml:data \
+		--output=${D}${datadir}/l4t-storage-layout/$file \
+		${WORKDIR}/$file.contents
+    else
+        mv ${WORKDIR}/$file.contents ${D}${datadir}/l4t-storage-layout/$file
+    fi
 }
 
 do_install:append() {
@@ -19,6 +40,20 @@ do_install:append() {
     </device>
 </partition_layout>
 EOF
+
+    rm -f ${WORKDIR}/UDA-size.xml
+    if [ -n "${TEGRA_MENDER_UDA_SIZE_MB}" ]; then
+        uda_bytes=$(expr ${TEGRA_MENDER_UDA_SIZE_MB} \* 1024 \* 1024)
+        cat <<EOF >${WORKDIR}/UDA-size.xml
+<partition_layout>
+    <device>
+        <partition name="UDA">
+            <size> $uda_bytes </size>
+        </partition>
+    </device>
+</partition_layout>
+EOF
+    fi
 
     mender_flash_layout_adjust "${PARTITION_LAYOUT_TEMPLATE}"
     mender_flash_layout_adjust "${PARTITION_LAYOUT_EXTERNAL}"


### PR DESCRIPTION
### Problem

NVIDIA's flash layout templates parameterise every partition whose size an integrator is expected to set — and the data partition is the one exception:

```xml
<partition name="APP"   id="1" type="data">  <size> APPSIZE </size>
<partition name="APP_b" id="2" type="data">  <size> APPSIZE </size>
<partition name="UDA"         type="data">  <size> 419430400 </size>
```

`APPSIZE` has a substitution point — meta-tegra's `image_types_tegra.bbclass` fills it from `ROOTFSPART_SIZE`, alongside `LNXSIZE`, `RECSIZE`, `RECROOTFSSIZE` and the device sector counts. This layer already sets `ROOTFSPART_SIZE` from `MENDER_CALC_ROOTFS_SIZE`, so the A/B slots track mender's accounting today.

UDA is a literal. There is no token to substitute and no variable that reaches it, so nothing carries `MENDER_DATA_PART_SIZE_MB` into the layout — even though mender sizes the ext4 data image flashed into that partition from exactly that value. It is the only partition in the layout that mender sizes but cannot address.

The default hides it: `MENDER_DATA_PART_SIZE_MB` defaults to 128, a 128 MiB image fits inside a 400 MiB partition with room to spare, and `systemd-growfs` then expands the filesystem to fill it. Raising the value inverts that — mender builds a data image larger than the allocation the layout keeps, and it no longer fits the partition it is flashed into.

(`mender-grow-data` cannot help here: on the t234 A/B layouts the reserved and APP partitions sit after UDA, so `mender-resize-data-part` fails on every boot with `Error: Can't have overlapping partitions.` and the unit lands in systemd's failed state. Only the filesystem-grow half does anything.)

### Fix

Rewrite the size where the filename is already rewritten: a second `nvflashxmlparse` pass (`--update-parttype-sizes-from`) over the same staged layouts, fed by a document in the same shape as the existing `UDA.xml` heredoc.

`TEGRA_MENDER_UDA_SIZE_MB` defaults to `MENDER_DATA_PART_SIZE_MB`, so the layout follows mender's accounting; setting it empty skips the pass and leaves the staged layouts byte-identical to before.

One file, +36/-1. It is deliberately as general as the filename rewrite it sits beside — both address UDA by name — rather than introducing a partition map.

### Scope

Applies to NVIDIA's staged layouts, both the internal template and the external one, so eMMC and NVMe alike.

It is a no-op where this layer substitutes its own external layout (`p3768-0000-p3767-0000`), because there the data partition is `permanet_user_storage`, last on the device, and `mender-growfs-data` expands it over the remaining space. That case needs no fixed size and is untouched here.

### Verification

Built for a t234 machine on the classic scheme, with a large `MENDER_DATA_PART_SIZE_MB`:

| check | result |
|---|---|
| parse | clean |
| staged `<size>`, both layouts | `42412802048` — the configured value, was `419430400` |
| `<filename> DATAFILE </filename>` | still applied; the existing pass is unaffected |
| `APPSIZE` token | intact in both layouts — the size pass runs before meta-tegra's `sed` and does not disturb it |
| `TEGRA_MENDER_UDA_SIZE_MB = ""` | layouts byte-identical to before |

### Note on default behaviour

`MENDER_DATA_PART_SIZE_MB` defaults to 128, so an untouched config moves from a 400 MiB UDA to a 128 MiB UDA that the accounting actually claims. Anything relying on the implicit growfs-to-400MiB behaviour should set `MENDER_DATA_PART_SIZE_MB` (or `TEGRA_MENDER_UDA_SIZE_MB`) explicitly.

Fit remains the integrator's responsibility: the A/B slots, the configured data size and the fixed partitions must together fit the device, or `tegraparser` aborts GPT generation (`End sector for APP_b expected at ..., actual: 0`).

### Where this arguably belongs

This is a workaround for a missing knob one layer down. meta-tegra parameterises `LNXSIZE`, `RECSIZE`, `APPSIZE`, `RECROOTFSSIZE` and the device sector counts, but has no data-partition size variable at all. The tidier arrangement would be a `TEGRA_DATA_PART_SIZE` in meta-tegra that this layer merely sets from `MENDER_DATA_PART_SIZE_MB`, exactly as it already sets `ROOTFSPART_SIZE` — leaving mender supplying a value and owning no rewriting.

`nvflashxmlparse` is meta-tegra's own tool and `--update-parttype-sizes-from` is an existing option, in a class that already invokes it, so that change would need neither a new mechanism nor a patched template. Happy to take it there instead if you would rather this not live in the mender layer.
