### PR TITLE
fix(tegra): share the disk and ESP detection, and resolve both on the booted disk

### DIFF
--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-mender-helpers/files/disk-helpers.sh
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-mender-helpers/files/disk-helpers.sh
@@ -1,0 +1,112 @@
+# Disk and ESP detection for the Mender Tegra integration.
+#
+# On a board with two Tegra layouts, an NVMe and a card, the partition names are
+# ambiguous: both disks carry APP, APP_b and esp, both ESPs share a filesystem
+# UUID, and the partition UUIDs are assigned at flash time. by-partlabel follows
+# whichever disk udev settled last, /boot/efi whichever gpt-auto picked. Acting on
+# the wrong one is silent, so everything here derives from the mounted root.
+#
+# POSIX shell, busybox ash compatible. PROC_MOUNTS, SYS_BLOCK, ESP_MOUNT and
+# PARTLABEL_DIR are overridable for the offline tests, and read at each use.
+#
+# Sourced at runtime by the update module; spliced in at build time by the classic
+# state scripts, which run from the artifact and cannot rely on the rootfs.
+
+tegra_log() {
+	echo "${TEGRA_LOG_PREFIX:-tegra-mender}: $*" 1>&2
+}
+
+# The disk / was mounted from. Non-zero when unknown, as from a recovery ramdisk.
+tegra_booted_disk() {
+	_tgh_root=$(readlink -f "$(awk '$2 == "/" { print $1; exit }' "${PROC_MOUNTS:-/proc/mounts}")" 2>/dev/null)
+	_tgh_part=${_tgh_root##*/}
+	[ -n "$_tgh_part" ] || return 1
+	_tgh_disk=$(readlink -f "${SYS_BLOCK:-/sys/class/block}/${_tgh_part}/..") || return 1
+	_tgh_disk=${_tgh_disk##*/}
+	[ -n "$_tgh_disk" ] && [ "$_tgh_disk" != "block" ] || return 1
+	echo "$_tgh_disk"
+}
+
+# <disk> <label> -> the device carrying that label on that disk. blkid is the
+# fallback for an initramfs, which often has no lsblk, or none with PARTLABEL.
+tegra_partlabel_on_disk() {
+	_tgh_dev=$(lsblk -n -r -o NAME,PARTLABEL "/dev/$1" 2>/dev/null \
+		| awk -v l="$2" '$2 == l { print "/dev/" $1; exit }')
+	if [ -z "$_tgh_dev" ]; then
+		for _tgh_cand in "${SYS_BLOCK:-/sys/class/block}/$1"/"$1"*; do
+			[ -e "$_tgh_cand/partition" ] || continue
+			_tgh_n=${_tgh_cand##*/}
+			[ "$(blkid -o value -s PARTLABEL "/dev/$_tgh_n" 2>/dev/null)" = "$2" ] || continue
+			_tgh_dev="/dev/$_tgh_n"
+			break
+		done
+	fi
+	[ -n "$_tgh_dev" ] || return 1
+	echo "$_tgh_dev"
+}
+
+# <label> -> the device carrying it on the booted disk. The symlink is consulted
+# only when the booted disk is unknown: if it is known and lacks the label, the
+# symlink points at another disk and following it would act on the wrong medium.
+tegra_partlabel_dev() {
+	if _tgh_bdisk=$(tegra_booted_disk); then
+		tegra_partlabel_on_disk "$_tgh_bdisk" "$1" && return 0
+		tegra_log "no partition labelled $1 on the booted disk /dev/$_tgh_bdisk"
+		return 1
+	fi
+	# readlink -f reports success for a path that does not exist, so check it.
+	_tgh_link=$(readlink -f "${PARTLABEL_DIR:-/dev/disk/by-partlabel}/$1" 2>/dev/null) || return 1
+	[ -n "$_tgh_link" ] && [ -e "$_tgh_link" ] || return 1
+	echo "$_tgh_link"
+}
+
+# The ESP of the booted disk. No symlink fallback: a caller that cannot derive it
+# is better off with whatever is mounted, correct on any single-ESP board.
+tegra_esp_device() {
+	_tgh_edisk=$(tegra_booted_disk) || return 1
+	tegra_partlabel_on_disk "$_tgh_edisk" esp
+}
+
+# The device currently backing the ESP mount point, empty when nothing is there.
+tegra_esp_mounted_device() {
+	_tgh_have=$(awk -v m="${ESP_MOUNT:-/boot/efi}" '$2 == m { print $1; exit }' \
+		"${PROC_MOUNTS:-/proc/mounts}")
+	[ -n "$_tgh_have" ] || return 0
+	readlink -f "$_tgh_have"
+}
+
+# Make the ESP mount point the booted disk's ESP, remounting if something else got
+# there first. Keeps an existing mount when the derivation fails, and returns
+# non-zero only when there is nothing usable: fatal to the caller staging a
+# capsule, not to one cleaning an old one up.
+tegra_ensure_esp_mounted() {
+	_tgh_want=$(tegra_esp_device) || {
+		_tgh_mounted=$(tegra_esp_mounted_device)
+		if [ -n "$_tgh_mounted" ]; then
+			tegra_log "cannot determine the booted disk's ESP; keeping ${ESP_MOUNT:-/boot/efi} as mounted ($_tgh_mounted)"
+			return 0
+		fi
+		tegra_log "cannot determine the booted disk's ESP and nothing is mounted at ${ESP_MOUNT:-/boot/efi}"
+		return 1
+	}
+	_tgh_mounted=$(tegra_esp_mounted_device)
+	if [ "$_tgh_mounted" = "$_tgh_want" ]; then
+		tegra_log "ESP $_tgh_want mounted at ${ESP_MOUNT:-/boot/efi}"
+		return 0
+	fi
+	if [ -n "$_tgh_mounted" ]; then
+		tegra_log "${ESP_MOUNT:-/boot/efi} is $_tgh_mounted but the booted disk's ESP is $_tgh_want; remounting"
+		umount "${ESP_MOUNT:-/boot/efi}" || {
+			tegra_log "cannot unmount ${ESP_MOUNT:-/boot/efi}"
+			return 1
+		}
+	else
+		tegra_log "nothing mounted at ${ESP_MOUNT:-/boot/efi}; mounting the booted disk's ESP $_tgh_want"
+	fi
+	mkdir -p "${ESP_MOUNT:-/boot/efi}"
+	mount "$_tgh_want" "${ESP_MOUNT:-/boot/efi}" || {
+		tegra_log "cannot mount $_tgh_want at ${ESP_MOUNT:-/boot/efi}"
+		return 1
+	}
+	return 0
+}

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-mender-helpers/tegra-mender-helpers_1.0.bb
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-mender-helpers/tegra-mender-helpers_1.0.bb
@@ -1,0 +1,24 @@
+SUMMARY = "Shared disk and ESP detection for the Mender Tegra integration"
+DESCRIPTION = "A POSIX shell library resolving the booted disk, the partition \
+carrying a given label on it, and its ESP. Shared by both update schemes, since a \
+board with two Tegra layouts makes the partition labels ambiguous."
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
+
+SRC_URI = "file://disk-helpers.sh"
+
+S = "${UNPACKDIR}"
+
+COMPATIBLE_MACHINE = "(tegra)"
+
+# Staged as well as packaged: the update module sources it from the rootfs, the
+# classic state scripts splice the staged copy in at build time.
+do_install() {
+    install -d ${D}${datadir}/tegra-mender
+    install -m 0644 ${S}/disk-helpers.sh ${D}${datadir}/tegra-mender/disk-helpers.sh
+}
+
+FILES:${PN} = "${datadir}/tegra-mender/disk-helpers.sh"
+
+# Shell, so architecture independent, but allarch and COMPATIBLE_MACHINE do not mix.
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/abort-blupdate
@@ -2,7 +2,18 @@
 # Must parse and run under busybox ash: this layer targets images such as
 # core-image-minimal where /bin/sh is busybox and bash is not installed.
 
-CAPTARGET="/boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap"
+# Shared disk and ESP detection, spliced in at build time. See switch-rootfs.
+#TEGRA_DISK_HELPERS
+
+TEGRA_LOG_PREFIX="abort-blupdate"
+ESP_MOUNT="${ESP_MOUNT:-/boot/efi}"
+
+# A rollback can follow a reboot, and nothing pins the ESP mount across one, so
+# the capsule could be removed from the wrong disk and left armed on the right
+# one. Advisory: a rollback should finish either way.
+tegra_ensure_esp_mounted || true
+
+CAPTARGET="$ESP_MOUNT/EFI/UpdateCapsule/TEGRA_BL.Cap"
 
 if [ -f "$CAPTARGET" ]; then
     rm "$CAPTARGET"

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/switch-rootfs
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/files/switch-rootfs
@@ -2,6 +2,13 @@
 set -e
 echo "$(mender-update show-artifact): $(basename "$0") was called!" >&2
 
+# Shared disk and ESP detection, spliced in at build time from
+# meta-mender-tegra-common. Not sourced: this runs from inside the artifact.
+#TEGRA_DISK_HELPERS
+
+TEGRA_LOG_PREFIX="switch-rootfs"
+ESP_MOUNT="${ESP_MOUNT:-/boot/efi}"
+
 get_bootpart() {
 	local current_slot=`nvbootctrl get-current-slot 2>/dev/null`
 	if [ -z "$current_slot" ]; then
@@ -25,21 +32,35 @@ current_slot=`get_bootpart`
 echo "current_slot=$current_slot" >&2
 
 next_slot=
-next_rootfs_dev=
+next_label=
 if [ $current_slot = "0" ]; then
 	next_slot="1"
-	next_rootfs_dev="/dev/disk/by-partlabel/APP_b"
+	next_label="APP_b"
 else
 	next_slot="0"
-	next_rootfs_dev="/dev/disk/by-partlabel/APP"
+	next_label="APP"
 fi
+
+next_rootfs_dev=$(tegra_partlabel_dev "$next_label") || {
+	echo "ERR: cannot resolve $next_label to a device" >&2
+	exit 1
+}
+echo "next slot $next_slot is $next_rootfs_dev" >&2
 
 tmp_mount=`mktemp -d`
 
 reset_unbootable_status $next_slot
-mkdir -p /boot/efi/EFI/UpdateCapsule
+
+# UEFI reads the capsule from the medium it booted, so staging it on the other
+# disk's ESP arms nothing and the switch silently does not happen.
+tegra_ensure_esp_mounted || {
+	echo "ERR: no usable ESP to stage the capsule on" >&2
+	exit 1
+}
+
+mkdir -p "$ESP_MOUNT/EFI/UpdateCapsule"
 mount -o ro $next_rootfs_dev $tmp_mount
-cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap /boot/efi/EFI/UpdateCapsule/TEGRA_BL.Cap
+cp ${tmp_mount}/opt/nvidia/UpdateCapsule/tegra-bl.cap "$ESP_MOUNT/EFI/UpdateCapsule/TEGRA_BL.Cap"
 umount $tmp_mount
 oe4t-set-uefi-OSIndications
 

--- a/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/tegra-state-scripts_1.0.bb
+++ b/meta-mender-tegra/meta-mender-tegra-common/recipes-mender/tegra-state-scripts/tegra-state-scripts_1.0.bb
@@ -14,10 +14,24 @@ inherit mender-state-scripts
 PERSIST_MACHINE_ID = ""
 PERSIST_MACHINE_ID:mender-persist-systemd-machine-id = "yes"
 
+# For the staged helpers only; these scripts travel inside the artifact.
+DEPENDS = "tegra-mender-helpers"
+TEGRA_DISK_HELPERS = "${STAGING_DATADIR}/tegra-mender/disk-helpers.sh"
+
+# A state script runs from the artifact on whatever rootfs is booted, so it cannot
+# source the library: a device flashed before it existed would fail its next
+# update. Splice it in at the marker instead.
+tegra_splice_helpers() {
+    sed -e '/^#TEGRA_DISK_HELPERS$/r '"${TEGRA_DISK_HELPERS}" \
+        -e '/^#TEGRA_DISK_HELPERS$/d' \
+        "$1" > "$2"
+    grep -q '^tegra_booted_disk()' "$2" || bbfatal "helpers were not spliced into $2"
+}
+
 do_compile() {
-    cp ${S}/switch-rootfs ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_50_switch-rootfs
+    tegra_splice_helpers ${S}/switch-rootfs ${MENDER_STATE_SCRIPTS_DIR}/ArtifactInstall_Leave_50_switch-rootfs
     cp ${S}/verify-slot ${MENDER_STATE_SCRIPTS_DIR}/ArtifactCommit_Leave_50_verify-slot
-    cp ${S}/abort-blupdate ${MENDER_STATE_SCRIPTS_DIR}/ArtifactRollback_Leave_50_abort-blupdate
+    tegra_splice_helpers ${S}/abort-blupdate ${MENDER_STATE_SCRIPTS_DIR}/ArtifactRollback_Leave_50_abort-blupdate
 }
 
 # Make sure scripts aren't left around from old builds


### PR DESCRIPTION
Merges first, with #529 and #530 stacked on top.

A board carrying two Tegra layouts, an NVMe and a microSD, has nothing uniquely named left: both disks carry `APP`, `APP_b` and `esp`, both ESPs share a filesystem UUID because both came from the same `esp.img`, and the partition UUIDs are only handed out at flash time. `/dev/disk/by-partlabel` points at whichever disk udev settled last, and `/boot/efi` comes from systemd's gpt-auto generator, which picks one.

It fails quietly. UEFI reads the capsule from the medium it booted, so one staged on the other disk's ESP arms nothing: the deployment reports success and the board is back on the old slot a reboot later. A rootfs written into the other disk's `APP_b` is worse.

Both schemes need the same answers, so they move into `meta-mender-tegra-common` as `disk-helpers.sh`. Everything derives from the mounted root, which is the only trustworthy statement of which medium UEFI booted, and the same reasoning `assert_slot_mapping_sane` already applies when it trusts the mounted root over the partition labels.

`tegra_booted_disk` reads the device of `/` out of `/proc/mounts`, canonicalises it so that a `by-uuid` symlink or `/dev/root` becomes a real node, reduces it to a kernel name and resolves `${SYS_BLOCK}/<part>/..`. That last step is the whole trick: in sysfs `/sys/class/block/<part>` is a symlink into `/sys/devices`, so its parent directory is the disk. A basename of `block` means the name was a whole disk rather than a partition, and is rejected. From a ramdisk root it returns non-zero, which is the recovery case and a supported answer rather than an error.

`tegra_partlabel_on_disk <disk> <label>` answers which partition on that disk carries the label. `lsblk -n -r -o NAME,PARTLABEL` first, where `-r` is what makes the awk field split safe, since default lsblk pads its columns. Underneath sits a blkid loop over `${SYS_BLOCK}/<disk>/<disk>*` requiring a `partition` file so stray entries are skipped, because an initramfs often has no lsblk at all, or one built without PARTLABEL support.

`tegra_partlabel_dev <label>` is where the policy lives. With the booted disk known, only that disk counts: a label absent from it means the by-partlabel symlink necessarily points at the other disk, so it refuses rather than act on the wrong medium. The symlink is consulted only when the booted disk cannot be determined at all, and its target is then checked for existence, since `readlink -f` reports success for a dangling path whose parent exists.

`tegra_esp_device` is the same lookup for the `esp` label, with no symlink fallback on purpose. A caller that cannot derive the ESP is better served by whatever is already mounted, which is correct on any board with a single ESP, and `tegra_ensure_esp_mounted` is what implements that:

- derived and already mounted: nothing to do
- derived, the other disk's mounted: unmount, mount the right one
- derived, nothing mounted: mount it
- not derivable but something is mounted: keep it, and say so in the log
- not derivable and nothing mounted: non-zero

Whether that non-zero is fatal is the caller's decision. It is when a capsule is about to be staged, it is not when an old one is being cleaned up. `tegra_esp_mounted_device` backs those branches and returns 0 with empty output when nothing is mounted, so callers distinguish by emptiness rather than by exit status.

Two conventions worth knowing before editing the file. Variables are `_tgh_` prefixed plain globals rather than `local`, so it runs in any POSIX shell and cannot clobber a caller's names. And `PROC_MOUNTS`, `SYS_BLOCK`, `ESP_MOUNT` and `PARTLABEL_DIR` are read at each use rather than snapshotted, so it does not matter whether a caller sets them before or after the file arrives.

`switch-rootfs` takes both the slot and the ESP from this. `abort-blupdate` too, for a case that is easy to miss: it deleted whatever capsule sat at `/boot/efi`, and a rollback can follow a reboot with nothing pinning that mount, so it could clear the other disk's ESP and leave the staged capsule armed on the one that boots.

Note that the library reaches its two consumers by different routes, which is the part worth checking in review.

The update module lives in the rootfs, so it simply sources it, right after the overridable variables are set:

```sh
TEGRA_LOG_PREFIX="tegra-rootfs-image[$STATE]"
. "${TEGRA_DISK_HELPERS:-/usr/share/tegra-mender/disk-helpers.sh}"
```

The file is there because `tegra-mender-helpers` installs it to `${datadir}/tegra-mender/`, and the module recipe has the package in `RDEPENDS`. The override exists so the module can be run off target against a checked out copy.

A state script cannot do that. `mender-state-scripts.bbclass` puts the `Artifact*` scripts into `DEPLOYDIR`, so they travel inside the artifact and run on whatever rootfs is currently booted, and a device flashed before this existed has no such file. So each script carries a marker line where the library belongs:

```sh
# Shared disk and ESP detection, spliced in at build time from
# meta-mender-tegra-common. Not sourced: this runs from inside the artifact.
#TEGRA_DISK_HELPERS
```

and the classic recipe replaces that line with the file while copying the script into `MENDER_STATE_SCRIPTS_DIR`:

```
DEPENDS = "tegra-mender-helpers"
TEGRA_DISK_HELPERS = "${STAGING_DATADIR}/tegra-mender/disk-helpers.sh"

tegra_splice_helpers() {
    sed -e '/^#TEGRA_DISK_HELPERS$/r '"${TEGRA_DISK_HELPERS}" \
        -e '/^#TEGRA_DISK_HELPERS$/d' \
        "$1" > "$2"
    grep -q '^tegra_booted_disk()' "$2" || bbfatal "helpers were not spliced into $2"
}
```

sed's `r` queues the file for output after the matching line and the second expression drops the marker, so the library ends up inlined exactly where the comment says. The `grep` is there because a silent no-splice yields a script that parses fine and then dies mid deployment with `tegra_partlabel_dev: not found`.

Hence `DEPENDS` on the classic side, which only needs the file staged, and `RDEPENDS` on the native side, which needs it installed. On a device running the classic scheme there is no `/usr/share/tegra-mender/disk-helpers.sh` at all; the code sits inside the artifact's `ArtifactInstall_Leave_50_switch-rootfs`.

In a deployment log the sequence reads:

```
next slot 1 is /dev/mmcblk0p2
switch-rootfs: /boot/efi is /dev/nvme0n1p11 but the booted disk's ESP is /dev/mmcblk0p11; remounting
```

Exercised on an Orin Nano 8GB devkit with a microSD and an NVMe both fitted, both schemes, deployments and a rollback, including with the other disk's ESP mounted first, on the pinned BSP and on current meta-tegra `wrynose`.